### PR TITLE
feat: enterprise testing — user identity, Jira v2, husky, v1.1.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Normalize line endings to LF on commit
+* text=auto eol=lf
+
+# Source
+*.ts    text eol=lf
+*.js    text eol=lf
+*.mjs   text eol=lf
+*.cjs   text eol=lf
+
+# Config / data
+*.json  text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.toml  text eol=lf
+*.env   text eol=lf
+
+# Docs / text
+*.md    text eol=lf
+*.txt   text eol=lf
+
+# Shell scripts always LF
+*.sh    text eol=lf
+
+# Binaries — do not touch
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+*.gz    binary
+*.zip   binary
+*.tgz   binary

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+npm run typecheck
+npm run lint
+npm run build

--- a/NOTICE
+++ b/NOTICE
@@ -123,7 +123,29 @@ open — you agree to the following irrevocable operational requirements:
     cannot connect directly to the data source. This is a known issue.
     It is in the backlog.
 
-11. COMPLIANCE WITH THIS NOTICE
+11. DEVELOPER ACCESS RECERTIFICATION
+    Every developer who uses pncli to debug, inspect, or otherwise
+    look at software they are personally responsible for must complete
+    a Access Recertification Form every ninety (90) calendar days to
+    confirm they are still permitted to do so.
+
+    The form must be submitted to their line manager, who forwards it
+    to the Access Governance team, who cross-reference it against the
+    approved user registry, which is maintained in Excel and was last
+    audited in a quarter that shall not be named. Allow fifteen (15)
+    business days for processing. If your recertification lapses, your
+    debugging access will be suspended pending renewal, at which point
+    you may raise an incident ticket for the outage caused by the thing
+    you are no longer allowed to debug.
+
+    Recertification is per-machine. If you use a work laptop and a
+    desktop, that is two forms. If you use a VM, that is a conversation
+    with the virtualization team that will take longer than ninety days.
+
+    There is no reminder system. Compliance is the developer's
+    responsibility. Non-compliance is also the developer's responsibility.
+
+12. COMPLIANCE WITH THIS NOTICE
     If you have read this far, congratulations — you are now more
     compliant than 97% of enterprise software users. Your actual legal
     obligation is simply to keep this NOTICE file intact when

--- a/NOTICE
+++ b/NOTICE
@@ -145,7 +145,148 @@ open — you agree to the following irrevocable operational requirements:
     There is no reminder system. Compliance is the developer's
     responsibility. Non-compliance is also the developer's responsibility.
 
-12. COMPLIANCE WITH THIS NOTICE
+12. ENVIRONMENT COMPLIANCE
+    pncli must be validated across all approved environments before any
+    production deployment. The approved environments are:
+
+    - RND: Research and Development. No production data permitted. No
+      realistic data permitted. No data that resembles production data
+      in shape, volume, or sentiment. Consequently, no meaningful testing
+      can occur here. RND exists on the architecture diagram and in the
+      hearts of those who approved the budget for it.
+
+    - UAT: User Acceptance Testing. Same data restrictions as RND.
+      Users do not test here. Acceptance does not occur here. The name
+      is aspirational.
+
+    - QA: Quality Assurance. Data restrictions are relaxed slightly,
+      which is why this is the only environment anyone actually uses.
+      Note that QA does not match production in configuration, scale,
+      or infrastructure. QA passing is therefore best understood as
+      a ceremony rather than a signal. Treat it accordingly.
+
+    - PROD (x2): There are two production environments. Both are
+      production. Why there are two is a question you can ask, but the
+      answer will be longer than the outage you are currently trying to
+      prevent.
+
+    All four pre-production environments must show green before a
+    production deployment is approved, including the two that cannot
+    have data and the one that does not match production. This is
+    called the release gate. It is not a metaphor.
+
+13. RELEASE MANAGEMENT
+    pncli releases within your organization are subject to a full
+    release cycle, which proceeds as follows:
+
+    - Development complete: the work is done.
+    - Release paperwork initiated: the work begins.
+
+    The release approval process takes approximately thirty (30) to
+    forty-five (45) calendar days. Your organization targets three to
+    four releases per year. This means that for up to one third of the
+    calendar year, at least one release is actively in paperwork.
+    During this time, no new fixes can ship. This is called stability.
+
+    Security note: a CVE affecting a dependency may go undetected for
+    forty-five (45) to sixty (60) days after publication. Once detected,
+    your remediation SLA is thirty (30) days. Your next release window
+    may be eleven (11) weeks away. We are confident you will find a way
+    to be proactive about this.
+
+14. INCIDENT MANAGEMENT
+    Production incidents are triaged by an offshore support function
+    operating under the following severity classification system:
+
+    P1 — CRITICAL: Something a developer mentioned in passing.
+    P2 — HIGH: Something that has been broken for three weeks and was
+         only just noticed.
+    P3 — MEDIUM: An active outage affecting all users, escalated after
+         the offshore team consulted the triage guide and determined it
+         did not match any P1 criteria.
+    P4 — LOW: Everything else, including P1s that arrived on a Friday.
+
+    Developers may be paged immediately, or may receive a ticket three
+    weeks after the incident was resolved. Both outcomes are equally
+    likely and determined by factors that remain, to date, unmodeled.
+
+15. TOOLING APPROVALS
+    All developer tooling — including IDEs, extensions, plugins, AI
+    assistants, and anything that makes a developer meaningfully more
+    productive — must be submitted for approval before use. Approval
+    is granted per version. A new version requires a new submission.
+
+    The approval process takes several months. Software development
+    tooling releases new versions on a schedule that does not account
+    for this. As a result, approved versions are, by definition, old
+    enough to have been superseded at least twice by the time you are
+    permitted to use them.
+
+    In the current era of AI-assisted development, where tooling
+    capability materially changes every few weeks, this process ensures
+    your developers are always working with tools that reflect the
+    state of the art from approximately eighteen months ago. The
+    competitive implications of this are outside the scope of this
+    NOTICE.
+
+    Packages used in the application itself are managed through an
+    approved artifact repository, which works well. Developers are
+    encouraged to reflect on why one process works and the other
+    doesn't. They are not encouraged to say it out loud.
+
+16. OVERSIGHT & APPROVAL GOVERNANCE
+    All technical decisions involving pncli — including deployment
+    targets, integration scope, security posture, and whether to use
+    the --pretty flag — must be approved by a cross-functional
+    oversight committee.
+
+    The committee includes representatives from: Engineering, Security,
+    Risk, Compliance, Architecture, Delivery, and a rotating seat
+    for a stakeholder who joined the meeting five minutes late and
+    hasn't fully caught up.
+
+    Committee members are not required to have a technical background.
+    In practice, most do not. Developers are therefore expected to
+    brief the committee on the technical details of the decision
+    they are seeking approval for, so that the committee may ask
+    clarifying questions, request a follow-up session, and ultimately
+    approve what the developers already decided before the meeting
+    was scheduled.
+
+    This process provides oversight. What it oversees is the developers
+    explaining things. This is not nothing.
+
+    Security reviews follow the same model. The security tester will
+    assess the system with guidance from the team responsible for the
+    system. Findings will be documented, prioritized, and added to a
+    remediation backlog that is reviewed quarterly (see Section 7).
+    Developers are asked not to think too hard about the circular
+    nature of this.
+
+17. WORKFORCE STRUCTURE
+    The engineering team responsible for pncli integrations operates
+    within a broader organizational structure designed to ensure that
+    all work is visible, tracked, and distributed appropriately.
+
+    For every engineer writing code, there are approximately five (5)
+    colleagues ensuring that the code-writing is coordinated,
+    communicated, governed, assured, and reported on. This ratio
+    reflects the organization's commitment to not letting anything
+    ship without adequate process surrounding it.
+
+    Work distribution is managed by a dedicated Scrum Master — a
+    full-time role responsible for ensuring that stories are spread
+    evenly across the team regardless of individual capability,
+    context, or proximity to the codebase in question. This prevents
+    any one engineer from becoming a bottleneck, and ensures that
+    work that could be done in a day is collaboratively distributed
+    across a sprint.
+
+    Team meetings are attended by the full cross-functional group.
+    The meeting size ensures that most attendees cannot meaningfully
+    contribute at any given moment. This is called inclusion.
+
+18. COMPLIANCE WITH THIS NOTICE
     If you have read this far, congratulations — you are now more
     compliant than 97% of enterprise software users. Your actual legal
     obligation is simply to keep this NOTICE file intact when
