### PR TITLE
feat: SDElements integration — projects, tasks, threats, users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # pncli — The Paperwork Nightmare CLI
 
+[![npm](https://img.shields.io/npm/v/%40kolatts%2Fpncli?style=flat-square&color=cb3837&logo=npm)](https://www.npmjs.com/package/@kolatts/pncli)
+
 > One command does what three meetings couldn't.
 
-pncli gives AI coding agents (and humans) structured CLI access to Jira, Bitbucket, Confluence, and SonarQube. No MCP servers required. No meetings to schedule. No forms to fill out.
+pncli gives AI coding agents (and humans) structured CLI access to Jira, Bitbucket, Confluence, SonarQube, and SDElements. No MCP servers required. No meetings to schedule. No forms to fill out.
 
 ## Why?
 
@@ -47,6 +49,8 @@ pncli uses a three-layer config system (highest priority wins):
 | `PNCLI_BITBUCKET_PAT` | Bitbucket personal access token |
 | `PNCLI_SONAR_BASE_URL` | SonarQube Server base URL |
 | `PNCLI_SONAR_TOKEN` | SonarQube personal access token |
+| `PNCLI_SDE_BASE_URL` | SDElements base URL |
+| `PNCLI_SDE_TOKEN` | SDElements API token |
 | `PNCLI_CONFIG_PATH` | Override global config file path |
 
 ## For AI Agents
@@ -82,6 +86,7 @@ This project uses Conventional Commits for automatic versioning:
 | Bitbucket | ✅ Active | Server REST v1.0 |
 | Confluence | ✅ Active | Server REST v1 |
 | SonarQube | ✅ Active | Server Web API |
+| SDElements | ✅ Active | REST API v2 (cloud + on-prem) |
 | Artifactory | 🔜 Coming | The nightmare never ends |
 
 ## License

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 ## What is pncli?
 
-pncli is a CLI tool that provides structured JSON access to Jira, Bitbucket, Confluence, SonarQube, and local git state. Use it for all interactions with these services. It exists because MCP servers aren't available in this environment — pncli is your agent-friendly shim layer.
+pncli is a CLI tool that provides structured JSON access to Jira, Bitbucket, Confluence, SonarQube, SDElements, and local git state. Use it for all interactions with these services. It exists because MCP servers aren't available in this environment — pncli is your agent-friendly shim layer.
 
 ## Important
 
@@ -369,6 +369,11 @@ pncli sonar hotspots
 ```
 
 ### Sde
+
+Config keys: `sde.baseUrl`, `sde.token`. Env: `PNCLI_SDE_BASE_URL`, `PNCLI_SDE_TOKEN`.
+Cloud URL format: `https://your-org.sdelements.com` — on-prem: `https://sde.your-company.com`.
+Token: generate at **Settings → API Settings → APIv2 → Generate Token**. Shown once — store it immediately.
+Project IDs are numeric (e.g. `42`). Set `defaults.sde.project` in config or `.pncli.json` to avoid passing `--project` every time.
 
 ```
 pncli sde server-info

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -368,6 +368,84 @@ pncli sonar hotspots
   --all                Fetch all pages
 ```
 
+### Sde
+
+```
+pncli sde server-info
+
+pncli sde whoami
+
+pncli sde users
+  --email <email>      Filter by email address
+  --first-name <name>  Filter by first name
+  --last-name <name>   Filter by last name
+  --active <bool>      Filter by active status: true or false
+  --page <n>           Page number (1-based) (default: "1")
+  --page-size <n>      Results per page (default: "100")
+  --all                Fetch all pages
+
+pncli sde projects
+  --name <name>       Filter by project name
+  --search <text>     Text search on name and profile
+  --active <val>      Filter by active status: true, false, or all
+  --ordering <field>  Sort by: name, created, updated (prefix with - for
+  descending)
+  --expand <fields>   Expand nested fields (comma-separated):
+  application,business_unit,creator
+  --include <fields>  Include extra fields (comma-separated):
+  task_counts,permissions
+  --page <n>          Page number (1-based) (default: "1")
+  --page-size <n>     Results per page (default: "100")
+  --all               Fetch all pages
+
+pncli sde project
+  --id <id>           Project ID (or set defaults.sde.project in config)
+  --expand <fields>   Expand nested fields (comma-separated):
+  application,business_unit,creator
+  --include <fields>  Include extra fields (comma-separated):
+  task_counts,permissions
+
+pncli sde tasks
+  --project <id>         Project ID (or set defaults.sde.project in config)
+  --phase <slug>         Filter by phase slug (e.g. development,
+  architecture-design)
+  --priority <n>         Filter by priority (1-10)
+  --status <id>          Filter by status ID (e.g. TS1, TS2)
+  --assigned-to <email>  Filter by assignee email
+  --source <val>         Filter by source: default, custom, manual, project
+  --verification <val>   Filter by verification: pass, fail, partial, none
+  --tag <name>           Filter by tag name
+  --accepted <bool>      Filter by accepted status: true or false
+  --relevant <bool>      Filter by relevant status: true or false
+  --expand <fields>      Expand nested fields (comma-separated):
+  status,phase,problem,text
+  --include <fields>     Include extra fields (comma-separated):
+  how_tos,last_note,references,regulation_sections
+  --page <n>             Page number (1-based) (default: "1")
+  --page-size <n>        Results per page (default: "100")
+  --all                  Fetch all pages
+
+pncli sde task
+  --project <id>      Project ID (or set defaults.sde.project in config)
+  --task <id>         Task ID (e.g. T21)
+  --expand <fields>   Expand nested fields (comma-separated):
+  status,phase,problem,text
+  --include <fields>  Include extra fields (comma-separated):
+  how_tos,last_note,references
+
+pncli sde threats
+  --project <id>       Project ID (or set defaults.sde.project in config)
+  --severity <n>       Filter by severity (1-10)
+  --search <text>      Full-text search on title and threat ID
+  --ordering <field>   Sort by: threat__severity, threat_id, status (prefix -
+  for descending)
+  --capec-id <id>      Filter by CAPEC attack pattern ID
+  --component-id <id>  Filter by component ID
+  --page <n>           Page number (1-based) (default: "1")
+  --page-size <n>      Results per page (default: "100")
+  --all                Fetch all pages
+```
+
 ### Deps
 
 ```

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -370,11 +370,6 @@ pncli sonar hotspots
 
 ### Sde
 
-Config keys: `sde.baseUrl`, `sde.token`. Env: `PNCLI_SDE_BASE_URL`, `PNCLI_SDE_TOKEN`.
-Cloud URL format: `https://your-org.sdelements.com` — on-prem: `https://sde.your-company.com`.
-Token: generate at **Settings → API Settings → APIv2 → Generate Token**. Shown once — store it immediately.
-Project IDs are numeric (e.g. `42`). Set `defaults.sde.project` in config or `.pncli.json` to avoid passing `--project` every time.
-
 ```
 pncli sde server-info
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { registerJiraCommands } from './services/jira/commands.js';
 import { registerBitbucketCommands } from './services/bitbucket/commands.js';
 import { registerConfluenceCommands } from './services/confluence/commands.js';
 import { registerSonarCommands } from './services/sonar/commands.js';
+import { registerSdeCommands } from './services/sde/commands.js';
 import { registerDepsCommands } from './services/deps/commands.js';
 import { registerConfigCommands } from './services/config/commands.js';
 
@@ -55,6 +56,7 @@ registerJiraCommands(program);
 registerBitbucketCommands(program);
 registerConfluenceCommands(program);
 registerSonarCommands(program);
+registerSdeCommands(program);
 registerDepsCommands(program);
 registerConfigCommands(program);
 
@@ -66,6 +68,7 @@ Services:
   bitbucket    Bitbucket Server
   confluence   Confluence
   sonar        SonarQube Server (quality gates, issues, metrics, hotspots)
+  sde          SDElements (threat modeling, countermeasures, compliance)
   config       Manage pncli configuration
 `);
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, SonarDefaults } from '../types/config.js';
+import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, SonarDefaults, SdeDefaults } from '../types/config.js';
 import type { CustomFieldDefinition } from '../types/jira.js';
 
 const ENV_KEYS = {
@@ -21,6 +21,8 @@ const ENV_KEYS = {
   ARTIFACTORY_REPO_MAVEN: 'PNCLI_ARTIFACTORY_REPO_MAVEN',
   SONAR_BASE_URL: 'PNCLI_SONAR_BASE_URL',
   SONAR_TOKEN: 'PNCLI_SONAR_TOKEN',
+  SDE_BASE_URL: 'PNCLI_SDE_BASE_URL',
+  SDE_TOKEN: 'PNCLI_SDE_TOKEN',
   CONFIG_PATH: 'PNCLI_CONFIG_PATH'
 } as const;
 
@@ -61,11 +63,12 @@ function mergeCustomFields(
 function mergeDefaults(
   global: GlobalConfig['defaults'],
   repo: RepoConfig['defaults']
-): { jira: JiraDefaults; bitbucket: BitbucketDefaults; sonar: SonarDefaults } {
+): { jira: JiraDefaults; bitbucket: BitbucketDefaults; sonar: SonarDefaults; sde: SdeDefaults } {
   return {
     jira: { ...global?.jira, ...repo?.jira },
     bitbucket: { ...global?.bitbucket, ...repo?.bitbucket },
-    sonar: { ...global?.sonar, ...repo?.sonar }
+    sonar: { ...global?.sonar, ...repo?.sonar },
+    sde: { ...global?.sde, ...repo?.sde }
   };
 }
 
@@ -114,6 +117,10 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
     sonar: {
       baseUrl: process.env[ENV_KEYS.SONAR_BASE_URL] ?? globalConfig.sonar?.baseUrl,
       token: process.env[ENV_KEYS.SONAR_TOKEN] ?? globalConfig.sonar?.token
+    },
+    sde: {
+      baseUrl: process.env[ENV_KEYS.SDE_BASE_URL] ?? globalConfig.sde?.baseUrl,
+      token: process.env[ENV_KEYS.SDE_TOKEN] ?? globalConfig.sde?.token
     },
     defaults: mergedDefaults
   };
@@ -176,6 +183,10 @@ export function maskConfig(config: ResolvedConfig): unknown {
     sonar: {
       ...config.sonar,
       token: config.sonar.token ? '***' : undefined
+    },
+    sde: {
+      ...config.sde,
+      token: config.sde.token ? '***' : undefined
     }
   };
 }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -239,6 +239,61 @@ export class HttpClient {
     return request<T>(url, init, opts.timeoutMs ?? 30000);
   }
 
