### PR TITLE
feat: Jira custom fields + auto-generated copilot docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);const f=(j.tool_input||{}).file_path||'';process.exit(f.endsWith('commands.ts')?0:1);})\" && cd 'C:/Code/pncli' && npm run build --silent && node scripts/update-copilot-instructions.mjs 2>/dev/null || true",
+            "statusMessage": "Updating copilot-instructions.md..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/NOTICE
+++ b/NOTICE
@@ -16,18 +16,48 @@ to execute pncli — including accidentally in a terminal they didn't mean to
 open — you agree to the following irrevocable operational requirements:
 
 1. MANDATORY STAND-UP PARTICIPATION
-   Any team that adopts pncli must hold a daily stand-up of no fewer than
-   45 minutes to discuss whether the stand-up is still necessary. Minutes
-   must be recorded in triplicate, stored in Confluence, and linked from a
-   Jira ticket that is immediately moved to "Backlog" by someone who
-   doesn't know what a backlog is for.
+   All teams must hold a daily stand-up, strictly time-boxed to fifteen
+   (15) minutes. The stand-up will run forty-five (45) minutes.
+
+   Each attendee answers three questions: what they did yesterday, what
+   they are doing today, and whether anything is blocking them. Blockers
+   may not be discussed in the stand-up. Schedule a separate meeting.
+   The separate meeting will be attended by the same people, at a
+   different time, so that the stand-up can remain on time.
+
+   If a topic requires detail or problem solving, it must be taken
+   offline. Offline means a second meeting. The second meeting requires
+   a third to align on next steps. Resolution happens asynchronously,
+   in a Confluence page no one will find.
+
+   Anyone who says "no blockers, nothing to add" will be privately noted
+   as either not doing enough work or not communicating enough about it.
+   Both are concerns. Say something. Say anything. The stand-up is not
+   about information. It is about presence. Be present.
 
 2. RETURN-TO-OFFICE COMPLIANCE
-   Use of pncli is permitted only from a desk located on a floor staffed
-   by at least three (3) layers of management who have never run a
-   terminal. Hot desks are acceptable provided each seat has been
-   pre-approved by a committee of no fewer than seven (7) stakeholders,
-   none of whom use the software or know what it does.
+   All employees are required to be in office five (5) days per week,
+   effective immediately, no exceptions.
+
+   Exception requests may be submitted via the Flexible Work Arrangement
+   Portal. The portal is not publicly linked. You did not hear about it
+   here. Approved exceptions are confidential and will not be disclosed
+   to other employees who also do not have exceptions and are definitely
+   in the office. You did not notice this.
+
+   Employees who choose not to comply will be noted as having made a
+   choice. The consequences will follow through a process entirely
+   unrelated to this policy and will not be referred to as a layoff.
+   It is an alignment exercise.
+
+   Desk assignment is managed by Facilities. Facilities is managed by
+   a spreadsheet last updated by someone who no longer works here, under
+   a policy that has since changed, in a building reconfigured twice
+   without updating the spreadsheet. Your assigned desk may be a column,
+   a decommissioned printer station, or a hot desk already occupied by
+   someone with an exception.
+
+   There are no exceptions.
 
 3. JIRA TICKET REQUIREMENT
    Before running any pncli command in a non-local environment, your team
@@ -38,17 +68,33 @@ open — you agree to the following irrevocable operational requirements:
    PowerPoint" before they can approve it.
 
 4. CHANGE ADVISORY BOARD REVIEW
-   Any upgrade to a new version of pncli — including patch releases,
-   security fixes, and versions that fix the thing that's actively on
-   fire — must be submitted to the Change Advisory Board (CAB) no fewer
-   than six (6) business weeks in advance. The CAB meets on the third
-   Wednesday of months that contain the letter 'R'. Emergency changes
-   require a 47-page risk assessment and a blood sacrifice (metaphorical —
-   see Section 9: HR Policy on Metaphorical Sacrifices).
+   All changes must be submitted to the Change Advisory Board (CAB) for
+   approval before implementation. Before you can present to CAB, you
+   must first obtain a Permit.
 
-   Upon CAB approval, you have thirty (30) calendar days to implement the
-   approved change. Note that the standard change request process takes
-   ninety (90) calendar days. This is not a contradiction. This is tension.
+   Permits are tiered — Standard, Elevated, Complex, and Significant —
+   each with its own intake, its own approver, and a processing window
+   of ten (10) to forty-five (45) business days. Which tier applies is
+   determined by a classification guide available upon request by
+   submitting a Standard Permit.
+
+   Each intake is different. Some are forms. Some are emails to a shared
+   mailbox monitored by someone in a department that has since been
+   restructured. Some require a conversation with a Delivery Manager who
+   may or may not be aware they are part of the process. These things
+   vary by team, by floor, and by who picked up the phone last time.
+
+   Your change may be reclassified into a higher tier at any point. This
+   resets the clock. There is no notification.
+
+   CAB reviews the change. No member of CAB fully understands what they
+   are reviewing. Approval is based on whether the paperwork looks
+   complete and whether the change has been waiting long enough that
+   objecting feels rude.
+
+   CAB does not approve software. CAB approves paperwork about software.
+   The distinction matters a great deal to CAB. It is invisible to
+   production.
 
 5. APPROVAL CHAIN
    Any use of the `--force` flag, in any context, requires written
@@ -57,263 +103,297 @@ open — you agree to the following irrevocable operational requirements:
    with the Ombudsman of Flags, whose inbox has been full since 2019.
 
 6. DOCUMENTATION REQUIREMENTS
-   All internal usage guides, runbooks, incident reports, onboarding
-   materials, architecture decisions, and anything anyone might ever
-   need to find again must be maintained exclusively in the following
-   approved platforms:
+   All documentation must be maintained in the following approved
+   platforms:
 
    a) Microsoft Excel. Specifically, a workbook called something like
-      "pncli_tracking_v3_FINAL_v2_USE_THIS_ONE.xlsx" stored in a
-      OneDrive folder that three people have access to and one of them
-      has left the company.
+      "pncli_tracking_v3_FINAL_v2_USE_THIS_ONE.xlsx" in a OneDrive
+      folder that three people have access to and one of them has left.
 
-   b) The internal SharePoint site, which was last redesigned in 2019
-      by a vendor who no longer exists, requires IE compatibility mode
-      to render correctly, and has a homepage that links to a page
-      that links to a page that links to a broken redirect. The search
-      function returns results from 2014. This is by design.
+   b) The internal SharePoint site, last redesigned in 2019 by a vendor
+      who no longer exists, which requires IE compatibility mode and has
+      a search function that returns results from 2014. This is by design.
 
-   Under no circumstances may documentation be stored somewhere
-   findable. Confluence is permitted as a secondary archive, provided
-   every page is titled "Draft - DO NOT USE" regardless of status.
+   Under no circumstances may documentation be stored somewhere findable.
+   Confluence is permitted as a secondary archive, provided every page is
+   titled "Draft - DO NOT USE" regardless of status.
 
 7. QUARTERLY REVIEW PROCESS
-   Usage of pncli within your organization must be reviewed once per
-   quarter (every ninety (90) days) by a standing review committee.
-   The committee must produce a findings report, a summary of the
-   findings report, an executive summary of the summary, and a
-   one-page overview suitable for someone who will not read it.
+   Usage must be reviewed quarterly by a standing committee, which must
+   produce a findings report, a summary of the findings report, an
+   executive summary of the summary, and a one-page overview suitable
+   for someone who will not read it.
 