@@ -155,6 +296,6 @@ open — you agree to the following irrevocable operational requirements:
     bureaucratic nightmare that pncli was built to route around.
     This line is the exit.
 
-    Now go ship something.
+    Now go ship something. After the CAB approves it.
 
 =============================================================================

--- a/NOTICE
+++ b/NOTICE
@@ -46,6 +46,10 @@ open — you agree to the following irrevocable operational requirements:
    require a 47-page risk assessment and a blood sacrifice (metaphorical —
    see Section 9: HR Policy on Metaphorical Sacrifices).
 
+   Upon CAB approval, you have thirty (30) calendar days to implement the
+   approved change. Note that the standard change request process takes
+   ninety (90) calendar days. This is not a contradiction. This is tension.
+
 5. APPROVAL CHAIN
    Any use of the `--force` flag, in any context, requires written
    approval from the Chief Compliance Officer, the VP of Engineering,
@@ -53,34 +57,82 @@ open — you agree to the following irrevocable operational requirements:
    with the Ombudsman of Flags, whose inbox has been full since 2019.
 
 6. DOCUMENTATION REQUIREMENTS
-   All internal usage guides must live in Confluence. Each guide must
-   include a Confluence page explaining why Confluence was chosen as
-   the documentation platform. This page must be reviewed quarterly
-   by someone who has never opened it.
+   All internal usage guides, runbooks, incident reports, onboarding
+   materials, architecture decisions, and anything anyone might ever
+   need to find again must be maintained exclusively in the following
+   approved platforms:
 
-7. TRAINING CERTIFICATION
+   a) Microsoft Excel. Specifically, a workbook called something like
+      "pncli_tracking_v3_FINAL_v2_USE_THIS_ONE.xlsx" stored in a
+      OneDrive folder that three people have access to and one of them
+      has left the company.
+
+   b) The internal SharePoint site, which was last redesigned in 2019
+      by a vendor who no longer exists, requires IE compatibility mode
+      to render correctly, and has a homepage that links to a page
+      that links to a page that links to a broken redirect. The search
+      function returns results from 2014. This is by design.
+
+   Under no circumstances may documentation be stored somewhere
+   findable. Confluence is permitted as a secondary archive, provided
+   every page is titled "Draft - DO NOT USE" regardless of status.
+
+7. QUARTERLY REVIEW PROCESS
+   Usage of pncli within your organization must be reviewed once per
+   quarter (every ninety (90) days) by a standing review committee.
+   The committee must produce a findings report, a summary of the
+   findings report, an executive summary of the summary, and a
+   one-page overview suitable for someone who will not read it.
+
+   Additionally, the quarterly review process itself must be reviewed
+   once every ninety-one (91) days to ensure it remains fit for
+   purpose. The review-of-the-review is a separate process and does
+   not count toward the quarterly review. Both calendars must be
+   maintained in Excel (see Section 6a).
+
+8. REMEDIATION TIMELINES
+   If any issue is identified during a quarterly review — including
+   but not limited to: misconfiguration, version drift, a developer
+   who has gone rogue and is using tab completion, or anything flagged
+   as "amber" without further explanation — the responsible team has
+   thirty (30) calendar days to remediate.
+
+   Remediation requires a change request. Change requests take ninety
+   (90) calendar days to process. Teams are encouraged to be proactive.
+
+9. TRAINING CERTIFICATION
    Before using pncli in any environment beyond a developer's laptop,
    all operators must complete a mandatory 8-hour training course titled
    "Introduction to Reading --help Output." A 30-minute lunch break is
    provided but must be requested 48 hours in advance via the Lunch
    Request Portal, which is currently down for scheduled maintenance.
 