+  private sdeHeaders(): Record<string, string> {
+    const { token } = this.config.sde;
+    if (!token) throw new PncliError('SDElements credentials not configured. Run: pncli config init');
+    return {
+      'Authorization': `Token ${token}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'Connection': 'close'
+    };
+  }
+
+  async sde<T>(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<T> {
+    const baseUrl = this.config.sde.baseUrl;
+    if (!baseUrl) throw new PncliError('SDElements baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+    const headers = this.sdeHeaders();
+    const init: RequestInit = {
+      method: opts.method ?? 'GET',
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
+    };
+
+    if (this.dryRun) {
+      const safeHeaders = { ...headers, Authorization: '[REDACTED]' };
+      const msg = `DRY RUN: ${init.method} ${url}\nHeaders: ${JSON.stringify(safeHeaders, null, 2)}\n`
+        + (opts.body ? `Body: ${JSON.stringify(opts.body, null, 2)}\n` : '');
+      fs.writeSync(process.stderr.fd, msg);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    return request<T>(url, init, opts.timeoutMs ?? 30000);
+  }
+
+  async sdePaginate<T>(
+    fetchPage: (page: number, pageSize: number) => Promise<{ count: number; results: T[] }>
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+    const pageSize = 100;
+
+    while (true) {
+      const response = await fetchPage(page, pageSize);
+      results.push(...response.results);
+      if (results.length >= response.count || response.results.length === 0) break;
+      page++;
+    }
+
+    return results;
+  }
+
   private sonarHeaders(): Record<string, string> {
     const { token } = this.config.sonar;
     if (!token) throw new PncliError('SonarQube credentials not configured. Run: pncli config init');

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -125,6 +125,17 @@ export function registerConfigCommands(program: Command): void {
           results.sonar = { ok: null, message: 'not configured' };
         }
 
+        if (cfg.sde.baseUrl) {
+          try {
+            await http.sde<unknown>('/api/v2/users/me/');
+            results.sde = { ok: true, message: 'connected' };
+          } catch (err) {
+            results.sde = { ok: false, message: err instanceof Error ? err.message : String(err) };
+          }
+        } else {
+          results.sde = { ok: null, message: 'not configured' };
+        }
+
         success(results, 'config', 'test', start);
       } catch (err) {
         fail(err, 'config', 'test', start);
@@ -236,6 +247,26 @@ async function initGlobalConfig(start: number): Promise<void> {
     });
   }
 
+  process.stderr.write('\n── SDElements ────────────────────────────────────\n');
+  const useSde = await confirm({
+    message: 'Configure SDElements for threat modeling and countermeasure queries?',
+    default: false
+  });
+
+  let sdeBaseUrl = '';
+  let sdeToken = '';
+
+  if (useSde) {
+    sdeBaseUrl = await input({
+      message: 'SDElements base URL (e.g. https://your-org.sdelements.com or https://sde.your-company.com):',
+      default: ''
+    });
+
+    sdeToken = await password({
+      message: 'SDElements API token:'
+    });
+  }
+
   process.stderr.write('\n── Defaults ──────────────────────────────────────\n');
   const jiraProject = await input({
     message: 'Default Jira project key (optional):',
@@ -244,6 +275,11 @@ async function initGlobalConfig(start: number): Promise<void> {
 
   const sonarProject = useSonar ? await input({
     message: 'Default SonarQube project key (optional):',
+    default: ''
+  }) : '';
+
+  const sdeProject = useSde ? await input({
+    message: 'Default SDElements project ID (optional, numeric):',
     default: ''
   }) : '';
 
@@ -293,6 +329,12 @@ async function initGlobalConfig(start: number): Promise<void> {
         token: sonarToken || undefined
       }
     } : {}),
+    ...(useSde ? {
+      sde: {
+        baseUrl: sdeBaseUrl || undefined,
+        token: sdeToken || undefined
+      }
+    } : {}),
     defaults: {
       jira: {
         project: jiraProject || undefined
@@ -300,6 +342,11 @@ async function initGlobalConfig(start: number): Promise<void> {
       ...(useSonar && sonarProject ? {
         sonar: {
           project: sonarProject || undefined
+        }
+      } : {}),
+      ...(useSde && sdeProject ? {
+        sde: {
+          project: sdeProject || undefined
         }
       } : {})
     }

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -258,7 +258,7 @@ async function initGlobalConfig(start: number): Promise<void> {
 
   if (useSde) {
     sdeBaseUrl = await input({
-      message: 'SDElements base URL (e.g. https://your-org.sdelements.com or https://sde.your-company.com):',
+      message: 'SDElements base URL\n  Cloud-hosted: https://your-org.sdelements.com\n  On-premise:   https://sde.your-company.com\n  URL: ',
       default: ''
     });
 

--- a/src/services/sde/client.ts
+++ b/src/services/sde/client.ts
@@ -1,0 +1,228 @@
+import type { HttpClient } from '../../lib/http.js';
+import type {
+  SdeServerInfo,
+  SdeUser,
+  SdeProject,
+  SdeTask,
+  SdeThreat,
+  SdePaginatedResponse
+} from '../../types/sde.js';
+
+const API = '/api/v2';
+
+export interface ListProjectsOpts {
+  name?: string;
+  slug?: string;
+  search?: string;
+  active?: string;
+  ordering?: string;
+  expand?: string;
+  include?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ListTasksOpts {
+  projectId: number;
+  phase?: string;
+  priority?: string;
+  status?: string;
+  assignedTo?: string;
+  source?: string;
+  verification?: string;
+  tag?: string;
+  accepted?: string;
+  relevant?: string;
+  expand?: string;
+  include?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ListThreatsOpts {
+  projectId: number;
+  severity?: string;
+  title?: string;
+  threatId?: string;
+  capecId?: string;
+  componentId?: string;
+  search?: string;
+  ordering?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ListUsersOpts {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  isActive?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export class SdeClient {
+  constructor(private http: HttpClient) {}
+
+  async getServerInfo(): Promise<SdeServerInfo> {
+    return this.http.sde<SdeServerInfo>(`${API}/server-info/`);
+  }
+
+  async getMe(): Promise<SdeUser> {
+    return this.http.sde<SdeUser>(`${API}/users/me/`);
+  }
+
+  async getProject(projectId: number, expand?: string, include?: string): Promise<SdeProject> {
+    return this.http.sde<SdeProject>(`${API}/projects/${projectId}/`, {
+      params: { expand, include }
+    });
+  }
+
+  async getTask(projectId: number, taskId: string, expand?: string, include?: string): Promise<SdeTask> {
+    return this.http.sde<SdeTask>(`${API}/projects/${projectId}/tasks/${taskId}/`, {
+      params: { expand, include }
+    });
+  }
+
+  async listProjects(opts: ListProjectsOpts = {}): Promise<SdePaginatedResponse<SdeProject>> {
+    return this.http.sde<SdePaginatedResponse<SdeProject>>(`${API}/projects/`, {
+      params: {
+        name: opts.name,
+        slug: opts.slug,
+        search: opts.search,
+        active: opts.active,
+        ordering: opts.ordering,
+        expand: opts.expand,
+        include: opts.include,
+        page: opts.page ?? 1,
+        page_size: opts.pageSize ?? 100
+      }
+    });
+  }
+
+  async listAllProjects(opts: Omit<ListProjectsOpts, 'page' | 'pageSize'> = {}): Promise<SdeProject[]> {
+    return this.http.sdePaginate<SdeProject>(async (page, pageSize) => {
+      const resp = await this.http.sde<SdePaginatedResponse<SdeProject>>(`${API}/projects/`, {
+        params: {
+          name: opts.name,
+          slug: opts.slug,
+          search: opts.search,
+          active: opts.active,
+          ordering: opts.ordering,
+          expand: opts.expand,
+          include: opts.include,
+          page,
+          page_size: pageSize
+        }
+      });
+      return { count: resp.count, results: resp.results };
+    });
+  }
+
+  async listTasks(opts: ListTasksOpts): Promise<SdePaginatedResponse<SdeTask>> {
+    return this.http.sde<SdePaginatedResponse<SdeTask>>(`${API}/projects/${opts.projectId}/tasks/`, {
+      params: {
+        phase: opts.phase,
+        priority: opts.priority,
+        status: opts.status,
+        assigned_to: opts.assignedTo,
+        source: opts.source,
+        verification: opts.verification,
+        tag: opts.tag,
+        accepted: opts.accepted,
+        relevant: opts.relevant,
+        expand: opts.expand,
+        include: opts.include,
+        page: opts.page ?? 1,
+        page_size: opts.pageSize ?? 100
+      }
+    });
+  }
+
+  async listAllTasks(opts: Omit<ListTasksOpts, 'page' | 'pageSize'>): Promise<SdeTask[]> {
+    return this.http.sdePaginate<SdeTask>(async (page, pageSize) => {
+      const resp = await this.http.sde<SdePaginatedResponse<SdeTask>>(`${API}/projects/${opts.projectId}/tasks/`, {
+        params: {
+          phase: opts.phase,
+          priority: opts.priority,
+          status: opts.status,
+          assigned_to: opts.assignedTo,
+          source: opts.source,
+          verification: opts.verification,
+          tag: opts.tag,
+          accepted: opts.accepted,
+          relevant: opts.relevant,
+          expand: opts.expand,
+          include: opts.include,
+          page,
+          page_size: pageSize
+        }
+      });
+      return { count: resp.count, results: resp.results };
+    });
+  }
+
+  async listThreats(opts: ListThreatsOpts): Promise<SdePaginatedResponse<SdeThreat>> {
+    return this.http.sde<SdePaginatedResponse<SdeThreat>>(`${API}/projects/${opts.projectId}/threats/`, {
+      params: {
+        severity: opts.severity,
+        title: opts.title,
+        threat_id: opts.threatId,
+        capec_id: opts.capecId,
+        component_id: opts.componentId,
+        search: opts.search,
+        ordering: opts.ordering,
+        page: opts.page ?? 1,
+        page_size: opts.pageSize ?? 100
+      }
+    });
+  }
+
+  async listAllThreats(opts: Omit<ListThreatsOpts, 'page' | 'pageSize'>): Promise<SdeThreat[]> {
+    return this.http.sdePaginate<SdeThreat>(async (page, pageSize) => {
+      const resp = await this.http.sde<SdePaginatedResponse<SdeThreat>>(`${API}/projects/${opts.projectId}/threats/`, {
+        params: {
+          severity: opts.severity,
+          title: opts.title,
+          threat_id: opts.threatId,
+          capec_id: opts.capecId,
+          component_id: opts.componentId,
+          search: opts.search,
+          ordering: opts.ordering,
+          page,
+          page_size: pageSize
+        }
+      });
+      return { count: resp.count, results: resp.results };
+    });
+  }
+
+  async listUsers(opts: ListUsersOpts = {}): Promise<SdePaginatedResponse<SdeUser>> {
+    return this.http.sde<SdePaginatedResponse<SdeUser>>(`${API}/users/`, {
+      params: {
+        email: opts.email,
+        first_name: opts.firstName,
+        last_name: opts.lastName,
+        is_active: opts.isActive,
+        page: opts.page ?? 1,
+        page_size: opts.pageSize ?? 100
+      }
+    });
+  }
+
+  async listAllUsers(opts: Omit<ListUsersOpts, 'page' | 'pageSize'> = {}): Promise<SdeUser[]> {
+    return this.http.sdePaginate<SdeUser>(async (page, pageSize) => {
+      const resp = await this.http.sde<SdePaginatedResponse<SdeUser>>(`${API}/users/`, {
+        params: {
+          email: opts.email,
+          first_name: opts.firstName,
+          last_name: opts.lastName,
+          is_active: opts.isActive,
+          page,
+          page_size: pageSize
+        }
+      });
+      return { count: resp.count, results: resp.results };
+    });
+  }
+}

--- a/src/services/sde/client.ts
+++ b/src/services/sde/client.ts
@@ -61,6 +61,63 @@ export interface ListUsersOpts {
   pageSize?: number;
 }
 
+function projectParams(opts: Omit<ListProjectsOpts, 'page' | 'pageSize'>, page: number, pageSize: number) {
+  return {
+    name: opts.name,
+    slug: opts.slug,
+    search: opts.search,
+    active: opts.active,
+    ordering: opts.ordering,
+    expand: opts.expand,
+    include: opts.include,
+    page,
+    page_size: pageSize
+  };
+}
+
+function taskParams(opts: Omit<ListTasksOpts, 'page' | 'pageSize'>, page: number, pageSize: number) {
+  return {
+    phase: opts.phase,
+    priority: opts.priority,
+    status: opts.status,
+    assigned_to: opts.assignedTo,
+    source: opts.source,
+    verification: opts.verification,
+    tag: opts.tag,
+    accepted: opts.accepted,
+    relevant: opts.relevant,
+    expand: opts.expand,
+    include: opts.include,
+    page,
+    page_size: pageSize
+  };
+}
+
+function threatParams(opts: Omit<ListThreatsOpts, 'page' | 'pageSize'>, page: number, pageSize: number) {
+  return {
+    severity: opts.severity,
+    title: opts.title,
+    threat_id: opts.threatId,
+    capec_id: opts.capecId,
+    component_id: opts.componentId,
+    search: opts.search,
+    ordering: opts.ordering,
+    page,
+    page_size: pageSize
+  };
+}
+
+function userParams(opts: Omit<ListUsersOpts, 'page' | 'pageSize'>, page: number, pageSize: number) {
+  return {
+    email: opts.email,
+    first_name: opts.firstName,
+    last_name: opts.lastName,
+    is_active: opts.isActive,
+    page,
+    page_size: pageSize
+  };
+}
+
 export class SdeClient {
   constructor(private http: HttpClient) {}
 
@@ -86,34 +143,14 @@ export class SdeClient {
 
   async listProjects(opts: ListProjectsOpts = {}): Promise<SdePaginatedResponse<SdeProject>> {
     return this.http.sde<SdePaginatedResponse<SdeProject>>(`${API}/projects/`, {
-      params: {
-        name: opts.name,
-        slug: opts.slug,
-        search: opts.search,
-        active: opts.active,
-        ordering: opts.ordering,
-        expand: opts.expand,
-        include: opts.include,
-        page: opts.page ?? 1,
-        page_size: opts.pageSize ?? 100
-      }
+      params: projectParams(opts, opts.page ?? 1, opts.pageSize ?? 100)
     });
   }
 
   async listAllProjects(opts: Omit<ListProjectsOpts, 'page' | 'pageSize'> = {}): Promise<SdeProject[]> {
     return this.http.sdePaginate<SdeProject>(async (page, pageSize) => {
       const resp = await this.http.sde<SdePaginatedResponse<SdeProject>>(`${API}/projects/`, {
-        params: {
-          name: opts.name,
-          slug: opts.slug,
-          search: opts.search,
-          active: opts.active,
-          ordering: opts.ordering,
-          expand: opts.expand,
-          include: opts.include,
-          page,
-          page_size: pageSize
-        }
+        params: projectParams(opts, page, pageSize)
       });
       return { count: resp.count, results: resp.results };
     });
@@ -121,42 +158,14 @@ export class SdeClient {
 
   async listTasks(opts: ListTasksOpts): Promise<SdePaginatedResponse<SdeTask>> {
     return this.http.sde<SdePaginatedResponse<SdeTask>>(`${API}/projects/${opts.projectId}/tasks/`, {
-      params: {
-        phase: opts.phase,
-        priority: opts.priority,
-        status: opts.status,
-        assigned_to: opts.assignedTo,
-        source: opts.source,
-        verification: opts.verification,
-        tag: opts.tag,
-        accepted: opts.accepted,
-        relevant: opts.relevant,
-        expand: opts.expand,
-        include: opts.include,
-        page: opts.page ?? 1,
-        page_size: opts.pageSize ?? 100
-      }
+      params: taskParams(opts, opts.page ?? 1, opts.pageSize ?? 100)
     });
   }
 
   async listAllTasks(opts: Omit<ListTasksOpts, 'page' | 'pageSize'>): Promise<SdeTask[]> {
     return this.http.sdePaginate<SdeTask>(async (page, pageSize) => {
       const resp = await this.http.sde<SdePaginatedResponse<SdeTask>>(`${API}/projects/${opts.projectId}/tasks/`, {
-        params: {
-          phase: opts.phase,
-          priority: opts.priority,
-          status: opts.status,
-          assigned_to: opts.assignedTo,
-          source: opts.source,
-          verification: opts.verification,
-          tag: opts.tag,
-          accepted: opts.accepted,
-          relevant: opts.relevant,
-          expand: opts.expand,
-          include: opts.include,
-          page,
-          page_size: pageSize
-        }
+        params: taskParams(opts, page, pageSize)
       });
       return { count: resp.count, results: resp.results };
     });
@@ -164,34 +173,14 @@ export class SdeClient {
 
   async listThreats(opts: ListThreatsOpts): Promise<SdePaginatedResponse<SdeThreat>> {
     return this.http.sde<SdePaginatedResponse<SdeThreat>>(`${API}/projects/${opts.projectId}/threats/`, {
-      params: {
-        severity: opts.severity,
-        title: opts.title,
-        threat_id: opts.threatId,
-        capec_id: opts.capecId,
-        component_id: opts.componentId,
-        search: opts.search,
-        ordering: opts.ordering,
-        page: opts.page ?? 1,
-        page_size: opts.pageSize ?? 100
-      }
+      params: threatParams(opts, opts.page ?? 1, opts.pageSize ?? 100)
     });
   }
 
   async listAllThreats(opts: Omit<ListThreatsOpts, 'page' | 'pageSize'>): Promise<SdeThreat[]> {
     return this.http.sdePaginate<SdeThreat>(async (page, pageSize) => {
       const resp = await this.http.sde<SdePaginatedResponse<SdeThreat>>(`${API}/projects/${opts.projectId}/threats/`, {
-        params: {
-          severity: opts.severity,
-          title: opts.title,
-          threat_id: opts.threatId,
-          capec_id: opts.capecId,
-          component_id: opts.componentId,
-          search: opts.search,
-          ordering: opts.ordering,
-          page,
-          page_size: pageSize
-        }
+        params: threatParams(opts, page, pageSize)
       });
       return { count: resp.count, results: resp.results };
     });
@@ -199,28 +188,14 @@ export class SdeClient {
 
   async listUsers(opts: ListUsersOpts = {}): Promise<SdePaginatedResponse<SdeUser>> {
     return this.http.sde<SdePaginatedResponse<SdeUser>>(`${API}/users/`, {
-      params: {
-        email: opts.email,
-        first_name: opts.firstName,
-        last_name: opts.lastName,
-        is_active: opts.isActive,
-        page: opts.page ?? 1,
-        page_size: opts.pageSize ?? 100
-      }
+      params: userParams(opts, opts.page ?? 1, opts.pageSize ?? 100)
     });
   }
 
   async listAllUsers(opts: Omit<ListUsersOpts, 'page' | 'pageSize'> = {}): Promise<SdeUser[]> {
     return this.http.sdePaginate<SdeUser>(async (page, pageSize) => {
       const resp = await this.http.sde<SdePaginatedResponse<SdeUser>>(`${API}/users/`, {
-        params: {
-          email: opts.email,
-          first_name: opts.firstName,
-          last_name: opts.lastName,
-          is_active: opts.isActive,
-          page,
-          page_size: pageSize
-        }
+        params: userParams(opts, page, pageSize)
       });
       return { count: resp.count, results: resp.results };
     });

--- a/src/services/sde/commands.ts
+++ b/src/services/sde/commands.ts
@@ -16,8 +16,9 @@ function getClient(program: Command): { client: SdeClient; config: ReturnType<ty
 function resolveProject(config: ReturnType<typeof loadConfig>, cliProject?: string): number {
   const project = cliProject ?? config.defaults.sde.project;
   if (!project) throw new PncliError('No project specified. Use --project or set defaults.sde.project in config.');
+  if (!/^\d+$/.test(project)) throw new PncliError(`Invalid project ID: "${project}". SDElements project IDs must be positive integers.`);
   const id = parseInt(project, 10);
-  if (isNaN(id)) throw new PncliError(`Invalid project ID: ${project}. SDElements project IDs are numeric.`);
+  if (id <= 0) throw new PncliError(`Invalid project ID: "${project}". SDElements project IDs must be positive integers.`);
   return id;
 }
 

--- a/src/services/sde/commands.ts
+++ b/src/services/sde/commands.ts
@@ -1,0 +1,253 @@
+import { Command } from 'commander';
+import { SdeClient } from './client.js';
+import { createHttpClient } from '../../lib/http.js';
+import { loadConfig } from '../../lib/config.js';
+import { success, fail } from '../../lib/output.js';
+import { PncliError } from '../../lib/errors.js';
+
+function getClient(program: Command): { client: SdeClient; config: ReturnType<typeof loadConfig> } {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config });
+  if (!config.sde.baseUrl) throw new PncliError('SDElements not configured. Run: pncli config init');
+  const http = createHttpClient(config, Boolean(opts.dryRun));
+  return { client: new SdeClient(http), config };
+}
+
+function resolveProject(config: ReturnType<typeof loadConfig>, cliProject?: string): number {
+  const project = cliProject ?? config.defaults.sde.project;
+  if (!project) throw new PncliError('No project specified. Use --project or set defaults.sde.project in config.');
+  const id = parseInt(project, 10);
+  if (isNaN(id)) throw new PncliError(`Invalid project ID: ${project}. SDElements project IDs are numeric.`);
+  return id;
+}
+
+export function registerSdeCommands(program: Command): void {
+  const sde = program.command('sde').description('SDElements operations (threat modeling, countermeasures, compliance)');
+
+  // ── Server Info ───────────────────────────────────────────────────────────
+
+  sde.command('server-info')
+    .description('Get server version and platform info (requires super-user)')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const data = await client.getServerInfo();
+        success(data, 'sde', 'server-info', start);
+      } catch (err) { fail(err, 'sde', 'server-info', start); }
+    });
+
+  // ── Whoami ────────────────────────────────────────────────────────────────
+
+  sde.command('whoami')
+    .description('Get current authenticated user')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const data = await client.getMe();
+        success(data, 'sde', 'whoami', start);
+      } catch (err) { fail(err, 'sde', 'whoami', start); }
+    });
+
+  // ── Users ─────────────────────────────────────────────────────────────────
+
+  sde.command('users')
+    .description('List users')
+    .option('--email <email>', 'Filter by email address')
+    .option('--first-name <name>', 'Filter by first name')
+    .option('--last-name <name>', 'Filter by last name')
+    .option('--active <bool>', 'Filter by active status: true or false')
+    .option('--page <n>', 'Page number (1-based)', '1')
+    .option('--page-size <n>', 'Results per page', '100')
+    .option('--all', 'Fetch all pages')
+    .action(async (opts: { email?: string; firstName?: string; lastName?: string; active?: string; page: string; pageSize: string; all?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const baseOpts = {
+          email: opts.email,
+          firstName: opts.firstName,
+          lastName: opts.lastName,
+          isActive: opts.active
+        };
+        if (opts.all) {
+          const data = await client.listAllUsers(baseOpts);
+          success(data, 'sde', 'users', start);
+        } else {
+          const data = await client.listUsers({
+            ...baseOpts,
+            page: parseInt(opts.page, 10),
+            pageSize: parseInt(opts.pageSize, 10)
+          });
+          success(data, 'sde', 'users', start);
+        }
+      } catch (err) { fail(err, 'sde', 'users', start); }
+    });
+
+  // ── Projects ──────────────────────────────────────────────────────────────
+
+  sde.command('projects')
+    .description('List projects')
+    .option('--name <name>', 'Filter by project name')
+    .option('--search <text>', 'Text search on name and profile')
+    .option('--active <val>', 'Filter by active status: true, false, or all')
+    .option('--ordering <field>', 'Sort by: name, created, updated (prefix with - for descending)')
+    .option('--expand <fields>', 'Expand nested fields (comma-separated): application,business_unit,creator')
+    .option('--include <fields>', 'Include extra fields (comma-separated): task_counts,permissions')
+    .option('--page <n>', 'Page number (1-based)', '1')
+    .option('--page-size <n>', 'Results per page', '100')
+    .option('--all', 'Fetch all pages')
+    .action(async (opts: { name?: string; search?: string; active?: string; ordering?: string; expand?: string; include?: string; page: string; pageSize: string; all?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const baseOpts = {
+          name: opts.name,
+          search: opts.search,
+          active: opts.active,
+          ordering: opts.ordering,
+          expand: opts.expand,
+          include: opts.include
+        };
+        if (opts.all) {
+          const data = await client.listAllProjects(baseOpts);
+          success(data, 'sde', 'projects', start);
+        } else {
+          const data = await client.listProjects({
+            ...baseOpts,
+            page: parseInt(opts.page, 10),
+            pageSize: parseInt(opts.pageSize, 10)
+          });
+          success(data, 'sde', 'projects', start);
+        }
+      } catch (err) { fail(err, 'sde', 'projects', start); }
+    });
+
+  // ── Project ───────────────────────────────────────────────────────────────
+
+  sde.command('project')
+    .description('Get a single project by ID')
+    .option('--id <id>', 'Project ID (or set defaults.sde.project in config)')
+    .option('--expand <fields>', 'Expand nested fields (comma-separated): application,business_unit,creator')
+    .option('--include <fields>', 'Include extra fields (comma-separated): task_counts,permissions')
+    .action(async (opts: { id?: string; expand?: string; include?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, config } = getClient(program);
+        const projectId = resolveProject(config, opts.id);
+        const data = await client.getProject(projectId, opts.expand, opts.include);
+        success(data, 'sde', 'project', start);
+      } catch (err) { fail(err, 'sde', 'project', start); }
+    });
+
+  // ── Tasks ─────────────────────────────────────────────────────────────────
+
+  sde.command('tasks')
+    .description('List countermeasures for a project')
+    .option('--project <id>', 'Project ID (or set defaults.sde.project in config)')
+    .option('--phase <slug>', 'Filter by phase slug (e.g. development, architecture-design)')
+    .option('--priority <n>', 'Filter by priority (1-10)')
+    .option('--status <id>', 'Filter by status ID (e.g. TS1, TS2)')
+    .option('--assigned-to <email>', 'Filter by assignee email')
+    .option('--source <val>', 'Filter by source: default, custom, manual, project')
+    .option('--verification <val>', 'Filter by verification: pass, fail, partial, none')
+    .option('--tag <name>', 'Filter by tag name')
+    .option('--accepted <bool>', 'Filter by accepted status: true or false')
+    .option('--relevant <bool>', 'Filter by relevant status: true or false')
+    .option('--expand <fields>', 'Expand nested fields (comma-separated): status,phase,problem,text')
+    .option('--include <fields>', 'Include extra fields (comma-separated): how_tos,last_note,references,regulation_sections')
+    .option('--page <n>', 'Page number (1-based)', '1')
+    .option('--page-size <n>', 'Results per page', '100')
+    .option('--all', 'Fetch all pages')
+    .action(async (opts: { project?: string; phase?: string; priority?: string; status?: string; assignedTo?: string; source?: string; verification?: string; tag?: string; accepted?: string; relevant?: string; expand?: string; include?: string; page: string; pageSize: string; all?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { client, config } = getClient(program);
+        const projectId = resolveProject(config, opts.project);
+        const baseOpts = {
+          projectId,
+          phase: opts.phase,
+          priority: opts.priority,
+          status: opts.status,
+          assignedTo: opts.assignedTo,
+          source: opts.source,
+          verification: opts.verification,
+          tag: opts.tag,
+          accepted: opts.accepted,
+          relevant: opts.relevant,
+          expand: opts.expand,
+          include: opts.include
+        };
+        if (opts.all) {
+          const data = await client.listAllTasks(baseOpts);
+          success(data, 'sde', 'tasks', start);
+        } else {
+          const data = await client.listTasks({
+            ...baseOpts,
+            page: parseInt(opts.page, 10),
+            pageSize: parseInt(opts.pageSize, 10)
+          });
+          success(data, 'sde', 'tasks', start);
+        }
+      } catch (err) { fail(err, 'sde', 'tasks', start); }
+    });
+
+  // ── Task ──────────────────────────────────────────────────────────────────
+
+  sde.command('task')
+    .description('Get a single countermeasure')
+    .option('--project <id>', 'Project ID (or set defaults.sde.project in config)')
+    .requiredOption('--task <id>', 'Task ID (e.g. T21)')
+    .option('--expand <fields>', 'Expand nested fields (comma-separated): status,phase,problem,text')
+    .option('--include <fields>', 'Include extra fields (comma-separated): how_tos,last_note,references')
+    .action(async (opts: { project?: string; task: string; expand?: string; include?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, config } = getClient(program);
+        const projectId = resolveProject(config, opts.project);
+        const data = await client.getTask(projectId, opts.task, opts.expand, opts.include);
+        success(data, 'sde', 'task', start);
+      } catch (err) { fail(err, 'sde', 'task', start); }
+    });
+
+  // ── Threats ───────────────────────────────────────────────────────────────
+
+  sde.command('threats')
+    .description('List threats for a project')
+    .option('--project <id>', 'Project ID (or set defaults.sde.project in config)')
+    .option('--severity <n>', 'Filter by severity (1-10)')
+    .option('--search <text>', 'Full-text search on title and threat ID')
+    .option('--ordering <field>', 'Sort by: threat__severity, threat_id, status (prefix - for descending)')
+    .option('--capec-id <id>', 'Filter by CAPEC attack pattern ID')
+    .option('--component-id <id>', 'Filter by component ID')
+    .option('--page <n>', 'Page number (1-based)', '1')
+    .option('--page-size <n>', 'Results per page', '100')
+    .option('--all', 'Fetch all pages')
+    .action(async (opts: { project?: string; severity?: string; search?: string; ordering?: string; capecId?: string; componentId?: string; page: string; pageSize: string; all?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { client, config } = getClient(program);
+        const projectId = resolveProject(config, opts.project);
+        const baseOpts = {
+          projectId,
+          severity: opts.severity,
+          search: opts.search,
+          ordering: opts.ordering,
+          capecId: opts.capecId,
+          componentId: opts.componentId
+        };
+        if (opts.all) {
+          const data = await client.listAllThreats(baseOpts);
+          success(data, 'sde', 'threats', start);
+        } else {
+          const data = await client.listThreats({
+            ...baseOpts,
+            page: parseInt(opts.page, 10),
+            pageSize: parseInt(opts.pageSize, 10)
+          });
+          success(data, 'sde', 'threats', start);
+        }
+      } catch (err) { fail(err, 'sde', 'threats', start); }
+    });
+}

--- a/src/services/sde/commands.ts
+++ b/src/services/sde/commands.ts
@@ -21,6 +21,20 @@ function resolveProject(config: ReturnType<typeof loadConfig>, cliProject?: stri
   return id;
 }
 
+function parsePage(val: string, flag: string): number {
+  const n = parseInt(val, 10);
+  if (isNaN(n) || n < 1) throw new PncliError(`Invalid ${flag}: "${val}". Must be a positive integer.`);
+  return n;
+}
+
+function validateActive(val: string | undefined, allowed: string[]): string | undefined {
+  if (val === undefined) return undefined;
+  if (!allowed.includes(val)) {
+    throw new PncliError(`Invalid --active value: "${val}". Allowed: ${allowed.join(', ')}.`);
+  }
+  return val;
+}
+
 export function registerSdeCommands(program: Command): void {
   const sde = program.command('sde').description('SDElements operations (threat modeling, countermeasures, compliance)');
 
@@ -69,7 +83,7 @@ export function registerSdeCommands(program: Command): void {
           email: opts.email,
           firstName: opts.firstName,
           lastName: opts.lastName,
-          isActive: opts.active
+          isActive: validateActive(opts.active, ['true', 'false'])
         };
         if (opts.all) {
           const data = await client.listAllUsers(baseOpts);
@@ -77,8 +91,8 @@ export function registerSdeCommands(program: Command): void {
         } else {
           const data = await client.listUsers({
             ...baseOpts,
-            page: parseInt(opts.page, 10),
-            pageSize: parseInt(opts.pageSize, 10)
+            page: parsePage(opts.page, '--page'),
+            pageSize: parsePage(opts.pageSize, '--page-size')
           });
           success(data, 'sde', 'users', start);
         }
@@ -105,7 +119,7 @@ export function registerSdeCommands(program: Command): void {
         const baseOpts = {
           name: opts.name,
           search: opts.search,
-          active: opts.active,
+          active: validateActive(opts.active, ['true', 'false', 'all']),
           ordering: opts.ordering,
           expand: opts.expand,
           include: opts.include
@@ -116,8 +130,8 @@ export function registerSdeCommands(program: Command): void {
         } else {
           const data = await client.listProjects({
             ...baseOpts,
-            page: parseInt(opts.page, 10),
-            pageSize: parseInt(opts.pageSize, 10)
+            page: parsePage(opts.page, '--page'),
+            pageSize: parsePage(opts.pageSize, '--page-size')
           });
           success(data, 'sde', 'projects', start);
         }
@@ -185,8 +199,8 @@ export function registerSdeCommands(program: Command): void {
         } else {
           const data = await client.listTasks({
             ...baseOpts,
-            page: parseInt(opts.page, 10),
-            pageSize: parseInt(opts.pageSize, 10)
+            page: parsePage(opts.page, '--page'),
+            pageSize: parsePage(opts.pageSize, '--page-size')
           });
           success(data, 'sde', 'tasks', start);
         }
@@ -243,8 +257,8 @@ export function registerSdeCommands(program: Command): void {
         } else {
           const data = await client.listThreats({
             ...baseOpts,
-            page: parseInt(opts.page, 10),
-            pageSize: parseInt(opts.pageSize, 10)
+            page: parsePage(opts.page, '--page'),
+            pageSize: parsePage(opts.pageSize, '--page-size')
           });
           success(data, 'sde', 'threats', start);
         }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -15,6 +15,15 @@ export interface SonarDefaults {
   project?: string;
 }
 
+export interface SdeConfig {
+  baseUrl?: string;
+  token?: string;
+}
+
+export interface SdeDefaults {
+  project?: string;
+}
+
 export interface JiraConfig {
   baseUrl?: string;
   apiToken?: string;
@@ -47,6 +56,7 @@ export interface Defaults {
   jira?: JiraDefaults;
   bitbucket?: BitbucketDefaults;
   sonar?: SonarDefaults;
+  sde?: SdeDefaults;
 }
 
 export interface UserConfig {
@@ -61,6 +71,7 @@ export interface GlobalConfig {
   confluence?: ConfluenceConfig;
   artifactory?: ArtifactoryConfig;
   sonar?: SonarConfig;
+  sde?: SdeConfig;
   defaults?: Defaults;
 }
 
@@ -92,9 +103,14 @@ export interface ResolvedConfig {
     baseUrl: string | undefined;
     token: string | undefined;
   };
+  sde: {
+    baseUrl: string | undefined;
+    token: string | undefined;
+  };
   defaults: {
     jira: JiraDefaults;
     bitbucket: BitbucketDefaults;
     sonar: SonarDefaults;
+    sde: SdeDefaults;
   };
 }

--- a/src/types/sde.ts
+++ b/src/types/sde.ts
@@ -1,0 +1,119 @@
+export interface SdeRelease {
+  name: string;
+  date: string;
+}
+
+export interface SdePlatform {
+  python_implementation: string;
+  python_version: string;
+  os: string;
+  pip_packages: Record<string, string>;
+}
+
+export interface SdeServerInfo {
+  domain: string;
+  release: SdeRelease;
+  platform: SdePlatform;
+  plugins: Record<string, unknown>;
+  jobs_queue_length: number;
+  sso_settings: unknown;
+}
+
+export interface SdeUserGroup {
+  id: number;
+  name: string;
+  role: string;
+}
+
+export interface SdeUser {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: string;
+  groups: SdeUserGroup[];
+  last_login: string | null;
+  date_joined: string;
+  is_active: boolean;
+  is_superuser: boolean;
+  external_id: string | null;
+}
+
+export interface SdeApplication {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+export interface SdeProject {
+  id: number;
+  slug: string;
+  name: string;
+  url: string;
+  application: number | SdeApplication;
+  archived: boolean;
+  description: string;
+  created: string;
+  updated: string;
+  survey_complete: boolean;
+  survey_dirty: boolean;
+  locked: boolean;
+  risk_policy_compliant: boolean;
+  tags: string[];
+  users: unknown[];
+  groups: unknown[];
+}
+
+export interface SdeAssignedUser {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: string;
+}
+
+export interface SdeTask {
+  id: string;
+  task_id: string;
+  title: string;
+  text: string;
+  url: string;
+  phase: string | { id: number; name: string; slug: string };
+  priority: number;
+  status: string | { id: string; name: string; slug: string; meaning: string };
+  assigned_to: SdeAssignedUser[];
+  accepted: boolean;
+  relevant: boolean;
+  relevant_via_survey: boolean;
+  project_specific: boolean;
+  manually_added_from_library: boolean;
+  verification_status: string;
+  note_count: number;
+  became_relevant: string | null;
+  updated: string;
+  status_updated: string;
+  tags: string[];
+  problem: string | null;
+}
+
+export interface SdeThreat {
+  id: string;
+  threat_id: string;
+  title: string;
+  severity: number;
+  description: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  became_relevant: string | null;
+  problems: unknown[];
+  capecs: unknown[];
+  related_components: unknown[];
+}
+
+export interface SdePaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}


### PR DESCRIPTION
## Summary

- Adds `pncli sde` command group with 8 read-only subcommands against the SDElements REST API v2
- Supports both cloud (`*.sdelements.com`) and on-premise deployments via configurable `baseUrl`
- Follows the same integration pattern as Jira, SonarQube, Confluence, and Bitbucket

## Commands

| Command | Description |
|---------|-------------|
| `sde server-info` | Server version/release info (super-user only) |
| `sde whoami` | Current authenticated user |
| `sde users` | List users with filtering |
| `sde projects` | List projects with filtering and pagination |
| `sde project` | Get single project by ID |
| `sde tasks` | List countermeasures for a project |
| `sde task` | Get single countermeasure |
| `sde threats` | List threats for a project |

All list commands support `--all` for full pagination, or `--page`/`--page-size` for manual control.

## Configuration

```json
{
  "sde": {
    "baseUrl": "https://your-org.sdelements.com",
    "token": "<api-token>"
  },
  "defaults": {
    "sde": { "project": "42" }
  }
}
```

Env vars: `PNCLI_SDE_BASE_URL`, `PNCLI_SDE_TOKEN`. Default project also settable per-repo via `.pncli.json`.

## Notes

- Auth uses `Authorization: Token <token>` (SDElements format) rather than `Bearer`
- Connectivity test in `pncli config test` uses `GET /api/v2/users/me/` (avoids super-user requirement of `/server-info/`)
- SDElements project IDs are numeric; `resolveProject()` parses and validates them

## Test plan

- [ ] `npm run build` — clean TypeScript compilation
- [ ] `pncli sde --help` — all 8 subcommands listed
- [ ] `pncli config init` — SDElements prompts appear
- [ ] `pncli sde whoami --dry-run` — request uses `Token` auth header, correct URL
- [ ] `pncli config test` — SDE connectivity result appears
- [ ] Against a live SDElements instance: `pncli sde whoami`, `pncli sde projects --all`, `pncli sde tasks --project <id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)