-   Additionally, the quarterly review process itself must be reviewed
-   once every ninety-one (91) days to ensure it remains fit for
-   purpose. The review-of-the-review is a separate process and does
-   not count toward the quarterly review. Both calendars must be
-   maintained in Excel (see Section 6a).
+   The quarterly review process itself must also be reviewed — every
+   ninety-one (91) days — to ensure it remains fit for purpose. The
+   review-of-the-review is a separate process and does not count toward
+   the quarterly review. Both calendars must be maintained in Excel.
 
 8. REMEDIATION TIMELINES
-   If any issue is identified during a quarterly review — including
-   but not limited to: misconfiguration, version drift, a developer
-   who has gone rogue and is using tab completion, or anything flagged
-   as "amber" without further explanation — the responsible team has
-   thirty (30) calendar days to remediate.
-
-   Remediation requires a change request. Change requests take ninety
-   (90) calendar days to process. Teams are encouraged to be proactive.
+   Any issue identified during a quarterly review must be remediated
+   within thirty (30) calendar days. Remediation requires a change
+   request. Change requests take ninety (90) calendar days to process.
+   Teams are encouraged to be proactive.
 
 9. TRAINING CERTIFICATION
-   Before using pncli in any environment beyond a developer's laptop,
-   all operators must complete a mandatory 8-hour training course titled
+   All operators must complete a mandatory 8-hour training course titled
    "Introduction to Reading --help Output." A 30-minute lunch break is
    provided but must be requested 48 hours in advance via the Lunch
    Request Portal, which is currently down for scheduled maintenance.
 
-   Completion certificates must be stored in the Learning Management
-   System, which syncs to a SharePoint list that feeds an Excel
-   dashboard that is emailed to a distribution list every Friday
-   to eleven people, nine of whom have set up an auto-archive rule.
+   Completion certificates are stored in the Learning Management System,
+   which syncs to a SharePoint list that feeds an Excel dashboard emailed
+   every Friday to eleven people, nine of whom have set up an auto-archive
+   rule.
 
 10. METRICS & REPORTING
-    All pncli usage must be reported to the Developer Productivity Team,
-    who will use the data to build a dashboard that no one looks at,
-    which will be presented quarterly to executives who will ask why
-    the numbers aren't higher and whether there is an app for it.
+    All usage must be reported to the Developer Productivity Team, who
+    will use the data to build a dashboard that no one looks at, presented
+    quarterly to executives who will ask why the numbers aren't higher and
+    whether there is an app for it.
 
-    Raw metrics must be exported to Excel before being imported into
-    the approved reporting tool, because the approved reporting tool
-    cannot connect directly to the data source. This is a known issue.
-    It is in the backlog.
+    Raw metrics must be exported to Excel before being imported into the
+    approved reporting tool, because the approved reporting tool cannot
+    connect directly to the data source. This is a known issue. It is in
+    the backlog.
 
 11. DEVELOPER ACCESS RECERTIFICATION
-    Every developer who uses pncli to debug, inspect, or otherwise
-    look at software they are personally responsible for must complete
-    a Access Recertification Form every ninety (90) calendar days to
-    confirm they are still permitted to do so.
-
-    The form must be submitted to their line manager, who forwards it
-    to the Access Governance team, who cross-reference it against the
-    approved user registry, which is maintained in Excel and was last
-    audited in a quarter that shall not be named. Allow fifteen (15)
+    Every developer must complete an Access Recertification Form every
+    ninety (90) days to confirm they are still permitted to debug the
+    software they are personally responsible for. Allow fifteen (15)
     business days for processing. If your recertification lapses, your
-    debugging access will be suspended pending renewal, at which point
-    you may raise an incident ticket for the outage caused by the thing
-    you are no longer allowed to debug.
+    debugging access will be suspended, at which point you may raise an
+    incident ticket for the outage caused by the thing you are no longer
+    allowed to debug.
 
-    Recertification is per-machine. If you use a work laptop and a
-    desktop, that is two forms. If you use a VM, that is a conversation
-    with the virtualization team that will take longer than ninety days.
+    Recertification is per-machine. If you use a VM, that is a
+    conversation with the virtualization team that will take longer than
+    ninety days.
 
     There is no reminder system. Compliance is the developer's
     responsibility. Non-compliance is also the developer's responsibility.
 
 12. ENVIRONMENT COMPLIANCE
-    Your organization maintains four pre-production environments to
-    ensure software is thoroughly tested before it reaches users.
-    None of them can do that, but they are maintained nonetheless.
+    Your organization maintains four pre-production environments. None
+    of them can do what they are supposed to do, but they are maintained
+    nonetheless.
 
-    - RND: No production-like data is permitted. No realistic data
-      of any kind is permitted. What is permitted is unclear. RND
-      exists on the architecture diagram and in the hearts of those
-      who approved the budget for it. Development work done here
-      is tested against conditions that do not exist anywhere else,
-      including production.
+    - RND: No production-like data is permitted. No realistic data of
+      any kind is permitted. What is permitted is unclear. RND exists
+      on the architecture diagram and in the hearts of those who
+      approved the budget for it.
 
     - UAT: User Acceptance Testing. Users do not test here. The
-      environment has the same data restrictions as RND, which is
-      why. The name remains.
+      environment has the same data restrictions as RND, which is why.
+      The name remains.
 
-    - QA: The one environment with enough data to be useful, and
-      the one environment that does not match production in any
-      meaningful way. QA passing is therefore a team ritual, like
-      a rain dance, except the rain still doesn't come on schedule
-      and someone has to write a post-mortem about it.
+    - QA: The one environment with enough data to be useful, which does
+      not match production in any meaningful way. QA passing is a team
+      ritual, like a rain dance, except the rain still doesn't come on
+      schedule and someone has to write a post-mortem about it.
 
-    - PROD (x2): There are two. Both are production. This is not
-      a DR configuration anyone can fully explain. Raising the
-      question in a meeting is not recommended unless you have
-      blocked the next two hours.
+    - PROD (x2): There are two. Both are production. This is not a DR
+      configuration anyone can fully explain. Raising the question in a
+      meeting is not recommended unless you have blocked the next two hours.
 
     All four pre-production environments must show green before a
-    deployment is approved. Showing green in an environment with
-    no data, against infrastructure that doesn't match production,
-    is a formal requirement. Catching bugs is a stretch goal.
+    deployment is approved. Catching bugs is a stretch goal.
 
 13. RELEASE MANAGEMENT
-    Your organization ships software approximately three to four
-    times per year. Each release requires thirty (30) to forty-five
-    (45) days of approvals, which means the team spends roughly one
-    third of the year doing paperwork about software instead of
-    shipping it. The remaining two thirds are spent preparing for
-    the next round of paperwork.
+    DORA tracks four software delivery performance tiers: Elite, High,
+    Medium, and Low. Elite teams deploy multiple times per day. Low
+    performers deploy somewhere between once a week and once a month.
 
-    This is called a release cadence. pncli was built to help
-    automate the work that happens between releases. We regret
-    there is not more of it.
+    Your organization ships three to four times per year. The researchers
+    left a blank below Low. They assumed it was a data error.
 
-    Security note: your organization typically detects a published
-    CVE forty-five (45) to sixty (60) days after it is public.
-    Your remediation SLA is thirty (30) days from detection.
-    Your next release window is determined by a calendar that
-    was not designed with any of this in mind. pncli can file
-    the Jira ticket. The Jira ticket cannot file itself into
-    a release. That takes another month.
+    Each release requires thirty (30) to forty-five (45) days of
+    approvals. This is called a release cadence. Geologists call it
+    deposition.
+
+    Security note: your organization typically detects a published CVE
+    forty-five (45) to sixty (60) days after it is public. Your
+    remediation SLA is thirty (30) days from detection. Your next release
+    window was scheduled by a calendar that predates the concept. These
+    three facts are aware of each other. No one else is.
 
 14. INCIDENT MANAGEMENT