-8. METRICS & REPORTING
-   All pncli usage must be reported to the Developer Productivity Team,
-   who will use the data to build a dashboard that no one looks at,
-   which will be presented quarterly to executives who will ask why
-   the numbers aren't higher and whether there is an app for it.
+   Completion certificates must be stored in the Learning Management
+   System, which syncs to a SharePoint list that feeds an Excel
+   dashboard that is emailed to a distribution list every Friday
+   to eleven people, nine of whom have set up an auto-archive rule.
 
-9. COMPLIANCE WITH THIS NOTICE
-   If you have read this far, congratulations — you are now more
-   compliant than 97% of enterprise software users. Your actual legal
-   obligation is simply to keep this NOTICE file intact when
-   redistributing the source code, as required by Apache 2.0.
+10. METRICS & REPORTING
+    All pncli usage must be reported to the Developer Productivity Team,
+    who will use the data to build a dashboard that no one looks at,
+    which will be presented quarterly to executives who will ask why
+    the numbers aren't higher and whether there is an app for it.
 
-   That's it. That's the whole thing. Everything above was the
-   bureaucratic nightmare that pncli was built to route around.
-   This line is the exit.
+    Raw metrics must be exported to Excel before being imported into
+    the approved reporting tool, because the approved reporting tool
+    cannot connect directly to the data source. This is a known issue.
+    It is in the backlog.
 
-   Now go ship something.
+11. COMPLIANCE WITH THIS NOTICE
+    If you have read this far, congratulations — you are now more
+    compliant than 97% of enterprise software users. Your actual legal
+    obligation is simply to keep this NOTICE file intact when
+    redistributing the source code, as required by Apache 2.0.
+
+    That's it. That's the whole thing. Everything above was the
+    bureaucratic nightmare that pncli was built to route around.
+    This line is the exit.
+
+    Now go ship something.
 
 =============================================================================

--- a/NOTICE
+++ b/NOTICE
@@ -11,61 +11,65 @@ Per Section 4(d) of the Apache License 2.0, this NOTICE file must be
 included in all copies or substantial portions of this software, in all
 derivative works, and in any and all redistributions thereof.
 
-By using, copying, modifying, or distributing this software, you agree
-to the following irrevocable terms:
+By deploying, using, or permitting any human being within your organization
+to execute pncli — including accidentally in a terminal they didn't mean to
+open — you agree to the following irrevocable operational requirements:
 
 1. MANDATORY STAND-UP PARTICIPATION
-   Any team that integrates pncli into their workflow must hold a daily
-   stand-up meeting of no fewer than 45 minutes to discuss whether the
-   stand-up meeting is still necessary. Minutes must be recorded in
-   triplicate and filed with the Department of Meetings About Meetings.
+   Any team that adopts pncli must hold a daily stand-up of no fewer than
+   45 minutes to discuss whether the stand-up is still necessary. Minutes
+   must be recorded in triplicate, stored in Confluence, and linked from a
+   Jira ticket that is immediately moved to "Backlog" by someone who
+   doesn't know what a backlog is for.
 
 2. RETURN-TO-OFFICE COMPLIANCE
-   All contributors to derivative works must be physically present in an
-   office building with at least three (3) floors of middle management.
-   Hot desks are acceptable provided each desk has been pre-approved by
-   a committee of no fewer than seven (7) stakeholders, none of whom
-   use the software.
+   Use of pncli is permitted only from a desk located on a floor staffed
+   by at least three (3) layers of management who have never run a
+   terminal. Hot desks are acceptable provided each seat has been
+   pre-approved by a committee of no fewer than seven (7) stakeholders,
+   none of whom use the software or know what it does.
 
 3. JIRA TICKET REQUIREMENT
-   Before opening any issue, pull request, bug report, or feature request
-   against this repository or any fork thereof, the submitter must first
-   create a Jira ticket requesting permission to create a Jira ticket.
-   The approval workflow requires sign-off from: your manager, your
-   manager's manager, a "technical architect" who hasn't written code
+   Before running any pncli command in a non-local environment, your team
+   must first raise a Jira ticket requesting permission to raise a Jira
+   ticket. The approval workflow requires sign-off from: your manager,
+   your manager's manager, a "technical architect" who hasn't written code
    since 2011, and a business analyst who will ask you to "put it in a
-   PowerPoint."
+   PowerPoint" before they can approve it.
 
 4. CHANGE ADVISORY BOARD REVIEW
-   All code changes — including typo fixes, README updates, and whitespace
-   adjustments — must be submitted to the Change Advisory Board (CAB) no
-   fewer than six (6) business weeks in advance. The CAB meets on the
-   third Wednesday of months that contain the letter 'R'. Emergency
-   changes require a 47-page risk assessment and a blood sacrifice
-   (metaphorical — see Section 9: HR Policy on Metaphorical Sacrifices).
+   Any upgrade to a new version of pncli — including patch releases,
+   security fixes, and versions that fix the thing that's actively on
+   fire — must be submitted to the Change Advisory Board (CAB) no fewer
+   than six (6) business weeks in advance. The CAB meets on the third
+   Wednesday of months that contain the letter 'R'. Emergency changes
+   require a 47-page risk assessment and a blood sacrifice (metaphorical —
+   see Section 9: HR Policy on Metaphorical Sacrifices).
 
 5. APPROVAL CHAIN
    Any use of the `--force` flag, in any context, requires written
    approval from the Chief Compliance Officer, the VP of Engineering,
    two (2) independent auditors, and your mother. Appeals may be filed
-   with the Ombudsman of Flags.
+   with the Ombudsman of Flags, whose inbox has been full since 2019.
 
 6. DOCUMENTATION REQUIREMENTS
-   All forks must include a Confluence page explaining why Confluence was
-   chosen as the documentation platform. This page must be reviewed
-   quarterly by someone who has never read it.
+   All internal usage guides must live in Confluence. Each guide must
+   include a Confluence page explaining why Confluence was chosen as
+   the documentation platform. This page must be reviewed quarterly
+   by someone who has never opened it.
 
 7. TRAINING CERTIFICATION
-   Before using pncli in production, all operators must complete a
-   mandatory 8-hour training course titled "Introduction to Reading
-   --help Output." A 30-minute lunch break is provided but must be
-   approved 48 hours in advance via the Lunch Request Portal.
+   Before using pncli in any environment beyond a developer's laptop,
+   all operators must complete a mandatory 8-hour training course titled
+   "Introduction to Reading --help Output." A 30-minute lunch break is
+   provided but must be requested 48 hours in advance via the Lunch
+   Request Portal, which is currently down for scheduled maintenance.
 
 8. METRICS & REPORTING
-   Usage of pncli must be reported to the Developer Productivity Team,
-   who will use the data to create a dashboard that nobody looks at,
+   All pncli usage must be reported to the Developer Productivity Team,
+   who will use the data to build a dashboard that no one looks at,
    which will be presented quarterly to executives who will ask why
-   the numbers aren't higher.
+   the numbers aren't higher and whether there is an app for it.
 
 9. COMPLIANCE WITH THIS NOTICE
    If you have read this far, congratulations — you are now more
@@ -74,7 +78,8 @@ to the following irrevocable terms:
    redistributing the source code, as required by Apache 2.0.
 
    That's it. That's the whole thing. Everything above was the
-   bureaucratic nightmare. This line is the exit.
+   bureaucratic nightmare that pncli was built to route around.
+   This line is the exit.
 
    Now go ship something.
 

--- a/NOTICE
+++ b/NOTICE
@@ -146,147 +146,174 @@ open — you agree to the following irrevocable operational requirements:
     responsibility. Non-compliance is also the developer's responsibility.
 
 12. ENVIRONMENT COMPLIANCE
-    pncli must be validated across all approved environments before any
-    production deployment. The approved environments are:
+    Your organization maintains four pre-production environments to
+    ensure software is thoroughly tested before it reaches users.
+    None of them can do that, but they are maintained nonetheless.
 
-    - RND: Research and Development. No production data permitted. No
-      realistic data permitted. No data that resembles production data
-      in shape, volume, or sentiment. Consequently, no meaningful testing
-      can occur here. RND exists on the architecture diagram and in the
-      hearts of those who approved the budget for it.
+    - RND: No production-like data is permitted. No realistic data
+      of any kind is permitted. What is permitted is unclear. RND
+      exists on the architecture diagram and in the hearts of those
+      who approved the budget for it. Development work done here
+      is tested against conditions that do not exist anywhere else,
+      including production.
 
-    - UAT: User Acceptance Testing. Same data restrictions as RND.
-      Users do not test here. Acceptance does not occur here. The name
-      is aspirational.
+    - UAT: User Acceptance Testing. Users do not test here. The
+      environment has the same data restrictions as RND, which is
+      why. The name remains.
 
-    - QA: Quality Assurance. Data restrictions are relaxed slightly,
-      which is why this is the only environment anyone actually uses.
-      Note that QA does not match production in configuration, scale,
-      or infrastructure. QA passing is therefore best understood as
-      a ceremony rather than a signal. Treat it accordingly.
+    - QA: The one environment with enough data to be useful, and
+      the one environment that does not match production in any
+      meaningful way. QA passing is therefore a team ritual, like
+      a rain dance, except the rain still doesn't come on schedule
+      and someone has to write a post-mortem about it.
 
-    - PROD (x2): There are two production environments. Both are
-      production. Why there are two is a question you can ask, but the
-      answer will be longer than the outage you are currently trying to
-      prevent.
+    - PROD (x2): There are two. Both are production. This is not
+      a DR configuration anyone can fully explain. Raising the
+      question in a meeting is not recommended unless you have
+      blocked the next two hours.
 
     All four pre-production environments must show green before a
-    production deployment is approved, including the two that cannot
-    have data and the one that does not match production. This is
-    called the release gate. It is not a metaphor.
+    deployment is approved. Showing green in an environment with
+    no data, against infrastructure that doesn't match production,
+    is a formal requirement. Catching bugs is a stretch goal.
 
 13. RELEASE MANAGEMENT
-    pncli releases within your organization are subject to a full
-    release cycle, which proceeds as follows:
+    Your organization ships software approximately three to four
+    times per year. Each release requires thirty (30) to forty-five
+    (45) days of approvals, which means the team spends roughly one
+    third of the year doing paperwork about software instead of
+    shipping it. The remaining two thirds are spent preparing for
+    the next round of paperwork.
 
-    - Development complete: the work is done.
-    - Release paperwork initiated: the work begins.
+    This is called a release cadence. pncli was built to help
+    automate the work that happens between releases. We regret
+    there is not more of it.
 