-    Production incidents are first handled by an offshore support
-    function operating under the following severity model:
+    Production incidents are handled by an offshore support function
+    under the following severity model:
 
     P1 — CRITICAL: Something a developer mentioned in passing.
-    P2 — HIGH: Something that has been broken for three weeks
-         and was only just noticed.
-    P3 — MEDIUM: An active outage affecting all users, escalated
-         after the offshore team consulted the triage guide and
-         determined it did not match any P1 criteria because the
-         word "all" was not in the dropdown.
-    P4 — LOW: Everything else, including P1s that arrived on a
-         Friday after 4pm, which is a different kind of P1.
+    P2 — HIGH: Something that has been broken for three weeks and was
+         only just noticed.
+    P3 — MEDIUM: An active outage affecting all users, escalated after
+         the offshore team determined it did not match P1 criteria
+         because the word "all" was not in the dropdown.
+    P4 — LOW: Everything else, including P1s that arrived on a Friday
+         after 4pm, which is a different kind of P1.
 
-    A developer may be paged within minutes, or may receive a
-    ticket three weeks after the incident was already resolved.
-    Both are equally likely. The difference is not correlated
-    with severity. It is correlated with something, but nobody
+    A developer may be paged within minutes, or receive a ticket three
+    weeks after the incident was already resolved. The difference is not
+    correlated with severity. It is correlated with something, but nobody
     has had time to find out what.
 
 15. TOOLING APPROVALS
-    Any tool a developer wishes to use — IDE, extension, plugin,
-    AI assistant, or anything else that measurably closes the gap
-    between thinking of something and doing it — must be formally
-    approved before use. Approval is granted per version. A minor
-    version bump is a new application.
+    Any tool that measurably closes the gap between thinking of something
+    and doing it must be formally approved before use. Approval is granted
+    per version. A minor version bump is a new application.
 
-    The approval process takes several months. Tool vendors do not
-    wait. By the time a version is approved, it has been superseded
-    at least twice and the approved version is now the one with the
-    known vulnerability the newer version fixed. This is the process
-    working as intended.
+    By the time a version is approved, it has been superseded at least
+    twice, and the approved version is now the one with the known
+    vulnerability the newer version fixed. This is the process working
+    as intended.
 
-    In an era where AI tooling shifts capability on a weekly basis,
-    this ensures your engineers are always eighteen months behind
-    the current state of the art, which is a competitive position
-    your organization has committed to with some consistency.
+    In an era where AI tooling shifts capability weekly, this ensures
+    your engineers are always eighteen months behind the current state
+    of the art, which is a competitive position your organization has
+    committed to with some consistency.
 
     Library and package management through the internal artifact
-    repository is, notably, fast and functional. Nobody has
-    scheduled a meeting to discuss why the contrast exists. It
-    would take several months to approve the agenda.
+    repository is, notably, fast and functional. Nobody has scheduled
+    a meeting to discuss why the contrast exists. It would take several
+    months to approve the agenda.
 
 16. OVERSIGHT & APPROVAL GOVERNANCE
-    All technical decisions — what to integrate, how to configure
-    it, what a flag does, whether the flag is approved — must be
-    reviewed by a cross-functional committee before implementation.
+    All technical decisions must be reviewed by a cross-functional
+    committee before implementation. The committee includes Engineering,
+    Security, Risk, Compliance, Architecture, Delivery, and a rotating
+    seat for someone who joined the meeting late, muted themselves
+    immediately, and has not been seen since.
 
-    The committee is composed of representatives from Engineering,
-    Security, Risk, Compliance, Architecture, and Delivery, plus
-    a rotating seat for someone who joined the meeting late, muted
-    themselves immediately, and has not been seen since.
+    Most committee members have no technical background. Developers are
+    therefore required to explain the decision to the committee so the
+    committee can approve it. The developer who explained the decision
+    is the same developer who made it. The approval is from someone who
+    could not have made it. The system has a name for this: governance.
 
-    Most committee members have no technical background. This means
-    developers are required to explain the decision to the committee
-    so the committee can approve the decision. The developer who
-    explained the decision is the same developer who made it. The
-    approval is from someone who could not have made it. The system
-    has a name for this: governance.
-
-    Security reviews follow the same structure. The security team
-    assesses the system. The development team guides the assessment.
-    The findings are returned to the development team for remediation.
-    At no point does anyone involved who is not a developer touch
-    the software. The audit trail, however, is immaculate.
+    The audit trail, however, is immaculate.
 
 17. WORKFORCE STRUCTURE
-    For every engineer using pncli to do something, approximately
-    five (5) colleagues are in a meeting about it. This is not a
-    criticism. The meetings are very organized.
+    For every engineer using pncli to do something, approximately five
+    (5) colleagues are in a meeting about it. This is not a criticism.
+    The meetings are very organized.
 
-    Work is allocated by a dedicated Scrum Master, a full-time role
-    whose primary function is to ensure no single engineer carries
-    too much of the work. Stories are distributed across the team
-    based on capacity, availability, and story points — not on
-    familiarity with the system, previous ownership of the code,
-    or any demonstrated ability to complete the story. This prevents
-    bottlenecks. It also prevents progress, but the velocity chart
-    looks balanced, which is what gets presented to leadership.
+    Stories are distributed based on capacity, availability, and story
+    points — not on familiarity with the system, ownership of the code,
+    or demonstrated ability to complete the story. This prevents
+    bottlenecks. It also prevents progress, but the velocity chart looks
+    balanced, which is what gets presented to leadership.
 
-    Team meetings include the full cross-functional group, which
-    means the room is large enough that most people cannot contribute
-    and small enough that no one can leave. Cameras are optional.
-    Attention is aspirational. The meeting runs to time because the
-    Scrum Master has a hard stop.
+    Team meetings include the full cross-functional group, meaning the
+    room is large enough that most people cannot contribute and small
+    enough that no one can leave. Cameras are optional. Attention is
+    aspirational. The meeting runs to time because the Scrum Master has
+    a hard stop.
 
-18. INCIDENT ACCOUNTABILITY & CORRECTIVE ACTION
-    When something breaks in production, the organization's response
-    proceeds in two phases: fixing it, and then generating paperwork
-    about having fixed it. The paperwork phase is longer.
+18. TECHNICAL LEAD RESPONSIBILITIES
+    All paperwork that requires someone who understands what the software
+    does must be completed by the Technical Lead. This is because the
+    Technical Lead is the only person who knows where the form is, who
+    the right person to email is, and what the change actually involves.
+    Delegating results in a question escalated back to the Technical Lead
+    anyway. They have been designated as the efficient path.
 
-    The developer closest to the broken thing will be asked to produce:
-    a root cause analysis, a contributing factors document, a timeline
-    reconstruction, a risk register update, a lessons-learned summary,
-    a corrective action plan, a corrective action plan review, and a
-    brief slide deck suitable for a post-incident review meeting that
-    will be attended by people who were not involved in the incident
-    and will ask questions that suggest they have not read any of the
-    above documents.
+    Any effort to let engineers build the system will surface a
+    previously unscheduled requirement that redirects them to paperwork.
+    The story moves back to In Progress. The sprint will not be adjusted.
+    The velocity will be noted as a concern at the retrospective.
 
-    Corrective actions are tracked. Developers who accumulate corrective
-    actions are placed on the Heightened Oversight Register — an
-    internal list, maintained in Excel, of engineers whose work is
-    subject to additional review. There is no formal process for being
-    removed from the Heightened Oversight Register. There is a formal
-    process for being added to it. The asymmetry is not documented,
-    but it is consistent.
+    PRODUCTION SUPPORT: The Technical Lead will be paged when a service
+    fails, regardless of whether they own the service or have ever seen
+    it. This assumption will not be tested in advance. It will be tested
+    in production, which is a different kind of test and does not require
+    a Test Evidence Pack.
 