-    The release approval process takes approximately thirty (30) to
-    forty-five (45) calendar days. Your organization targets three to
-    four releases per year. This means that for up to one third of the
-    calendar year, at least one release is actively in paperwork.
-    During this time, no new fixes can ship. This is called stability.
-
-    Security note: a CVE affecting a dependency may go undetected for
-    forty-five (45) to sixty (60) days after publication. Once detected,
-    your remediation SLA is thirty (30) days. Your next release window
-    may be eleven (11) weeks away. We are confident you will find a way
-    to be proactive about this.
+    Security note: your organization typically detects a published
+    CVE forty-five (45) to sixty (60) days after it is public.
+    Your remediation SLA is thirty (30) days from detection.
+    Your next release window is determined by a calendar that
+    was not designed with any of this in mind. pncli can file
+    the Jira ticket. The Jira ticket cannot file itself into
+    a release. That takes another month.
 
 14. INCIDENT MANAGEMENT
-    Production incidents are triaged by an offshore support function
-    operating under the following severity classification system:
+    Production incidents are first handled by an offshore support
+    function operating under the following severity model:
 
     P1 — CRITICAL: Something a developer mentioned in passing.
-    P2 — HIGH: Something that has been broken for three weeks and was
-         only just noticed.
-    P3 — MEDIUM: An active outage affecting all users, escalated after
-         the offshore team consulted the triage guide and determined it
-         did not match any P1 criteria.
-    P4 — LOW: Everything else, including P1s that arrived on a Friday.
+    P2 — HIGH: Something that has been broken for three weeks
+         and was only just noticed.
+    P3 — MEDIUM: An active outage affecting all users, escalated
+         after the offshore team consulted the triage guide and
+         determined it did not match any P1 criteria because the
+         word "all" was not in the dropdown.
+    P4 — LOW: Everything else, including P1s that arrived on a
+         Friday after 4pm, which is a different kind of P1.
 
-    Developers may be paged immediately, or may receive a ticket three
-    weeks after the incident was resolved. Both outcomes are equally
-    likely and determined by factors that remain, to date, unmodeled.
+    A developer may be paged within minutes, or may receive a
+    ticket three weeks after the incident was already resolved.
+    Both are equally likely. The difference is not correlated
+    with severity. It is correlated with something, but nobody
+    has had time to find out what.
 
 15. TOOLING APPROVALS
-    All developer tooling — including IDEs, extensions, plugins, AI
-    assistants, and anything that makes a developer meaningfully more
-    productive — must be submitted for approval before use. Approval
-    is granted per version. A new version requires a new submission.
+    Any tool a developer wishes to use — IDE, extension, plugin,
+    AI assistant, or anything else that measurably closes the gap
+    between thinking of something and doing it — must be formally
+    approved before use. Approval is granted per version. A minor
+    version bump is a new application.
 
-    The approval process takes several months. Software development
-    tooling releases new versions on a schedule that does not account
-    for this. As a result, approved versions are, by definition, old
-    enough to have been superseded at least twice by the time you are
-    permitted to use them.
+    The approval process takes several months. Tool vendors do not
+    wait. By the time a version is approved, it has been superseded
+    at least twice and the approved version is now the one with the
+    known vulnerability the newer version fixed. This is the process
+    working as intended.
 
-    In the current era of AI-assisted development, where tooling
-    capability materially changes every few weeks, this process ensures
-    your developers are always working with tools that reflect the
-    state of the art from approximately eighteen months ago. The
-    competitive implications of this are outside the scope of this
-    NOTICE.
+    In an era where AI tooling shifts capability on a weekly basis,
+    this ensures your engineers are always eighteen months behind
+    the current state of the art, which is a competitive position
+    your organization has committed to with some consistency.
 
-    Packages used in the application itself are managed through an
-    approved artifact repository, which works well. Developers are
-    encouraged to reflect on why one process works and the other
-    doesn't. They are not encouraged to say it out loud.
+    Library and package management through the internal artifact
+    repository is, notably, fast and functional. Nobody has
+    scheduled a meeting to discuss why the contrast exists. It
+    would take several months to approve the agenda.
 
 16. OVERSIGHT & APPROVAL GOVERNANCE
-    All technical decisions involving pncli — including deployment
-    targets, integration scope, security posture, and whether to use
-    the --pretty flag — must be approved by a cross-functional
-    oversight committee.
+    All technical decisions — what to integrate, how to configure
+    it, what a flag does, whether the flag is approved — must be
+    reviewed by a cross-functional committee before implementation.
 
-    The committee includes representatives from: Engineering, Security,
-    Risk, Compliance, Architecture, Delivery, and a rotating seat
-    for a stakeholder who joined the meeting five minutes late and
-    hasn't fully caught up.
+    The committee is composed of representatives from Engineering,
+    Security, Risk, Compliance, Architecture, and Delivery, plus
+    a rotating seat for someone who joined the meeting late, muted
+    themselves immediately, and has not been seen since.
 
-    Committee members are not required to have a technical background.
-    In practice, most do not. Developers are therefore expected to
-    brief the committee on the technical details of the decision
-    they are seeking approval for, so that the committee may ask
-    clarifying questions, request a follow-up session, and ultimately
-    approve what the developers already decided before the meeting
-    was scheduled.
+    Most committee members have no technical background. This means
+    developers are required to explain the decision to the committee
+    so the committee can approve the decision. The developer who
+    explained the decision is the same developer who made it. The
+    approval is from someone who could not have made it. The system
+    has a name for this: governance.
 
-    This process provides oversight. What it oversees is the developers
-    explaining things. This is not nothing.
-
-    Security reviews follow the same model. The security tester will
-    assess the system with guidance from the team responsible for the
-    system. Findings will be documented, prioritized, and added to a
-    remediation backlog that is reviewed quarterly (see Section 7).
-    Developers are asked not to think too hard about the circular
-    nature of this.
+    Security reviews follow the same structure. The security team
+    assesses the system. The development team guides the assessment.
+    The findings are returned to the development team for remediation.
+    At no point does anyone involved who is not a developer touch
+    the software. The audit trail, however, is immaculate.
 
 17. WORKFORCE STRUCTURE
-    The engineering team responsible for pncli integrations operates
-    within a broader organizational structure designed to ensure that
-    all work is visible, tracked, and distributed appropriately.
+    For every engineer using pncli to do something, approximately
+    five (5) colleagues are in a meeting about it. This is not a
+    criticism. The meetings are very organized.
 
-    For every engineer writing code, there are approximately five (5)
-    colleagues ensuring that the code-writing is coordinated,
-    communicated, governed, assured, and reported on. This ratio
-    reflects the organization's commitment to not letting anything
-    ship without adequate process surrounding it.
+    Work is allocated by a dedicated Scrum Master, a full-time role
+    whose primary function is to ensure no single engineer carries
+    too much of the work. Stories are distributed across the team
+    based on capacity, availability, and story points — not on
+    familiarity with the system, previous ownership of the code,
+    or any demonstrated ability to complete the story. This prevents
+    bottlenecks. It also prevents progress, but the velocity chart
+    looks balanced, which is what gets presented to leadership.
 
-    Work distribution is managed by a dedicated Scrum Master — a
-    full-time role responsible for ensuring that stories are spread
-    evenly across the team regardless of individual capability,
-    context, or proximity to the codebase in question. This prevents
-    any one engineer from becoming a bottleneck, and ensures that
-    work that could be done in a day is collaboratively distributed
-    across a sprint.
+    Team meetings include the full cross-functional group, which
+    means the room is large enough that most people cannot contribute
+    and small enough that no one can leave. Cameras are optional.
+    Attention is aspirational. The meeting runs to time because the
+    Scrum Master has a hard stop.
 
-    Team meetings are attended by the full cross-functional group.
-    The meeting size ensures that most attendees cannot meaningfully
-    contribute at any given moment. This is called inclusion.
+18. INCIDENT ACCOUNTABILITY & CORRECTIVE ACTION
+    When something breaks in production, the organization's response
+    proceeds in two phases: fixing it, and then generating paperwork
+    about having fixed it. The paperwork phase is longer.
 
-18. COMPLIANCE WITH THIS NOTICE
+    The developer closest to the broken thing will be asked to produce:
+    a root cause analysis, a contributing factors document, a timeline
+    reconstruction, a risk register update, a lessons-learned summary,
+    a corrective action plan, a corrective action plan review, and a
+    brief slide deck suitable for a post-incident review meeting that
+    will be attended by people who were not involved in the incident
+    and will ask questions that suggest they have not read any of the
+    above documents.
+
+    Corrective actions are tracked. Developers who accumulate corrective
+    actions are placed on the Heightened Oversight Register — an
+    internal list, maintained in Excel, of engineers whose work is
+    subject to additional review. There is no formal process for being
+    removed from the Heightened Oversight Register. There is a formal
+    process for being added to it. The asymmetry is not documented,
+    but it is consistent.
+
+    Note: the Heightened Oversight Register should not be confused
+    with the Enhanced Monitoring List, the Watch List for Delivery
+    Risk, the Escalation Tracker, or the informally maintained
+    spreadsheet kept by one specific delivery manager that nobody
+    is supposed to know about but everyone does. These are separate
+    documents with overlapping names and no shared governance. They
+    are all maintained in Excel.
+
+19. COMPLIANCE WITH THIS NOTICE
     If you have read this far, congratulations — you are now more
     compliant than 97% of enterprise software users. Your actual legal
     obligation is simply to keep this NOTICE file intact when

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pncli",
+  "name": "@kolatts/pncli",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pncli",
+      "name": "@kolatts/pncli",
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -21,6 +21,7 @@
         "@typescript-eslint/eslint-plugin": "^8.31.0",
         "@typescript-eslint/parser": "^8.31.0",
         "eslint": "^9.25.1",
+        "husky": "^9.1.7",
         "tsup": "^8.4.0",
         "tsx": "^4.19.3",
         "typescript": "^5.8.3"
@@ -2440,6 +2441,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kolatts/pncli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kolatts/pncli",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kolatts/pncli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "The Paperwork Nightmare CLI — One command does what three meetings couldn't.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "tsup",
     "dev": "tsx src/cli.ts",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepare": "husky"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.5.0",
@@ -25,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^8.31.0",
     "@typescript-eslint/parser": "^8.31.0",
     "eslint": "^9.25.1",
+    "husky": "^9.1.7",
     "tsup": "^8.4.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { createRequire } from 'module';
-import { setGlobalOptions } from './lib/output.js';
+import { setGlobalOptions, setGlobalUser } from './lib/output.js';
+import { loadConfig } from './lib/config.js';
 import { registerGitCommands } from './services/git/commands.js';
 import { registerJiraCommands } from './services/jira/commands.js';
 import { registerBitbucketCommands } from './services/bitbucket/commands.js';
@@ -26,13 +27,19 @@ program
   .option('--dry-run', 'Print API requests without executing', false)
   .option('--config <path>', 'Override global config file location');
 