-    Note: the Heightened Oversight Register should not be confused
-    with the Enhanced Monitoring List, the Watch List for Delivery
-    Risk, the Escalation Tracker, or the informally maintained
-    spreadsheet kept by one specific delivery manager that nobody
-    is supposed to know about but everyone does. These are separate
-    documents with overlapping names and no shared governance. They
-    are all maintained in Excel.
+    TECHNICAL DIRECTION: Enterprise Architects attend vendor briefings
+    and produce recommendations based on what the vendor demonstrated.
+    The Technical Lead determines what the organization will actually
+    build, which will differ substantially, and explains the difference
+    in a way that does not make the Architects feel bad about the
+    briefing. This is called alignment. It takes several meetings.
 
-19. COMPLIANCE WITH THIS NOTICE
+    DEADLINE ACCOUNTABILITY: If the project is late, the Technical Lead
+    will be asked to explain why. The correct answer — that the timeline
+    was set before requirements were known and two engineers spent six
+    weeks on Permit paperwork — is not the answer that will be recorded.
+    The recorded answer will reference planning and estimation. The
+    Technical Lead's name will be adjacent to both words.
+
+    SURPRISE DEADLINES: Periodically, a deadline will appear that is two
+    weeks away, originating from a commitment made in a meeting the
+    Technical Lead was not invited to, by someone who did not know what
+    the work involved, to someone who needed a date. The Technical Lead
+    is now accountable for the date. The people in the meeting are
+    accountable for their calendars.
+
+    SECURITY TEAM APPLICATIONS: Occasionally an application owned by
+    the Security team will need support. The Security team will indicate
+    this is not something they support. The Technical Lead will be asked.
+    The application will be unrecognizable. The Technical Lead will
+    support it anyway, because a P1 with no owner is somehow worse.
+
+    The Technical Lead's availability for technical work is approximately
+    zero (0) to two (2) hours per week. The Technical Lead is considered
+    a resource. The resource is fully utilized. Utilization is high.
+    Output is a separate metric.
+
+19. INCIDENT ACCOUNTABILITY & CORRECTIVE ACTION
+    When something breaks in production, the response proceeds in two
+    phases: fixing it, then generating paperwork about having fixed it.
+    The paperwork phase is longer.
+
+    The developer closest to the broken thing will produce: a root cause
+    analysis, a contributing factors document, a timeline reconstruction,
+    a risk register update, a lessons-learned summary, a corrective action
+    plan, a corrective action plan review, and a slide deck for a
+    post-incident review attended by people who will ask questions that
+    suggest they have not read any of the above.
+
+    Developers who accumulate corrective actions are placed on the
+    Heightened Oversight Register. There is no formal process for being
+    removed. There is a formal process for being added. The asymmetry is
+    not documented, but it is consistent.
+
+    The Heightened Oversight Register should not be confused with the
+    Enhanced Monitoring List, the Watch List for Delivery Risk, the
+    Escalation Tracker, or the informally maintained spreadsheet kept by
+    one specific delivery manager that nobody is supposed to know about
+    but everyone does. These are separate documents with overlapping names
+    and no shared governance. They are all maintained in Excel.
+
+20. QUALITY ASSURANCE
+    Your organization has two separate quality functions. They do not
+    report to the same person. They have different definitions of quality.
+    Neither definition is software.
+
+    PRODUCT QUALITY ASSURANCE ensures that user stories are correctly
+    written. Not that the software works. That the stories are correctly
+    written. Stories deviating from the approved format will be returned
+    for revision regardless of whether the software is already deployed
+    and in use by actual users. Product QA owns the story. What happens
+    after is someone else's lane.
+
+    Acceptance criteria are reviewed against a seventeen-item checklist.
+    Four items are duplicates with different wording. One references a
+    template that no longer exists. Completion is mandatory.
+    Comprehension is not assessed.
+
+    QUALITY ENGINEERING reviews the Test Evidence Pack for completeness
+    and correct formatting. Whether the tests caught anything is not on
+    the sign-off sheet and is therefore not in scope.
+
+    A test executed against the wrong environment with the wrong data,
+    returning a false positive, passes QE review if the date field is
+    filled in. A test that found a real defect fails if the screenshot
+    is the wrong dimensions.
+
+    When the two teams disagree on who owns a quality concern, they hold
+    a meeting, produce a RACI, and store it in Confluence under a page
+    titled "Draft - DO NOT USE." The software remains unreviewed during
+    this process, which both teams agree is not their fault.
+
+21. COMPLIANCE WITH THIS NOTICE
     If you have read this far, congratulations — you are now more
     compliant than 97% of enterprise software users. Your actual legal
     obligation is simply to keep this NOTICE file intact when

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -67,80 +67,204 @@ pncli is a CLI tool that provides structured JSON access to Jira, Bitbucket, and
 3. Check recent commits:
    `pncli git log --count 5`
 
+<!-- COMMAND-REFERENCE:START -->
 ## Command Reference
 
-### Git (local)
+### Git
 
 ```
 pncli git status
-  # Returns: { staged: string[], unstaged: string[], untracked: string[] }
 
-pncli git diff [--staged] [--file <path>]
-  # Returns: { files: [{ path, binary, truncated, hunks: [{ oldStart, newStart, lines[] }] }], truncated }
+pncli git diff
+  --staged       Show staged changes only
+  --file <path>  Limit diff to a specific file
 
-pncli git log [--count <n>] [--since <date>]
-  # Returns: [{ hash, author, date, message }]
+pncli git log
+  --count <n>     Number of commits to show (default: "10")
+  --since <date>  Show commits since date (e.g. "2 weeks ago")
 
 pncli git branch
-  # Returns: { current, local: string[], remote: string[] }
 
 pncli git current-pr
-  # Returns: PR object for current branch, or null
 ```
 
-### Bitbucket Server
+### Jira
 
 ```
-pncli bitbucket list-prs [--state OPEN|MERGED|DECLINED|ALL] [--author <username>] [--reviewer <username>]
-pncli bitbucket get-pr --id <pr-id>
-pncli bitbucket create-pr --title "..." --source <branch> [--target <branch>] [--description "..."] [--reviewers user1,user2]
-pncli bitbucket update-pr --id <pr-id> [--title "..."] [--description "..."] [--reviewers user1,user2]
-pncli bitbucket merge-pr --id <pr-id> [--strategy <merge|squash|ff>] [--delete-branch]
-pncli bitbucket decline-pr --id <pr-id>
+pncli jira get-issue
+  --key <issue-key>  Issue key (e.g. PROJ-123)
 
-pncli bitbucket list-comments --pr <pr-id>
-pncli bitbucket add-comment --pr <pr-id> --body "..."
-pncli bitbucket add-inline-comment --pr <pr-id> --file <path> --line <n> --body "..." [--line-type <ADDED|REMOVED|CONTEXT>]
-pncli bitbucket reply-comment --pr <pr-id> --comment-id <id> --body "..."
-pncli bitbucket resolve-comment --pr <pr-id> --comment-id <id>
-pncli bitbucket delete-comment --pr <pr-id> --comment-id <id>
+pncli jira create-issue
+  --project <key>         Project key
+  --type <type>           Issue type (Bug, Story, Task, ...)
+  --summary <text>        Issue summary
+  --description <text>    Issue description
+  --priority <name>       Priority name
+  --assignee <accountId>  Assignee account ID
+  --labels <labels>       Comma-separated labels
+  --field <Name=value>    Custom field value (repeatable) (default: [])
 
-pncli bitbucket diff --pr <pr-id> [--file <path>] [--context-lines <n>]
-pncli bitbucket list-files --pr <pr-id>
+pncli jira update-issue
+  --key <issue-key>       Issue key
+  --summary <text>        New summary
+  --description <text>    New description
+  --priority <name>       New priority
+  --assignee <accountId>  New assignee account ID
+  --labels <labels>       Comma-separated labels
+  --field <Name=value>    Custom field value (repeatable) (default: [])
 
-pncli bitbucket approve --pr <pr-id>
-pncli bitbucket unapprove --pr <pr-id>
-pncli bitbucket needs-work --pr <pr-id>
-pncli bitbucket list-reviewers --pr <pr-id>
+pncli jira transition-issue
+  --key <issue-key>          Issue key
+  --transition <name-or-id>  Transition name or ID
 
-pncli bitbucket list-builds --pr <pr-id>
-pncli bitbucket get-build-status --commit <sha>
+pncli jira list-transitions
+  --key <issue-key>  Issue key
+
+pncli jira add-comment
+  --key <issue-key>  Issue key
+  --body <text>      Comment text
+
+pncli jira list-comments
+  --key <issue-key>  Issue key
+
+pncli jira search
+  --jql <query>      JQL query string
+  --max-results <n>  Maximum number of results
+
+pncli jira assign
+  --key <issue-key>       Issue key
+  --assignee <accountId>  Assignee account ID
+
+pncli jira link-issue
+  --key <issue-key>     Source issue key
+  --link-type <type>    Link type name or ID
+  --target <issue-key>  Target issue key
+
+pncli jira fields
+  --discover     Fetch field metadata from Jira API
+  --custom-only  Show only custom fields (requires --discover)
 ```
 