-// Propagate global options before any command runs
+// Propagate global options and user identity before any command runs
 program.hook('preAction', (thisCommand) => {
   const opts = thisCommand.optsWithGlobals();
   setGlobalOptions({
     pretty: Boolean(opts.pretty),
     verbose: Boolean(opts.verbose)
   });
+  try {
+    const config = loadConfig({ configPath: opts.config as string | undefined });
+    setGlobalUser(config.user);
+  } catch {
+    // config may not exist yet (e.g. during `config init`) — silently skip
+  }
 });
 
 registerGitCommands(program);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,7 +6,6 @@ import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketD
 
 const ENV_KEYS = {
   JIRA_BASE_URL: 'PNCLI_JIRA_BASE_URL',
-  JIRA_EMAIL: 'PNCLI_JIRA_EMAIL',
   JIRA_API_TOKEN: 'PNCLI_JIRA_API_TOKEN',
   BITBUCKET_BASE_URL: 'PNCLI_BITBUCKET_BASE_URL',
   BITBUCKET_PAT: 'PNCLI_BITBUCKET_PAT',
@@ -66,7 +65,6 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
   return {
     jira: {
       baseUrl: process.env[ENV_KEYS.JIRA_BASE_URL] ?? globalConfig.jira?.baseUrl,
-      email: process.env[ENV_KEYS.JIRA_EMAIL] ?? globalConfig.jira?.email,
       apiToken: process.env[ENV_KEYS.JIRA_API_TOKEN] ?? globalConfig.jira?.apiToken
     },
     bitbucket: {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -66,8 +66,8 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
 
   return {
     user: {
-      email: process.env[ENV_KEYS.EMAIL],
-      userId: process.env[ENV_KEYS.USERID]
+      email: process.env[ENV_KEYS.EMAIL] ?? globalConfig.user?.email,
+      userId: process.env[ENV_KEYS.USERID] ?? globalConfig.user?.userId
     },
     jira: {
       baseUrl: process.env[ENV_KEYS.JIRA_BASE_URL] ?? globalConfig.jira?.baseUrl,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,6 +5,8 @@ import { execSync } from 'child_process';
 import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults } from '../types/config.js';
 
 const ENV_KEYS = {
+  EMAIL: 'PNCLI_EMAIL',
+  USERID: 'PNCLI_USERID',
   JIRA_BASE_URL: 'PNCLI_JIRA_BASE_URL',
   JIRA_API_TOKEN: 'PNCLI_JIRA_API_TOKEN',
   BITBUCKET_BASE_URL: 'PNCLI_BITBUCKET_BASE_URL',
@@ -63,6 +65,10 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
   const mergedDefaults = mergeDefaults(globalConfig.defaults, repoConfig.defaults);
 
   return {
+    user: {
+      email: process.env[ENV_KEYS.EMAIL],
+      userId: process.env[ENV_KEYS.USERID]
+    },
     jira: {
       baseUrl: process.env[ENV_KEYS.JIRA_BASE_URL] ?? globalConfig.jira?.baseUrl,
       apiToken: process.env[ENV_KEYS.JIRA_API_TOKEN] ?? globalConfig.jira?.apiToken

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -101,11 +101,10 @@ export class HttpClient {
   }
 
   private jiraHeaders(): Record<string, string> {
-    const { email, apiToken } = this.config.jira;
-    if (!email || !apiToken) throw new PncliError('Jira credentials not configured. Run: pncli config init');
-    const token = Buffer.from(`${email}:${apiToken}`).toString('base64');
+    const { apiToken } = this.config.jira;
+    if (!apiToken) throw new PncliError('Jira credentials not configured. Run: pncli config init');
     return {
-      'Authorization': `Basic ${token}`,
+      'Authorization': `Bearer ${apiToken}`,
       'Content-Type': 'application/json',
       'Accept': 'application/json'
     };

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -3,9 +3,14 @@ import type { Meta, SuccessEnvelope, ErrorEnvelope, ErrorDetail } from '../types
 import { PncliError } from './errors.js';
 
 let globalOptions = { pretty: false, verbose: false };
+let globalUser: { email: string | undefined; userId: string | undefined } = { email: undefined, userId: undefined };
 
 export function setGlobalOptions(opts: { pretty: boolean; verbose: boolean }): void {
   globalOptions = opts;
+}
+
+export function setGlobalUser(user: { email: string | undefined; userId: string | undefined }): void {
+  globalUser = user;
 }
 
 function buildMeta(service: string, action: string, startTime: number): Meta {
@@ -13,7 +18,8 @@ function buildMeta(service: string, action: string, startTime: number): Meta {
     service,
     action,
     timestamp: new Date().toISOString(),
-    duration_ms: Date.now() - startTime
+    duration_ms: Date.now() - startTime,
+    user: (globalUser.email ?? globalUser.userId) ? globalUser : undefined
   };
 }
 

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -82,6 +82,18 @@ export function registerConfigCommands(program: Command): void {
 async function initGlobalConfig(start: number): Promise<void> {
   process.stderr.write('pncli config init — Global configuration\n\n');
 
+  process.stderr.write('── Identity ──────────────────────────────────────\n');
+  const userEmail = await input({
+    message: 'Your email address (used across Jira, Bitbucket, etc.):',
+    default: ''
+  });
+
+  const userId = await input({
+    message: 'Your username / user ID:',
+    default: ''
+  });
+
+  process.stderr.write('\n── Jira ──────────────────────────────────────────\n');
   const jiraBaseUrl = await input({
     message: 'Jira base URL (e.g. https://jira.your-company.com):',
     default: ''
@@ -91,6 +103,7 @@ async function initGlobalConfig(start: number): Promise<void> {
     message: 'Jira personal access token:'
   });
 
+  process.stderr.write('\n── Bitbucket ─────────────────────────────────────\n');
   const bitbucketBaseUrl = await input({
     message: 'Bitbucket Server base URL (e.g. https://bitbucket.your-company.com):',
     default: ''
@@ -100,11 +113,13 @@ async function initGlobalConfig(start: number): Promise<void> {
     message: 'Bitbucket personal access token:'
   });
 
+  process.stderr.write('\n── Defaults ──────────────────────────────────────\n');
   const jiraProject = await input({
     message: 'Default Jira project key (optional):',
     default: ''
   });
 
+  process.stderr.write('\n');
   const confirmed = await confirm({
     message: 'Write config to ~/.pncli/config.json?',
     default: true
@@ -116,6 +131,10 @@ async function initGlobalConfig(start: number): Promise<void> {
   }
 
   writeGlobalConfig({
+    user: {
+      email: userEmail || undefined,
+      userId: userId || undefined
+    },
     jira: {
       baseUrl: jiraBaseUrl || undefined,
       apiToken: jiraApiToken || undefined

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -83,17 +83,12 @@ async function initGlobalConfig(start: number): Promise<void> {
   process.stderr.write('pncli config init — Global configuration\n\n');
 
   const jiraBaseUrl = await input({
-    message: 'Jira base URL (e.g. https://your-domain.atlassian.net):',
-    default: ''
-  });
-
-  const jiraEmail = await input({
-    message: 'Jira email address:',
+    message: 'Jira base URL (e.g. https://jira.your-company.com):',
     default: ''
   });
 
   const jiraApiToken = await password({
-    message: 'Jira API token:'
+    message: 'Jira personal access token:'
   });
 
   const bitbucketBaseUrl = await input({
@@ -123,7 +118,6 @@ async function initGlobalConfig(start: number): Promise<void> {
   writeGlobalConfig({
     jira: {
       baseUrl: jiraBaseUrl || undefined,
-      email: jiraEmail || undefined,
       apiToken: jiraApiToken || undefined
     },
     bitbucket: {

--- a/src/services/jira/client.ts
+++ b/src/services/jira/client.ts
@@ -6,7 +6,7 @@ import type {
   JiraSearchResult
 } from '../../types/jira.js';
 
-const API = '/rest/api/3';
+const API = '/rest/api/2';
 
 export interface CreateIssueOpts {
   project: string;
@@ -45,15 +45,9 @@ export class JiraClient {
         project: { key: opts.project },
         issuetype: { name: opts.issueType },
         summary: opts.summary,
-        ...(opts.description ? {
-          description: {
-            type: 'doc',
-            version: 1,
-            content: [{ type: 'paragraph', content: [{ type: 'text', text: opts.description }] }]
-          }
-        } : {}),
+        ...(opts.description ? { description: opts.description } : {}),
         ...(opts.priority ? { priority: { name: opts.priority } } : {}),
-        ...(opts.assignee ? { assignee: { accountId: opts.assignee } } : {}),
+        ...(opts.assignee ? { assignee: { name: opts.assignee } } : {}),
         ...(opts.labels?.length ? { labels: opts.labels } : {})
       }
     };
@@ -69,15 +63,9 @@ export class JiraClient {
   async updateIssue(key: string, opts: UpdateIssueOpts): Promise<void> {
     const fields: Record<string, unknown> = {};
     if (opts.summary) fields.summary = opts.summary;
-    if (opts.description) {
-      fields.description = {
-        type: 'doc',
-        version: 1,
-        content: [{ type: 'paragraph', content: [{ type: 'text', text: opts.description }] }]
-      };
-    }
+    if (opts.description) fields.description = opts.description;
     if (opts.priority) fields.priority = { name: opts.priority };
-    if (opts.assignee) fields.assignee = { accountId: opts.assignee };
+    if (opts.assignee) fields.assignee = { name: opts.assignee };
     if (opts.labels) fields.labels = opts.labels;
 
     await this.http.jira<void>(`${API}/issue/${key}`, {
@@ -103,13 +91,7 @@ export class JiraClient {
   async addComment(key: string, text: string): Promise<JiraComment> {
     return this.http.jira<JiraComment>(`${API}/issue/${key}/comment`, {
       method: 'POST',
-      body: {
-        body: {
-          type: 'doc',
-          version: 1,
-          content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
-        }
-      }
+      body: { body: text }
     });
   }
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -3,6 +3,10 @@ export interface Meta {
   action: string;
   timestamp: string;
   duration_ms: number;
+  user?: {
+    email: string | undefined;
+    userId: string | undefined;
+  };
 }
 
 export interface SuccessEnvelope<T> {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -25,7 +25,13 @@ export interface Defaults {
   bitbucket?: BitbucketDefaults;
 }
 
+export interface UserConfig {
+  email?: string;
+  userId?: string;
+}
+
 export interface GlobalConfig {
+  user?: UserConfig;
   jira?: JiraConfig;
   bitbucket?: BitbucketConfig;
   defaults?: Defaults;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,5 @@
 export interface JiraConfig {
   baseUrl?: string;
-  email?: string;
   apiToken?: string;
 }
 
@@ -39,7 +38,6 @@ export interface RepoConfig {
 export interface ResolvedConfig {
   jira: {
     baseUrl: string | undefined;
-    email: string | undefined;
     apiToken: string | undefined;
   };
   bitbucket: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -36,6 +36,10 @@ export interface RepoConfig {
 }
 
 export interface ResolvedConfig {
+  user: {
+    email: string | undefined;
+    userId: string | undefined;
+  };
   jira: {
     baseUrl: string | undefined;
     apiToken: string | undefined;


### PR DESCRIPTION
## Summary

- Switch Jira integration to API v2 with Bearer token auth
- Add `PNCLI_EMAIL` and `PNCLI_USERID` as global user identity env vars, with prompts in `config init` wizard
- Add husky pre-commit hook (typecheck, lint, build) to enforce CI locally
- Normalize line endings to LF via `.gitattributes`
- Expand `NOTICE` with enterprise-flavored sections (environment, release, incident, tooling, oversight, workforce)
- Bump version to **1.1.0**

## Test plan

- [ ] Run `pncli config init` and verify identity prompts appear
- [ ] Confirm `PNCLI_EMAIL` / `PNCLI_USERID` are picked up by commands
- [ ] Test Jira commands against a real Jira instance (API v2 + Bearer token)
- [ ] Verify pre-commit hook runs typecheck/lint/build on `git commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)