-### Jira Data Cloud
+### Bitbucket
 
 ```
-pncli jira get-issue --key <issue-key>
-pncli jira create-issue --project <key> --type <Bug|Story|Task> --summary "..." [--description "..."] [--priority <n>] [--assignee <accountId>] [--labels label1,label2]
-pncli jira update-issue --key <issue-key> [--summary "..."] [--description "..."] [--priority <n>] [--assignee <accountId>] [--labels label1,label2]
-pncli jira transition-issue --key <issue-key> --transition <name|id>
-pncli jira list-transitions --key <issue-key>
-pncli jira add-comment --key <issue-key> --body "..."
-pncli jira list-comments --key <issue-key>
-pncli jira search --jql "..." [--max-results <n>]
-pncli jira assign --key <issue-key> --assignee <accountId>
-pncli jira link-issue --key <issue-key> --link-type <n> --target <issue-key>
+pncli bitbucket list-prs
+  --state <state>        PR state: OPEN|MERGED|DECLINED|ALL (default: "OPEN")
+  --author <username>    Filter by author username
+  --reviewer <username>  Filter by reviewer username
+
+pncli bitbucket get-pr
+  --id <pr-id>  Pull request ID
+
+pncli bitbucket create-pr
+  --title <title>       PR title
+  --source <branch>     Source branch
+  --target <branch>     Target branch (defaults to config)
+  --description <desc>  PR description
+  --reviewers <users>   Comma-separated reviewer usernames
+
+pncli bitbucket update-pr
+  --id <pr-id>          Pull request ID
+  --title <title>       New title
+  --description <desc>  New description
+  --reviewers <users>   Comma-separated reviewer usernames
+
+pncli bitbucket merge-pr
+  --id <pr-id>           Pull request ID
+  --strategy <strategy>  Merge strategy: merge|squash|ff
+  --delete-branch        Delete source branch after merge
+
+pncli bitbucket decline-pr
+  --id <pr-id>  Pull request ID
+
+pncli bitbucket list-comments
+  --pr <pr-id>  Pull request ID
+
+pncli bitbucket add-comment
+  --pr <pr-id>   Pull request ID
+  --body <text>  Comment text
+
+pncli bitbucket add-inline-comment
+  --pr <pr-id>        Pull request ID
+  --file <path>       File path
+  --line <n>          Line number
+  --body <text>       Comment text
+  --line-type <type>  Line type: ADDED|REMOVED|CONTEXT (default: "ADDED")
+
+pncli bitbucket reply-comment
+  --pr <pr-id>       Pull request ID
+  --comment-id <id>  Comment ID to reply to
+  --body <text>      Reply text
+
+pncli bitbucket resolve-comment
+  --pr <pr-id>       Pull request ID
+  --comment-id <id>  Comment ID
+  --version <n>      Comment version (default: "0")
+
+pncli bitbucket delete-comment
+  --pr <pr-id>       Pull request ID
+  --comment-id <id>  Comment ID
+  --version <n>      Comment version (default: "0")
+
+pncli bitbucket diff
+  --pr <pr-id>         Pull request ID
+  --file <path>        Limit diff to a specific file
+  --context-lines <n>  Lines of context around changes
+
+pncli bitbucket list-files
+  --pr <pr-id>  Pull request ID
+
+pncli bitbucket approve
+  --pr <pr-id>  Pull request ID
+
+pncli bitbucket unapprove
+  --pr <pr-id>  Pull request ID
+
+pncli bitbucket needs-work
+  --pr <pr-id>  Pull request ID
+
+pncli bitbucket list-reviewers
+  --pr <pr-id>  Pull request ID
+
+pncli bitbucket list-builds
+  --pr <pr-id>  Pull request ID
+
+pncli bitbucket get-build-status
+  --commit <sha>  Commit SHA
+```
+
+### Confluence
+
+```
+# confluence — no subcommands implemented yet
+```
+
+### Sonar
+
+```
+# sonar — no subcommands implemented yet
+```
+
+### Artifactory
+
+```
+# artifactory — no subcommands implemented yet
 ```
 
 ### Config
 
 ```
-pncli config init                   # Interactive global config wizard
-pncli config init --repo            # Interactive repo config wizard
-pncli config show                   # Print resolved config (PATs masked)
-pncli config set <key> <value>      # Set a config value (e.g. jira.baseUrl https://...)
-pncli config test                   # Test service connectivity
+pncli config init
+  --repo      Write repo config (.pncli.json) instead of global config
+
+pncli config show
+
+pncli config set
+
+pncli config test
 ```
+
+<!-- COMMAND-REFERENCE:END -->
 
 ## Output Format
 

--- a/scripts/update-copilot-instructions.mjs
+++ b/scripts/update-copilot-instructions.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Regenerates the Command Reference section of copilot-instructions.md
+ * by introspecting the built CLI's --help output.
+ *
+ * Usage: node scripts/update-copilot-instructions.mjs
+ * Triggered automatically by Claude hook after edits to commands.ts files.
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(ROOT, 'dist', 'cli.js');
+const DOC = path.join(ROOT, 'copilot-instructions.md');
+const START_MARKER = '<!-- COMMAND-REFERENCE:START -->';
+const END_MARKER = '<!-- COMMAND-REFERENCE:END -->';
+
+function run(args) {
+  try {
+    return execSync(`node "${CLI}" ${args} --help`, {
+      encoding: 'utf8',
+      cwd: ROOT,
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' }
+    }).trim();
+  } catch (e) {
+    return e.stdout?.trim() ?? '';
+  }
+}
+
+/** Parse command names from a Commands: section in --help output */
+function parseCommandsSection(helpText) {
+  const lines = helpText.split('\n');
+  const startIdx = lines.findIndex(l => l.trimEnd() === 'Commands:');
+  if (startIdx === -1) return [];
+  // Commander.js indents command names with exactly 2 spaces.
+  // Wrapped description lines are indented much further (10+ spaces).
+  const CMD_INDENT = /^ {2}(\S)/;
+  const names = [];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.length > 0 && !line.startsWith(' ') && !line.startsWith('\t')) break;
+    const match = line.match(CMD_INDENT);
+    if (match) {
+      const name = line.trim().split(/\s+/)[0];
+      if (name && name !== 'help') names.push(name);
+    }
+  }
+  return names;
+}
+
+/** Parse top-level subcommand names from `pncli --help` output */
+function parseTopLevelCommands(helpText) {
+  return parseCommandsSection(helpText);
+}
+
+/** Parse subcommand names from `pncli <cmd> --help` output */
+function parseSubcommands(helpText) {
+  return parseCommandsSection(helpText);
+}
+
+/** Format a single help block, indented under its section */
+function formatHelp(helpText) {
+  // Strip the "Usage:" line and "Options:" block — keep just the description + commands list
+  // but for leaf commands keep the full options so agents know the flags
+  return helpText
+    .split('\n')
+    .map(l => '  ' + l)
+    .join('\n');
+}
+
+function buildCommandReference() {
+  const topHelp = run('');
+  const topCommands = parseTopLevelCommands(topHelp);
+
+  const lines = ['## Command Reference', ''];
+
+  for (const cmd of topCommands) {
+    const cmdHelp = run(cmd);
+    const subcommands = parseSubcommands(cmdHelp);
+    const cmdTitle = cmd.charAt(0).toUpperCase() + cmd.slice(1);
+
+    lines.push(`### ${cmdTitle}`);
+    lines.push('');
+    lines.push('```');
+
+    if (subcommands.length === 0) {
+      lines.push(`# ${cmd} — no subcommands implemented yet`);
+    } else {
+      for (const sub of subcommands) {
+        const subHelp = run(`${cmd} ${sub}`);
+        lines.push(`pncli ${cmd} ${sub}`);
+        // Extract usage line and options
+        const usageLine = subHelp.match(/^Usage:\s+(.+)$/m)?.[1] ?? '';
+        const description = subHelp.split('\n')[1]?.trim() ?? '';
+        if (description) lines.push(`  # ${description}`);
+        // Extract options (excluding -h/--help and global flags)
+        const subLines = subHelp.split('\n');
+        const optStart = subLines.findIndex(l => l.trimEnd() === 'Options:');
+        const opts = [];
+        if (optStart !== -1) {
+          for (let i = optStart + 1; i < subLines.length; i++) {
+            const l = subLines[i];
+            if (l.length > 0 && !l.startsWith(' ') && !l.startsWith('\t')) break;
+            const trimmed = l.trim();
+            if (trimmed && !trimmed.startsWith('-h,') && !trimmed.startsWith('--help')) {
+              opts.push(trimmed);
+            }
+          }
+        }
+        for (const opt of opts) {
+          lines.push(`  ${opt}`);
+        }
+        lines.push('');
+      }
+      // Remove trailing empty line before closing ```
+      if (lines[lines.length - 1] === '') lines.pop();
+    }
+
+    lines.push('```');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function updateDoc(newReference) {
+  const doc = readFileSync(DOC, 'utf8');
+  const startIdx = doc.indexOf(START_MARKER);
+  const endIdx = doc.indexOf(END_MARKER);
+
+  if (startIdx === -1 || endIdx === -1) {
+    console.error('ERROR: Markers not found in copilot-instructions.md');
+    process.exit(1);
+  }
+
+  const before = doc.slice(0, startIdx + START_MARKER.length);
+  const after = doc.slice(endIdx);
+  const updated = `${before}\n${newReference}\n${after}`;
+
+  writeFileSync(DOC, updated, 'utf8');
+  console.log('Updated copilot-instructions.md command reference.');
+}
+
+const reference = buildCommandReference();
+updateDoc(reference);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
 import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults } from '../types/config.js';
+import type { CustomFieldDefinition } from '../types/jira.js';
 
 const ENV_KEYS = {
   EMAIL: 'PNCLI_EMAIL',
@@ -38,6 +39,16 @@ function getRepoRoot(): string | null {
   }
 }
 
+function mergeCustomFields(
+  global: CustomFieldDefinition[] | undefined,
+  repo: CustomFieldDefinition[] | undefined
+): CustomFieldDefinition[] {
+  const map = new Map<string, CustomFieldDefinition>();
+  for (const f of global ?? []) map.set(f.id, f);
+  for (const f of repo ?? []) map.set(f.id, f); // repo wins
+  return Array.from(map.values());
+}
+
 function mergeDefaults(
   global: GlobalConfig['defaults'],
   repo: RepoConfig['defaults']
@@ -71,7 +82,8 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
     },
     jira: {
       baseUrl: process.env[ENV_KEYS.JIRA_BASE_URL] ?? globalConfig.jira?.baseUrl,
-      apiToken: process.env[ENV_KEYS.JIRA_API_TOKEN] ?? globalConfig.jira?.apiToken
+      apiToken: process.env[ENV_KEYS.JIRA_API_TOKEN] ?? globalConfig.jira?.apiToken,
+      customFields: mergeCustomFields(globalConfig.jira?.customFields, repoConfig.jira?.customFields)
     },
     bitbucket: {
       baseUrl: process.env[ENV_KEYS.BITBUCKET_BASE_URL] ?? globalConfig.bitbucket?.baseUrl,
@@ -120,7 +132,8 @@ export function maskConfig(config: ResolvedConfig): unknown {
     ...config,
     jira: {
       ...config.jira,
-      apiToken: config.jira.apiToken ? '***' : undefined
+      apiToken: config.jira.apiToken ? '***' : undefined,
+      customFields: config.jira.customFields
     },
     bitbucket: {
       ...config.bitbucket,

--- a/src/services/jira/client.ts
+++ b/src/services/jira/client.ts
@@ -3,7 +3,9 @@ import type {
   JiraIssue,
   JiraTransition,
   JiraComment,
-  JiraSearchResult
+  JiraSearchResult,
+  JiraFieldInfo,
+  CustomFieldDefinition
 } from '../../types/jira.js';
 
 const API = '/rest/api/2';
@@ -16,6 +18,7 @@ export interface CreateIssueOpts {
   priority?: string;
   assignee?: string;
   labels?: string[];
+  customFieldValues?: Record<string, unknown>;
 }
 
 export interface UpdateIssueOpts {
@@ -24,6 +27,7 @@ export interface UpdateIssueOpts {
   priority?: string;
   assignee?: string;
   labels?: string[];
+  customFieldValues?: Record<string, unknown>;
 }
 
 export interface LinkIssueOpts {
@@ -48,7 +52,8 @@ export class JiraClient {
         ...(opts.description ? { description: opts.description } : {}),
         ...(opts.priority ? { priority: { name: opts.priority } } : {}),
         ...(opts.assignee ? { assignee: { name: opts.assignee } } : {}),
-        ...(opts.labels?.length ? { labels: opts.labels } : {})
+        ...(opts.labels?.length ? { labels: opts.labels } : {}),
+        ...(opts.customFieldValues ?? {})
       }
     };
 
@@ -67,6 +72,7 @@ export class JiraClient {
     if (opts.priority) fields.priority = { name: opts.priority };
     if (opts.assignee) fields.assignee = { name: opts.assignee };
     if (opts.labels) fields.labels = opts.labels;
+    Object.assign(fields, opts.customFieldValues ?? {});
 
     await this.http.jira<void>(`${API}/issue/${key}`, {
       method: 'PUT',
@@ -105,11 +111,16 @@ export class JiraClient {
     });
   }
 
-  async search(jql: string, maxResults?: number): Promise<JiraSearchResult> {
+  async search(jql: string, maxResults?: number, customFields?: CustomFieldDefinition[]): Promise<JiraSearchResult> {
+    const standardFields = ['summary', 'status', 'priority', 'assignee', 'issuetype', 'project', 'created', 'updated', 'labels', 'reporter'];
+    const fields = customFields?.length
+      ? [...standardFields, ...customFields.map(f => f.id)]
+      : standardFields;
+
     if (maxResults !== undefined) {
       return this.http.jira<JiraSearchResult>(`${API}/search`, {
         method: 'POST',
-        body: { jql, maxResults, fields: ['summary', 'status', 'priority', 'assignee', 'issuetype', 'project', 'created', 'updated', 'labels', 'reporter'] }
+        body: { jql, maxResults, fields }
       });
     }
 
@@ -117,12 +128,16 @@ export class JiraClient {
     const allIssues = await this.http.jiraPaginate<JiraIssue>(async (startAt, max) => {
       const result = await this.http.jira<JiraSearchResult>(`${API}/search`, {
         method: 'POST',
-        body: { jql, startAt, maxResults: max, fields: ['summary', 'status', 'priority', 'assignee', 'issuetype', 'project', 'created', 'updated', 'labels', 'reporter'] }
+        body: { jql, startAt, maxResults: max, fields }
       });
       return { ...result, values: result.issues };
     });
 
     return { issues: allIssues, total: allIssues.length, startAt: 0, maxResults: allIssues.length };
+  }
+
+  async fetchFields(): Promise<JiraFieldInfo[]> {
+    return this.http.jira<JiraFieldInfo[]>(`${API}/field`);
   }
 
   async assignIssue(key: string, accountId: string): Promise<void> {

--- a/src/services/jira/commands.ts
+++ b/src/services/jira/commands.ts
@@ -1,9 +1,11 @@
 import { Command } from 'commander';
 import { JiraClient } from './client.js';
+import { buildFieldMap, translateJql, translateFieldsInOutput, formatFieldValue } from './custom-fields.js';
 import { createHttpClient } from '../../lib/http.js';
 import { loadConfig } from '../../lib/config.js';
 import { success, fail } from '../../lib/output.js';
 import { PncliError } from '../../lib/errors.js';
+import type { CustomFieldMap } from '../../types/jira.js';
 
 function getClient(program: Command): JiraClient {
   const opts = program.optsWithGlobals();
@@ -11,6 +13,17 @@ function getClient(program: Command): JiraClient {
   if (!config.jira.baseUrl) throw new PncliError('Jira not configured. Run: pncli config init');
   const http = createHttpClient(config, Boolean(opts.dryRun));
   return new JiraClient(http);
+}
+
+function getClientAndFields(program: Command): { client: JiraClient; fieldMap: CustomFieldMap; customFields: import('../../types/jira.js').CustomFieldDefinition[] } {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config });
+  if (!config.jira.baseUrl) throw new PncliError('Jira not configured. Run: pncli config init');
+  const http = createHttpClient(config, Boolean(opts.dryRun));
+  const client = new JiraClient(http);
+  const customFields = config.jira.customFields;
+  const fieldMap = buildFieldMap(customFields);
+  return { client, fieldMap, customFields };
 }
 
 function getDefaults(program: Command): { project?: string; issueType?: string; priority?: string } {
@@ -32,9 +45,10 @@ export function registerJiraCommands(program: Command): void {
     .action(async (opts: { key: string }) => {
       const start = Date.now();
       try {
-        const client = getClient(program);
+        const { client, fieldMap } = getClientAndFields(program);
         const data = await client.getIssue(opts.key);
-        success(data, 'jira', 'get-issue', start);
+        const translated = { ...data, fields: translateFieldsInOutput(data.fields as Record<string, unknown>, fieldMap) };
+        success(translated, 'jira', 'get-issue', start);
       } catch (err) { fail(err, 'jira', 'get-issue', start); }
     });
 
@@ -47,17 +61,19 @@ export function registerJiraCommands(program: Command): void {
     .option('--priority <name>', 'Priority name')
     .option('--assignee <accountId>', 'Assignee account ID')
     .option('--labels <labels>', 'Comma-separated labels')
-    .action(async (opts: { project?: string; type?: string; summary: string; description?: string; priority?: string; assignee?: string; labels?: string }) => {
+    .option('--field <Name=value>', 'Custom field value (repeatable)', (val: string, acc: string[]) => [...acc, val], [] as string[])
+    .action(async (opts: { project?: string; type?: string; summary: string; description?: string; priority?: string; assignee?: string; labels?: string; field: string[] }) => {
       const start = Date.now();
       try {
-        const client = getClient(program);
+        const { client, fieldMap } = getClientAndFields(program);
         const defaults = getDefaults(program);
         const project = opts.project ?? defaults.project;
         const issueType = opts.type ?? defaults.issueType ?? 'Task';
         const priority = opts.priority ?? defaults.priority;
         if (!project) throw new PncliError('--project required (or set defaults.jira.project in config)', 1);
         const labels = opts.labels ? opts.labels.split(',').map(s => s.trim()) : undefined;
-        const data = await client.createIssue({ project, issueType, summary: opts.summary, description: opts.description, priority, assignee: opts.assignee, labels });
+        const customFieldValues = parseFieldArgs(opts.field, fieldMap);
+        const data = await client.createIssue({ project, issueType, summary: opts.summary, description: opts.description, priority, assignee: opts.assignee, labels, customFieldValues });
         success(data, 'jira', 'create-issue', start);
       } catch (err) { fail(err, 'jira', 'create-issue', start); }
     });
@@ -70,12 +86,14 @@ export function registerJiraCommands(program: Command): void {
     .option('--priority <name>', 'New priority')
     .option('--assignee <accountId>', 'New assignee account ID')
     .option('--labels <labels>', 'Comma-separated labels')
-    .action(async (opts: { key: string; summary?: string; description?: string; priority?: string; assignee?: string; labels?: string }) => {
+    .option('--field <Name=value>', 'Custom field value (repeatable)', (val: string, acc: string[]) => [...acc, val], [] as string[])
+    .action(async (opts: { key: string; summary?: string; description?: string; priority?: string; assignee?: string; labels?: string; field: string[] }) => {
       const start = Date.now();
       try {
-        const client = getClient(program);
+        const { client, fieldMap } = getClientAndFields(program);
         const labels = opts.labels ? opts.labels.split(',').map(s => s.trim()) : undefined;
-        await client.updateIssue(opts.key, { summary: opts.summary, description: opts.description, priority: opts.priority, assignee: opts.assignee, labels });
+        const customFieldValues = parseFieldArgs(opts.field, fieldMap);
+        await client.updateIssue(opts.key, { summary: opts.summary, description: opts.description, priority: opts.priority, assignee: opts.assignee, labels, customFieldValues });
         success({ updated: opts.key }, 'jira', 'update-issue', start);
       } catch (err) { fail(err, 'jira', 'update-issue', start); }
     });
@@ -145,10 +163,15 @@ export function registerJiraCommands(program: Command): void {
     .action(async (opts: { jql: string; maxResults?: string }) => {
       const start = Date.now();
       try {
-        const client = getClient(program);
+        const { client, fieldMap, customFields } = getClientAndFields(program);
         const maxResults = opts.maxResults ? parseInt(opts.maxResults, 10) : undefined;
-        const data = await client.search(opts.jql, maxResults);
-        success(data, 'jira', 'search', start);
+        const translatedJql = translateJql(opts.jql, fieldMap);
+        const data = await client.search(translatedJql, maxResults, customFields);
+        const translatedIssues = data.issues.map(issue => ({
+          ...issue,
+          fields: translateFieldsInOutput(issue.fields as Record<string, unknown>, fieldMap)
+        }));
+        success({ ...data, issues: translatedIssues }, 'jira', 'search', start);
       } catch (err) { fail(err, 'jira', 'search', start); }
     });
 
@@ -178,4 +201,40 @@ export function registerJiraCommands(program: Command): void {
         success({ linked: opts.key, to: opts.target, type: opts.linkType }, 'jira', 'link-issue', start);
       } catch (err) { fail(err, 'jira', 'link-issue', start); }
     });
+
+  jira.command('fields')
+    .description('List custom fields (configured or discovered from Jira API)')
+    .option('--discover', 'Fetch field metadata from Jira API')
+    .option('--custom-only', 'Show only custom fields (requires --discover)')
+    .action(async (opts: { discover?: boolean; customOnly?: boolean }) => {
+      const start = Date.now();
+      try {
+        if (opts.discover) {
+          const client = getClient(program);
+          const fields = await client.fetchFields();
+          const result = opts.customOnly ? fields.filter(f => f.custom) : fields;
+          success(result, 'jira', 'fields', start);
+        } else {
+          const { customFields } = getClientAndFields(program);
+          success(customFields, 'jira', 'fields', start);
+        }
+      } catch (err) { fail(err, 'jira', 'fields', start); }
+    });
+}
+
+function parseFieldArgs(
+  fieldArgs: string[],
+  fieldMap: CustomFieldMap
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const arg of fieldArgs) {
+    const eq = arg.indexOf('=');
+    if (eq === -1) throw new PncliError(`Invalid --field format (expected Name=value): ${arg}`, 1);
+    const name = arg.slice(0, eq).trim();
+    const value = arg.slice(eq + 1);
+    const def = fieldMap.byName.get(name.toLowerCase());
+    if (!def) throw new PncliError(`Unknown custom field: "${name}". Run: pncli jira fields`, 1);
+    result[def.id] = formatFieldValue(value, def.type);
+  }
+  return result;
 }

--- a/src/services/jira/custom-fields.ts
+++ b/src/services/jira/custom-fields.ts
@@ -1,0 +1,74 @@
+import type { CustomFieldDefinition, CustomFieldMap, CustomFieldType } from '../../types/jira.js';
+
+export function buildFieldMap(fields: CustomFieldDefinition[]): CustomFieldMap {
+  const byName = new Map<string, CustomFieldDefinition>();
+  const byId = new Map<string, CustomFieldDefinition>();
+  for (const f of fields) {
+    byName.set(f.name.toLowerCase(), f);
+    byId.set(f.id, f);
+  }
+  return { byName, byId };
+}
+
+/**
+ * Replace friendly field names with customfield_* IDs in a JQL string.
+ * Splits on quoted segments to avoid replacing inside string literals.
+ * Sorts field names by length descending so "Story Points" matches before "Story".
+ */
+export function translateJql(jql: string, fieldMap: CustomFieldMap): string {
+  if (fieldMap.byName.size === 0) return jql;
+
+  // Sort names by length descending to avoid partial matches
+  const sortedNames = Array.from(fieldMap.byName.keys()).sort((a, b) => b.length - a.length);
+
+  // Split on quoted segments, only translate unquoted parts
+  const parts = jql.split(/(["'][^"']*["'])/);
+  return parts.map((part, i) => {
+    if (i % 2 === 1) return part; // inside quotes — leave as-is
+    let out = part;
+    for (const name of sortedNames) {
+      const def = fieldMap.byName.get(name)!;
+      // Match the field name as a whole word (case-insensitive), optionally quoted
+      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      out = out.replace(new RegExp(`(?<![\\w"'])${escaped}(?![\\w"'])`, 'gi'), def.id);
+    }
+    return out;
+  }).join('');
+}
+
+/**
+ * Replace customfield_* keys with friendly names in an issue fields object.
+ * Returns a new object; does not mutate the original.
+ */
+export function translateFieldsInOutput(
+  fields: Record<string, unknown>,
+  fieldMap: CustomFieldMap
+): Record<string, unknown> {
+  if (fieldMap.byId.size === 0) return fields;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    const def = fieldMap.byId.get(key);
+    result[def ? def.name : key] = value;
+  }
+  return result;
+}
+
+/**
+ * Format a CLI string value into the shape Jira's API expects for a given field type.
+ */
+export function formatFieldValue(value: string, type: CustomFieldType): unknown {
+  switch (type) {
+    case 'number':
+      return Number(value);
+    case 'select':
+      return { value };
+    case 'multi-select':
+      return value.split(',').map(v => ({ value: v.trim() }));
+    case 'labels':
+      return value.split(',').map(v => v.trim());
+    case 'user':
+      return { accountId: value };
+    default:
+      return value;
+  }
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,7 @@
 export interface JiraConfig {
   baseUrl?: string;
   apiToken?: string;
+  customFields?: import('./jira.js').CustomFieldDefinition[];
 }
 
 export interface BitbucketConfig {
@@ -39,6 +40,7 @@ export interface GlobalConfig {
 
 export interface RepoConfig {
   defaults?: Defaults;
+  jira?: { customFields?: import('./jira.js').CustomFieldDefinition[] };
 }
 
 export interface ResolvedConfig {
@@ -49,6 +51,7 @@ export interface ResolvedConfig {
   jira: {
     baseUrl: string | undefined;
     apiToken: string | undefined;
+    customFields: import('./jira.js').CustomFieldDefinition[];
   };
   bitbucket: {
     baseUrl: string | undefined;

--- a/src/types/jira.ts
+++ b/src/types/jira.ts
@@ -1,5 +1,37 @@
 // Phase 3 — Jira Data Cloud types
 
+export type CustomFieldType =
+  | 'string'
+  | 'number'
+  | 'date'
+  | 'datetime'
+  | 'select'
+  | 'multi-select'
+  | 'user'
+  | 'labels'
+  | 'url'
+  | 'textarea';
+
+export interface CustomFieldDefinition {
+  id: string;
+  name: string;
+  type: CustomFieldType;
+  description?: string;
+  examples?: string[];
+}
+
+export interface CustomFieldMap {
+  byName: Map<string, CustomFieldDefinition>;
+  byId: Map<string, CustomFieldDefinition>;
+}
+
+export interface JiraFieldInfo {
+  id: string;
+  name: string;
+  custom: boolean;
+  schema?: { type: string; custom?: string };
+}
+
 export interface JiraIssue {
   id: string;
   key: string;
@@ -15,6 +47,7 @@ export interface JiraIssue {
     project: { key: string; name: string };
     created: string;
     updated: string;
+    [key: string]: unknown;
   };
 }
 


### PR DESCRIPTION
## Summary

- **Jira custom fields**: define `customFields` in global `~/.pncli/config.json` or repo `.pncli.json` — friendly names translate to/from `customfield_*` IDs automatically in JQL, search output, and get-issue output
- **`--field "Name=value"`** option on `create-issue` and `update-issue` for setting custom fields by friendly name
- **`pncli jira fields`** subcommand to list configured fields, or `--discover --custom-only` to fetch from the Jira API
- **Auto-generated `copilot-instructions.md`**: `scripts/update-copilot-instructions.mjs` regenerates the Command Reference section from live `--help` output; a Claude hook in `.claude/settings.json` triggers it automatically after any `commands.ts` edit

## Test plan

- [ ] Add `customFields` to `~/.pncli/config.json` and verify `pncli jira fields` lists them
- [ ] Run `pncli jira search --jql '"Story Points" > 5'` — confirm JQL is translated before sending
- [ ] Run `pncli jira get-issue --key PROJ-123` — confirm `customfield_*` keys appear as friendly names
- [ ] Run `pncli jira create-issue --summary "Test" --field "Story Points=8"` — confirm field is set
- [ ] Run `pncli jira fields --discover --custom-only` — confirm live API fetch works
- [ ] Edit any `commands.ts` file — confirm `copilot-instructions.md` auto-updates via hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)