### PR TITLE
refactor: replace SSPI auth with PAT-only for Azure DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This project uses Conventional Commits for automatic versioning:
 | SDElements | ✅ Active | REST API v2 (cloud + on-prem) |
 | Artifactory | 🔜 Coming | The nightmare never ends |
 | Jenkins | 🔜 Coming | REST API |
-| Azure DevOps | 🔜 Coming | REST API v7 |
+| Azure DevOps Server | ✅ Active | REST API v7.1 (on-prem, Windows auth + PAT) |
 
 ## License
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -189,7 +189,10 @@ pncli bitbucket decline-pr
   --id <pr-id>  Pull request ID
 
 pncli bitbucket list-comments
-  --pr <pr-id>  Pull request ID
+  --pr <pr-id>       Pull request ID
+  --no-with-replies  Exclude replies; return top-level comments only
+  --inline-only      Return only inline file comments
+  --general-only     Return only general (non-inline) PR comments
 
 pncli bitbucket add-comment
   --pr <pr-id>   Pull request ID
@@ -370,12 +373,6 @@ pncli sonar hotspots
 
 ### Sde
 
-Config key: `sde.connection` (format: `api-token@hostname`). Env: `PNCLI_SDE_CONNECTION`.
-`https://` is added automatically — just use the hostname. Cloud: `your-org.sdelements.com`. On-prem: `sde.your-company.com`.
-Token: generate at **Settings → API Settings → APIv2 → Generate Token**. Shown once — store immediately.
-Example: `abc123token@your-org.sdelements.com`
-Project IDs are numeric. Set `defaults.sde.project` in config or `.pncli.json` to skip `--project` each time.
-
 ```
 pncli sde server-info
 
@@ -501,6 +498,22 @@ pncli config show
 pncli config set
 
 pncli config test
+```
+
+### Ado
+
+```
+pncli ado whoami
+
+pncli ado connection-data
+
+pncli ado project
+
+pncli ado work
+
+pncli ado repo
+
+pncli ado pipeline
 ```
 
 <!-- COMMAND-REFERENCE:END -->

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "chalk": "^5.4.1",
     "commander": "^13.1.0"
   },
-  "optionalDependencies": {
-    "node-expose-sspi": "^1.1.10"
-  },
   "devDependencies": {
     "@types/node": "^22.15.3",
     "@typescript-eslint/eslint-plugin": "^8.31.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "chalk": "^5.4.1",
     "commander": "^13.1.0"
   },
+  "optionalDependencies": {
+    "node-expose-sspi": "^1.1.10"
+  },
   "devDependencies": {
     "@types/node": "^22.15.3",
     "@typescript-eslint/eslint-plugin": "^8.31.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { registerSonarCommands } from './services/sonar/commands.js';
 import { registerSdeCommands } from './services/sde/commands.js';
 import { registerDepsCommands } from './services/deps/commands.js';
 import { registerConfigCommands } from './services/config/commands.js';
+import { registerAdoCommands } from './services/ado/commands/index.js';
 
 const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,6 +60,7 @@ registerSonarCommands(program);
 registerSdeCommands(program);
 registerDepsCommands(program);
 registerConfigCommands(program);
+registerAdoCommands(program);
 
 program.addHelpText('after', `
 Services:
@@ -69,6 +71,7 @@ Services:
   confluence   Confluence
   sonar        SonarQube Server (quality gates, issues, metrics, hotspots)
   sde          SDElements (threat modeling, countermeasures, compliance)
+  ado          Azure DevOps Server (work items, repos, PRs, pipelines)
   config       Manage pncli configuration
 `);
 

--- a/src/lib/adoFetch.ts
+++ b/src/lib/adoFetch.ts
@@ -1,0 +1,73 @@
+import type { ResolvedConfig } from '../types/config.js';
+import { PncliError } from './errors.js';
+
+// Module-level SSPI client singleton — lazily initialized on first use.
+// Only ever loaded on win32 when SSPI is needed.
+let sspiClient: { fetch: typeof fetch } | null = null;
+
+/**
+ * Returns a fetch-compatible function for Azure DevOps Server requests.
+ *
+ * Precedence:
+ *   1. PAT configured → native fetch + Basic auth header injected
+ *   2. Windows platform + node-expose-sspi loadable → SSPI fetch (current Windows user)
+ *   3. Otherwise → throw (clear message pointing user at config init)
+ *
+ * IMPORTANT: pass dryRun=true to skip SSPI initialisation in CI/dry-run contexts.
+ */
+export async function buildAdoFetcher(
+  config: ResolvedConfig,
+  dryRun = false
+): Promise<typeof fetch> {
+  const { pat, baseUrl } = config.ado;
+
+  if (!baseUrl) {
+    throw new PncliError('Azure DevOps baseUrl not configured. Run: pncli config init', 1);
+  }
+
+  // PAT path — simple, cross-platform
+  if (pat) {
+    const encoded = Buffer.from(':' + pat).toString('base64');
+    const authHeader = `Basic ${encoded}`;
+    return (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+      fetch(url, {
+        ...init,
+        headers: {
+          ...(init?.headers as Record<string, string> | undefined),
+          'Authorization': authHeader,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        }
+      });
+  }
+
+  // SSPI path — Windows only, no native module loaded under dry-run
+  if (dryRun) {
+    // Return a stub that returns a 200 so the dryRun block in http.ts fires first
+    return () => Promise.resolve(new Response('{}', { status: 200 }));
+  }
+
+  if (process.platform !== 'win32') {
+    throw new PncliError(
+      'Azure DevOps Windows Integrated Authentication is only available on Windows. ' +
+      'Set a PAT via pncli config init or PNCLI_ADO_PAT env var.',
+      1
+    );
+  }
+
+  // Lazy-load node-expose-sspi (optionalDependency)
+  if (!sspiClient) {
+    try {
+      const sso = await import('node-expose-sspi');
+      sspiClient = new sso.Client() as unknown as { fetch: typeof fetch };
+    } catch {
+      throw new PncliError(
+        'Could not load Windows authentication module (node-expose-sspi). ' +
+        'Run: npm install node-expose-sspi, or configure a PAT via pncli config init.',
+        1
+      );
+    }
+  }
+
+  return sspiClient.fetch.bind(sspiClient) as typeof fetch;
+}

--- a/src/lib/adoFetch.ts
+++ b/src/lib/adoFetch.ts
@@ -1,23 +1,12 @@
 import type { ResolvedConfig } from '../types/config.js';
 import { PncliError } from './errors.js';
 
-// Module-level SSPI client singleton — lazily initialized on first use.
-// Only ever loaded on win32 when SSPI is needed.
-let sspiClient: { fetch: typeof fetch } | null = null;
-
 /**
- * Returns a fetch-compatible function for Azure DevOps Server requests.
- *
- * Precedence:
- *   1. PAT configured → native fetch + Basic auth header injected
- *   2. Windows platform + node-expose-sspi loadable → SSPI fetch (current Windows user)
- *   3. Otherwise → throw (clear message pointing user at config init)
- *
- * IMPORTANT: pass dryRun=true to skip SSPI initialisation in CI/dry-run contexts.
+ * Returns a fetch-compatible function for Azure DevOps Server requests,
+ * with Basic auth (PAT) injected into every call.
  */
 export async function buildAdoFetcher(
-  config: ResolvedConfig,
-  dryRun = false
+  config: ResolvedConfig
 ): Promise<typeof fetch> {
   const { pat, baseUrl } = config.ado;
 
@@ -25,49 +14,23 @@ export async function buildAdoFetcher(
     throw new PncliError('Azure DevOps baseUrl not configured. Run: pncli config init', 1);
   }
 
-  // PAT path — simple, cross-platform
-  if (pat) {
-    const encoded = Buffer.from(':' + pat).toString('base64');
-    const authHeader = `Basic ${encoded}`;
-    return (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
-      fetch(url, {
-        ...init,
-        headers: {
-          ...(init?.headers as Record<string, string> | undefined),
-          'Authorization': authHeader,
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        }
-      });
-  }
-
-  // SSPI path — Windows only, no native module loaded under dry-run
-  if (dryRun) {
-    // Return a stub that returns a 200 so the dryRun block in http.ts fires first
-    return () => Promise.resolve(new Response('{}', { status: 200 }));
-  }
-
-  if (process.platform !== 'win32') {
+  if (!pat) {
     throw new PncliError(
-      'Azure DevOps Windows Integrated Authentication is only available on Windows. ' +
-      'Set a PAT via pncli config init or PNCLI_ADO_PAT env var.',
+      'Azure DevOps PAT not configured. Set a PAT via pncli config init or PNCLI_ADO_PAT env var.',
       1
     );
   }
 
-  // Lazy-load node-expose-sspi (optionalDependency)
-  if (!sspiClient) {
-    try {
-      const sso = await import('node-expose-sspi');
-      sspiClient = new sso.Client() as unknown as { fetch: typeof fetch };
-    } catch {
-      throw new PncliError(
-        'Could not load Windows authentication module (node-expose-sspi). ' +
-        'Run: npm install node-expose-sspi, or configure a PAT via pncli config init.',
-        1
-      );
-    }
-  }
-
-  return sspiClient.fetch.bind(sspiClient) as typeof fetch;
+  const encoded = Buffer.from(':' + pat).toString('base64');
+  const authHeader = `Basic ${encoded}`;
+  return (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+    fetch(url, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        'Authorization': authHeader,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    });
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, SonarDefaults, SdeDefaults } from '../types/config.js';
+import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, SonarDefaults, SdeDefaults, AdoDefaults } from '../types/config.js';
 import type { CustomFieldDefinition } from '../types/jira.js';
 
 const ENV_KEYS = {
@@ -22,6 +22,8 @@ const ENV_KEYS = {
   SONAR_BASE_URL: 'PNCLI_SONAR_BASE_URL',
   SONAR_TOKEN: 'PNCLI_SONAR_TOKEN',
   SDE_CONNECTION: 'PNCLI_SDE_CONNECTION',
+  ADO_BASE_URL: 'PNCLI_ADO_BASE_URL',
+  ADO_PAT: 'PNCLI_ADO_PAT',
   CONFIG_PATH: 'PNCLI_CONFIG_PATH'
 } as const;
 
@@ -71,12 +73,13 @@ function mergeCustomFields(
 function mergeDefaults(
   global: GlobalConfig['defaults'],
   repo: RepoConfig['defaults']
-): { jira: JiraDefaults; bitbucket: BitbucketDefaults; sonar: SonarDefaults; sde: SdeDefaults } {
+): { jira: JiraDefaults; bitbucket: BitbucketDefaults; sonar: SonarDefaults; sde: SdeDefaults; ado: AdoDefaults } {
   return {
     jira: { ...global?.jira, ...repo?.jira },
     bitbucket: { ...global?.bitbucket, ...repo?.bitbucket },
     sonar: { ...global?.sonar, ...repo?.sonar },
-    sde: { ...global?.sde, ...repo?.sde }
+    sde: { ...global?.sde, ...repo?.sde },
+    ado: { ...global?.ado, ...repo?.ado }
   };
 }
 
@@ -131,6 +134,13 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
       const parsed = raw ? parseSdeConnection(raw) : null;
       return { baseUrl: parsed?.baseUrl, token: parsed?.token };
     })(),
+    ado: {
+      baseUrl: process.env[ENV_KEYS.ADO_BASE_URL] ?? globalConfig.ado?.baseUrl,
+      pat: process.env[ENV_KEYS.ADO_PAT] ?? globalConfig.ado?.pat,
+      fieldAliases: globalConfig.ado?.fieldAliases ?? {},
+      discoveredFields: globalConfig.ado?.discoveredFields ?? [],
+      discoveredTypes: globalConfig.ado?.discoveredTypes ?? []
+    },
     defaults: mergedDefaults
   };
 }
@@ -196,6 +206,10 @@ export function maskConfig(config: ResolvedConfig): unknown {
     sde: {
       baseUrl: config.sde.baseUrl,
       token: config.sde.token ? '***' : undefined
+    },
+    ado: {
+      ...config.ado,
+      pat: config.ado.pat ? '***' : undefined
     }
   };
 }

--- a/src/lib/git-context.ts
+++ b/src/lib/git-context.ts
@@ -4,8 +4,11 @@ import type { ResolvedConfig } from '../types/config.js';
 export interface GitContext {
   root: string;
   branch: string;
+  // Bitbucket-resolved fields
   project: string | null;
   repo: string | null;
+  // Azure DevOps Server-resolved fields
+  ado: { collection: string; project: string; repo: string } | null;
 }
 
 export function getRepoRoot(): string | null {
@@ -57,6 +60,76 @@ export function parseRemote(
   return null;
 }
 
+/**
+ * Parses an Azure DevOps Server git remote URL into { collection, project, repo }.
+ *
+ * Supported formats:
+ *   HTTPS : https://<host>[/<prefix>]/<collection>/<project>/_git/<repo>
+ *   SSH   : ssh://git@<host>[:<port>][/<prefix>]/<collection>/<project>/_ssh/<repo>
+ *           git@<host>[:<port>]/<prefix>/<collection>/<project>/<repo>
+ *
+ * Strategy: find the `_git` or `_ssh` segment; walk back — the segment immediately
+ * before it is the project, the one before that is the collection. Anything before
+ * the collection is treated as a path prefix (e.g. /tfs/) and is ignored.
+ * URL is only parsed if the host is contained in adoBaseUrl (same guard as Bitbucket).
+ */
+export function parseAdoRemote(
+  remoteUrl: string,
+  adoBaseUrl: string | undefined
+): { collection: string; project: string; repo: string } | null {
+  if (!adoBaseUrl) return null;
+
+  const base = adoBaseUrl.replace(/\/$/, '').replace(/^https?:\/\//, '');
+
+  // Extract host from the remote URL (after stripping protocol/credentials)
+  let path = remoteUrl;
+  let host = '';
+
+  // ssh:// form
+  const sshProtoMatch = path.match(/^ssh:\/\/[^@]*@?([^/:]+)(?::\d+)?(.*)/);
+  if (sshProtoMatch) {
+    host = sshProtoMatch[1]!;
+    path = sshProtoMatch[2]!;
+  } else {
+    // git@host form or https://
+    const gitAtMatch = path.match(/^git@([^:]+)(?::\d+)?:(.*)/);
+    if (gitAtMatch) {
+      host = gitAtMatch[1]!;
+      path = '/' + gitAtMatch[2]!;
+    } else {
+      const httpsMatch = path.match(/^https?:\/\/([^/]+)(.*)/);
+      if (httpsMatch) {
+        host = httpsMatch[1]!;
+        path = httpsMatch[2]!;
+      }
+    }
+  }
+
+  if (!host || !base.includes(host)) return null;
+
+  // Strip trailing .git
+  path = path.replace(/\.git$/, '');
+
+  // Find _git or _ssh segment
+  const gitIdx = path.indexOf('/_git/');
+  const sshIdx = path.indexOf('/_ssh/');
+  const markerIdx = gitIdx !== -1 ? gitIdx : sshIdx;
+  if (markerIdx === -1) return null;
+
+  const repo = path.slice(markerIdx + 6); // skip /_git/ or /_ssh/
+  if (!repo) return null;
+
+  // Everything before the marker: /<prefix>/<collection>/<project>
+  const before = path.slice(1, markerIdx); // strip leading /
+  const parts = before.split('/').filter(Boolean);
+  if (parts.length < 2) return null;
+
+  const project = parts[parts.length - 1]!;
+  const collection = parts[parts.length - 2]!;
+
+  return { collection, project, repo };
+}
+
 function getRemoteUrls(repoRoot: string): string[] {
   try {
     const output = execSync('git remote -v', { encoding: 'utf8', cwd: repoRoot });
@@ -77,9 +150,9 @@ export function getGitContext(config: ResolvedConfig): GitContext | null {
   const branch = getCurrentBranch(root) ?? 'unknown';
   const remoteUrls = getRemoteUrls(root);
 
+  // Bitbucket: disambiguated by /scm/ pattern
   let project: string | null = null;
   let repo: string | null = null;
-
   for (const url of remoteUrls) {
     const parsed = parseRemote(url, config.bitbucket.baseUrl);
     if (parsed) {
@@ -89,5 +162,15 @@ export function getGitContext(config: ResolvedConfig): GitContext | null {
     }
   }
 
-  return { root, branch, project, repo };
+  // Azure DevOps Server: disambiguated by /_git/ pattern
+  let adoContext: GitContext['ado'] = null;
+  for (const url of remoteUrls) {
+    const parsed = parseAdoRemote(url, config.ado.baseUrl);
+    if (parsed) {
+      adoContext = parsed;
+      break;
+    }
+  }
+
+  return { root, branch, project, repo, ado: adoContext };
 }

--- a/src/lib/git-context.ts
+++ b/src/lib/git-context.ts
@@ -79,33 +79,41 @@ export function parseAdoRemote(
 ): { collection: string; project: string; repo: string } | null {
   if (!adoBaseUrl) return null;
 
-  const base = adoBaseUrl.replace(/\/$/, '').replace(/^https?:\/\//, '');
+  // Normalize base URL: extract just the hostname (without port) for comparison,
+  // so that https://tfs.company.com:8080 and git@tfs.company.com:... both match.
+  let baseHostname: string;
+  try {
+    const normalizedBase = /^https?:\/\//.test(adoBaseUrl) ? adoBaseUrl : `https://${adoBaseUrl}`;
+    baseHostname = new URL(normalizedBase).hostname.toLowerCase();
+  } catch {
+    baseHostname = adoBaseUrl.replace(/\/$/, '').replace(/^https?:\/\//, '').split(/[:/]/)[0]!.toLowerCase();
+  }
 
   // Extract host from the remote URL (after stripping protocol/credentials)
   let path = remoteUrl;
-  let host = '';
+  let remoteHostname = '';
 
   // ssh:// form
   const sshProtoMatch = path.match(/^ssh:\/\/[^@]*@?([^/:]+)(?::\d+)?(.*)/);
   if (sshProtoMatch) {
-    host = sshProtoMatch[1]!;
+    remoteHostname = sshProtoMatch[1]!.toLowerCase();
     path = sshProtoMatch[2]!;
   } else {
     // git@host form or https://
     const gitAtMatch = path.match(/^git@([^:]+)(?::\d+)?:(.*)/);
     if (gitAtMatch) {
-      host = gitAtMatch[1]!;
+      remoteHostname = gitAtMatch[1]!.toLowerCase();
       path = '/' + gitAtMatch[2]!;
     } else {
-      const httpsMatch = path.match(/^https?:\/\/([^/]+)(.*)/);
+      const httpsMatch = path.match(/^https?:\/\/([^/:]+)(?::\d+)?(.*)/);
       if (httpsMatch) {
-        host = httpsMatch[1]!;
+        remoteHostname = httpsMatch[1]!.toLowerCase();
         path = httpsMatch[2]!;
       }
     }
   }
 
-  if (!host || !base.includes(host)) return null;
+  if (!remoteHostname || remoteHostname !== baseHostname) return null;
 
   // Strip trailing .git
   path = path.replace(/\.git$/, '');

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -12,6 +12,7 @@ export interface HttpRequestOptions {
   body?: unknown;
   params?: Record<string, string | number | boolean | undefined>;
   timeoutMs?: number;
+  headers?: Record<string, string>;
 }
 
 export interface HttpError {
@@ -322,12 +323,51 @@ export class HttpClient {
     }
 
     const fetcher = await this.getAdoFetcher();
+    const defaultHeaders: Record<string, string> = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      ...opts.headers
+    };
     const init: RequestInit = {
       method: opts.method ?? 'GET',
+      headers: defaultHeaders,
       body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
     };
 
     return request<T>(url, init, opts.timeoutMs ?? 30000, fetcher);
+  }
+
+  async adoText(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<string> {
+    const baseUrl = this.config.ado.baseUrl;
+    if (!baseUrl) throw new PncliError('Azure DevOps baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+
+    if (this.dryRun) {
+      fs.writeSync(process.stderr.fd, `DRY RUN: ${opts.method ?? 'GET'} ${url}\n`);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    const fetcher = await this.getAdoFetcher();
+    const response = await fetchWithTimeout(url, {
+      method: opts.method ?? 'GET',
+      headers: { 'Accept': 'text/plain', ...opts.headers }
+    }, opts.timeoutMs ?? 30000, fetcher);
+
+    if (!response.ok) {
+      let message = `HTTP ${response.status} ${response.statusText}`;
+      try {
+        const parsed = JSON.parse(await response.text());
+        if (parsed.message) message = String(parsed.message);
+      } catch { /* ignore */ }
+      throw new PncliError(message, response.status, url);
+    }
+
+    return response.text();
   }
 
   async adoRaw(
@@ -352,6 +392,7 @@ export class HttpClient {
     try {
       response = await fetcher(url, {
         method: opts.method ?? 'GET',
+        headers: { 'Accept': 'application/json', 'Content-Type': 'application/json', ...opts.headers },
         body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
         signal: controller.signal
       });

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -3,6 +3,7 @@ import type { ResolvedConfig } from '../types/config.js';
 import { PncliError } from './errors.js';
 import { ExitCode } from './exitCodes.js';
 import { log } from './output.js';
+import { buildAdoFetcher } from './adoFetch.js';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
@@ -32,11 +33,11 @@ function buildUrl(base: string, path: string, params?: Record<string, string | n
   return url.toString();
 }
 
-async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number, fetcher: typeof fetch = fetch): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    return await fetcher(url, { ...init, signal: controller.signal });
   } finally {
     clearTimeout(timer);
   }
@@ -45,14 +46,15 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: numbe
 async function request<T>(
   url: string,
   init: RequestInit,
-  timeoutMs: number
+  timeoutMs: number,
+  fetcher: typeof fetch = fetch
 ): Promise<T> {
   let lastError: unknown;
 
   for (let attempt = 0; attempt < 3; attempt++) {
     let response: Response;
     try {
-      response = await fetchWithTimeout(url, init, timeoutMs);
+      response = await fetchWithTimeout(url, init, timeoutMs, fetcher);
     } catch (err) {
       throw new PncliError(
         `Request failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -119,6 +121,7 @@ async function request<T>(
 export class HttpClient {
   private config: ResolvedConfig;
   private dryRun: boolean;
+  private adoFetcher: typeof fetch | null = null;
 
   constructor(config: ResolvedConfig, dryRun = false) {
     this.config = config;
@@ -289,6 +292,99 @@ export class HttpClient {
       results.push(...response.results);
       if (results.length >= response.count || response.results.length === 0) break;
       page++;
+    }
+
+    return results;
+  }
+
+  private async getAdoFetcher(): Promise<typeof fetch> {
+    if (!this.adoFetcher) {
+      this.adoFetcher = await buildAdoFetcher(this.config, this.dryRun);
+    }
+    return this.adoFetcher;
+  }
+
+  async ado<T>(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<T> {
+    const baseUrl = this.config.ado.baseUrl;
+    if (!baseUrl) throw new PncliError('Azure DevOps baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+
+    if (this.dryRun) {
+      const msg = `DRY RUN: ${opts.method ?? 'GET'} ${url}\n`
+        + (opts.body ? `Body: ${JSON.stringify(opts.body, null, 2)}\n` : '');
+      fs.writeSync(process.stderr.fd, msg);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    const fetcher = await this.getAdoFetcher();
+    const init: RequestInit = {
+      method: opts.method ?? 'GET',
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
+    };
+
+    return request<T>(url, init, opts.timeoutMs ?? 30000, fetcher);
+  }
+
+  async adoRaw(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<{ data: unknown; headers: Headers }> {
+    const baseUrl = this.config.ado.baseUrl;
+    if (!baseUrl) throw new PncliError('Azure DevOps baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+
+    if (this.dryRun) {
+      fs.writeSync(process.stderr.fd, `DRY RUN: ${opts.method ?? 'GET'} ${url}\n`);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    const fetcher = await this.getAdoFetcher();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 30000);
+    let response: Response;
+    try {
+      response = await fetcher(url, {
+        method: opts.method ?? 'GET',
+        body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+        signal: controller.signal
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      let message = `HTTP ${response.status} ${response.statusText}`;
+      try {
+        const parsed = JSON.parse(await response.text());
+        if (parsed.message) message = String(parsed.message);
+      } catch { /* ignore */ }
+      throw new PncliError(message, response.status, url);
+    }
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : undefined;
+    return { data, headers: response.headers };
+  }
+
+  async adoPaginate<T>(
+    fetchPage: (continuationToken?: string) => Promise<{ data: { value: T[] }; headers: Headers }>
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let token: string | undefined;
+
+    while (true) {
+      const { data, headers } = await fetchPage(token);
+      results.push(...(data.value ?? []));
+      const next = headers.get('x-ms-continuationtoken');
+      if (!next) break;
+      token = next;
     }
 
     return results;

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -300,7 +300,7 @@ export class HttpClient {
 
   private async getAdoFetcher(): Promise<typeof fetch> {
     if (!this.adoFetcher) {
-      this.adoFetcher = await buildAdoFetcher(this.config, this.dryRun);
+      this.adoFetcher = await buildAdoFetcher(this.config);
     }
     return this.adoFetcher;
   }

--- a/src/services/ado/client/build.ts
+++ b/src/services/ado/client/build.ts
@@ -1,0 +1,102 @@
+import type { HttpClient } from '../../../lib/http.js';
+import type {
+  AdoBuildDefinition,
+  AdoBuild,
+  AdoBuildLog,
+  AdoPageResponse
+} from '../../../types/ado.js';
+
+const API = '7.1';
+
+export class AdoBuildClient {
+  constructor(private http: HttpClient) {}
+
+  // ── Definitions ───────────────────────────────────────────────────
+
+  async listDefinitions(collection: string, project: string): Promise<AdoBuildDefinition[]> {
+    return this.http.adoPaginate<AdoBuildDefinition>(async (token) => {
+      const params: Record<string, string | number | boolean | undefined> = {
+        'api-version': API,
+        ...(token ? { continuationToken: token } : {})
+      };
+      return this.http.adoRaw(
+        `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/definitions`,
+        { params }
+      ) as Promise<{ data: { value: AdoBuildDefinition[] }; headers: Headers }>;
+    });
+  }
+
+  async getDefinition(collection: string, project: string, id: number): Promise<AdoBuildDefinition> {
+    return this.http.ado<AdoBuildDefinition>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/definitions/${id}?api-version=${API}`
+    );
+  }
+
+  // ── Builds (runs) ─────────────────────────────────────────────────
+
+  async queueBuild(
+    collection: string,
+    project: string,
+    definitionId: number,
+    opts: { sourceBranch?: string; parameters?: string } = {}
+  ): Promise<AdoBuild> {
+    const body: Record<string, unknown> = {
+      definition: { id: definitionId },
+      ...(opts.sourceBranch ? { sourceBranch: opts.sourceBranch } : {}),
+      ...(opts.parameters ? { parameters: opts.parameters } : {})
+    };
+    return this.http.ado<AdoBuild>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/builds?api-version=${API}`,
+      { method: 'POST', body }
+    );
+  }
+
+  async listBuilds(
+    collection: string,
+    project: string,
+    opts: { definitionIds?: number[]; branchName?: string; statusFilter?: string; top?: number } = {}
+  ): Promise<AdoBuild[]> {
+    return this.http.adoPaginate<AdoBuild>(async (token) => {
+      const params: Record<string, string | number | boolean | undefined> = {
+        'api-version': API,
+        ...(opts.definitionIds?.length ? { definitionIds: opts.definitionIds.join(',') } : {}),
+        ...(opts.branchName ? { branchName: opts.branchName } : {}),
+        ...(opts.statusFilter ? { statusFilter: opts.statusFilter } : {}),
+        ...(opts.top ? { '$top': opts.top } : {}),
+        ...(token ? { continuationToken: token } : {})
+      };
+      return this.http.adoRaw(
+        `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/builds`,
+        { params }
+      ) as Promise<{ data: { value: AdoBuild[] }; headers: Headers }>;
+    });
+  }
+
+  async getBuild(collection: string, project: string, buildId: number): Promise<AdoBuild> {
+    return this.http.ado<AdoBuild>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/builds/${buildId}?api-version=${API}`
+    );
+  }
+
+  async cancelBuild(collection: string, project: string, buildId: number): Promise<AdoBuild> {
+    return this.http.ado<AdoBuild>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/builds/${buildId}?api-version=${API}`,
+      { method: 'PATCH', body: { status: 'cancelling' } }
+    );
+  }
+
+  // ── Logs ──────────────────────────────────────────────────────────
+
+  async listLogs(collection: string, project: string, buildId: number): Promise<AdoBuildLog[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoBuildLog>>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/builds/${buildId}/logs?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+
+  async getLog(collection: string, project: string, buildId: number, logId: number): Promise<string> {
+    return this.http.ado<string>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/builds/${buildId}/logs/${logId}?api-version=${API}`
+    );
+  }
+}

--- a/src/services/ado/client/build.ts
+++ b/src/services/ado/client/build.ts
@@ -95,7 +95,7 @@ export class AdoBuildClient {
   }
 
   async getLog(collection: string, project: string, buildId: number, logId: number): Promise<string> {
-    return this.http.ado<string>(
+    return this.http.adoText(
       `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/build/builds/${buildId}/logs/${logId}?api-version=${API}`
     );
   }

--- a/src/services/ado/client/core.ts
+++ b/src/services/ado/client/core.ts
@@ -1,0 +1,46 @@
+import type { HttpClient } from '../../../lib/http.js';
+import type {
+  AdoConnectionData,
+  AdoProject,
+  AdoProjectCollection,
+  AdoPageResponse
+} from '../../../types/ado.js';
+
+const API = '7.1';
+
+export class AdoCoreClient {
+  constructor(private http: HttpClient) {}
+
+  async getConnectionData(collection?: string): Promise<AdoConnectionData> {
+    const path = collection
+      ? `/${encodeURIComponent(collection)}/_apis/connectionData?api-version=${API}`
+      : `/_apis/connectionData?api-version=${API}`;
+    return this.http.ado<AdoConnectionData>(path);
+  }
+
+  async listCollections(): Promise<AdoProjectCollection[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoProjectCollection>>(
+      `/_apis/projectCollections?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+
+  async listProjects(collection: string): Promise<AdoProject[]> {
+    return this.http.adoPaginate<AdoProject>(async (token) => {
+      const params: Record<string, string | number | boolean | undefined> = {
+        'api-version': API,
+        ...(token ? { continuationToken: token } : {})
+      };
+      return this.http.adoRaw(
+        `/${encodeURIComponent(collection)}/_apis/projects`,
+        { params }
+      ) as Promise<{ data: { value: AdoProject[] }; headers: Headers }>;
+    });
+  }
+
+  async getProject(collection: string, projectName: string): Promise<AdoProject> {
+    return this.http.ado<AdoProject>(
+      `/${encodeURIComponent(collection)}/_apis/projects/${encodeURIComponent(projectName)}?api-version=${API}`
+    );
+  }
+}

--- a/src/services/ado/client/git.ts
+++ b/src/services/ado/client/git.ts
@@ -215,11 +215,10 @@ export class AdoGitClient {
   // ── Diffs / Files ─────────────────────────────────────────────────
 
   async listPRChanges(collection: string, project: string, repo: string, prId: number): Promise<AdoGitChange[]> {
-    const result = await this.http.ado<{ changes?: AdoGitChange[] }>(
+    const iterations = await this.http.ado<AdoPageResponse<{ id: number }>>(
       `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/iterations?api-version=${API}`
     );
     // Get the latest iteration then its changes
-    const iterations = result as unknown as { value: Array<{ id: number }> };
     const latestId = (iterations.value ?? []).at(-1)?.id;
     if (!latestId) return [];
     const changes = await this.http.ado<{ changeEntries?: AdoGitChange[] }>(

--- a/src/services/ado/client/git.ts
+++ b/src/services/ado/client/git.ts
@@ -1,0 +1,230 @@
+import type { HttpClient } from '../../../lib/http.js';
+import type {
+  AdoGitRepo,
+  AdoPullRequest,
+  AdoPRThread,
+  AdoPRComment,
+  AdoPRCompletionOptions,
+  AdoGitChange,
+  AdoPageResponse
+} from '../../../types/ado.js';
+
+const API = '7.1';
+
+export class AdoGitClient {
+  constructor(private http: HttpClient) {}
+
+  // ── Repositories ──────────────────────────────────────────────────
+
+  async listRepos(collection: string, project: string): Promise<AdoGitRepo[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoGitRepo>>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+
+  async getRepo(collection: string, project: string, repoId: string): Promise<AdoGitRepo> {
+    return this.http.ado<AdoGitRepo>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repoId)}?api-version=${API}`
+    );
+  }
+
+  // ── Pull Requests ─────────────────────────────────────────────────
+
+  async listPRs(
+    collection: string,
+    project: string,
+    repo: string,
+    opts: { status?: string; creatorAlias?: string; reviewerAlias?: string } = {}
+  ): Promise<AdoPullRequest[]> {
+    return this.http.adoPaginate<AdoPullRequest>(async (token) => {
+      const params: Record<string, string | number | boolean | undefined> = {
+        'api-version': API,
+        'searchCriteria.status': opts.status ?? 'active',
+        ...(opts.creatorAlias ? { 'searchCriteria.creatorId': opts.creatorAlias } : {}),
+        ...(opts.reviewerAlias ? { 'searchCriteria.reviewerId': opts.reviewerAlias } : {}),
+        ...(token ? { continuationToken: token } : {})
+      };
+      return this.http.adoRaw(
+        `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests`,
+        { params }
+      ) as Promise<{ data: { value: AdoPullRequest[] }; headers: Headers }>;
+    });
+  }
+
+  async getPR(collection: string, project: string, repo: string, prId: number): Promise<AdoPullRequest> {
+    return this.http.ado<AdoPullRequest>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}?api-version=${API}`
+    );
+  }
+
+  async createPR(
+    collection: string,
+    project: string,
+    repo: string,
+    body: {
+      title: string;
+      description?: string;
+      sourceRefName: string;
+      targetRefName: string;
+      reviewers?: Array<{ id: string }>;
+    }
+  ): Promise<AdoPullRequest> {
+    return this.http.ado<AdoPullRequest>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests?api-version=${API}`,
+      { method: 'POST', body }
+    );
+  }
+
+  async updatePR(
+    collection: string,
+    project: string,
+    repo: string,
+    prId: number,
+    body: Partial<{ title: string; description: string; reviewers: Array<{ id: string }> }>
+  ): Promise<AdoPullRequest> {
+    return this.http.ado<AdoPullRequest>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}?api-version=${API}`,
+      { method: 'PATCH', body }
+    );
+  }
+
+  async completePR(
+    collection: string,
+    project: string,
+    repo: string,
+    prId: number,
+    lastMergeSourceCommit: string,
+    completionOptions: AdoPRCompletionOptions
+  ): Promise<AdoPullRequest> {
+    return this.http.ado<AdoPullRequest>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}?api-version=${API}`,
+      {
+        method: 'PATCH',
+        body: {
+          status: 'completed',
+          lastMergeSourceCommit: { commitId: lastMergeSourceCommit },
+          completionOptions
+        }
+      }
+    );
+  }
+
+  async abandonPR(collection: string, project: string, repo: string, prId: number): Promise<AdoPullRequest> {
+    return this.http.ado<AdoPullRequest>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}?api-version=${API}`,
+      { method: 'PATCH', body: { status: 'abandoned' } }
+    );
+  }
+
+  // ── Reviewers / Votes ─────────────────────────────────────────────
+
+  async setPRVote(
+    collection: string,
+    project: string,
+    repo: string,
+    prId: number,
+    reviewerId: string,
+    vote: number
+  ): Promise<unknown> {
+    return this.http.ado<unknown>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/reviewers/${encodeURIComponent(reviewerId)}?api-version=${API}`,
+      { method: 'PUT', body: { vote } }
+    );
+  }
+
+  async listReviewers(collection: string, project: string, repo: string, prId: number): Promise<unknown[]> {
+    const pr = await this.getPR(collection, project, repo, prId);
+    return pr.reviewers;
+  }
+
+  // ── Threads / Comments ────────────────────────────────────────────
+
+  async listThreads(collection: string, project: string, repo: string, prId: number): Promise<AdoPRThread[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoPRThread>>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/threads?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+
+  async createThread(
+    collection: string,
+    project: string,
+    repo: string,
+    prId: number,
+    body: {
+      comments: Array<{ content: string; commentType?: string }>;
+      status?: string;
+      threadContext?: {
+        filePath: string;
+        rightFileStart?: { line: number; offset: number };
+        rightFileEnd?: { line: number; offset: number };
+        leftFileStart?: { line: number; offset: number };
+        leftFileEnd?: { line: number; offset: number };
+      };
+    }
+  ): Promise<AdoPRThread> {
+    return this.http.ado<AdoPRThread>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/threads?api-version=${API}`,
+      { method: 'POST', body }
+    );
+  }
+
+  async addCommentToThread(
+    collection: string,
+    project: string,
+    repo: string,
+    prId: number,
+    threadId: number,
+    content: string
+  ): Promise<AdoPRComment> {
+    return this.http.ado<AdoPRComment>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/threads/${threadId}/comments?api-version=${API}`,
+      { method: 'POST', body: { content, commentType: 'text' } }
+    );
+  }
+
+  async updateThread(
+    collection: string,
+    project: string,
+    repo: string,
+    prId: number,
+    threadId: number,
+    status: string
+  ): Promise<AdoPRThread> {
+    return this.http.ado<AdoPRThread>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/threads/${threadId}?api-version=${API}`,
+      { method: 'PATCH', body: { status } }
+    );
+  }
+
+  async deleteComment(
+    collection: string,
+    project: string,
+    repo: string,
+    prId: number,
+    threadId: number,
+    commentId: number
+  ): Promise<void> {
+    await this.http.ado<void>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/threads/${threadId}/comments/${commentId}?api-version=${API}`,
+      { method: 'DELETE' }
+    );
+  }
+
+  // ── Diffs / Files ─────────────────────────────────────────────────
+
+  async listPRChanges(collection: string, project: string, repo: string, prId: number): Promise<AdoGitChange[]> {
+    const result = await this.http.ado<{ changes?: AdoGitChange[] }>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/iterations?api-version=${API}`
+    );
+    // Get the latest iteration then its changes
+    const iterations = result as unknown as { value: Array<{ id: number }> };
+    const latestId = (iterations.value ?? []).at(-1)?.id;
+    if (!latestId) return [];
+    const changes = await this.http.ado<{ changeEntries?: AdoGitChange[] }>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repo)}/pullrequests/${prId}/iterations/${latestId}/changes?api-version=${API}`
+    );
+    return changes.changeEntries ?? [];
+  }
+}

--- a/src/services/ado/client/work.ts
+++ b/src/services/ado/client/work.ts
@@ -1,0 +1,93 @@
+import type { HttpClient } from '../../../lib/http.js';
+import type {
+  AdoWorkItem,
+  AdoWorkItemComment,
+  AdoWorkItemType,
+  AdoWorkItemTypeState,
+  AdoField,
+  AdoWiqlResult,
+  AdoPageResponse
+} from '../../../types/ado.js';
+
+const API = '7.1';
+const API_PREVIEW = '7.1-preview.4';
+
+export interface JsonPatchOp {
+  op: 'add' | 'replace' | 'remove';
+  path: string;
+  value?: unknown;
+}
+
+export class AdoWorkClient {
+  constructor(private http: HttpClient) {}
+
+  async getWorkItem(collection: string, id: number): Promise<AdoWorkItem> {
+    return this.http.ado<AdoWorkItem>(
+      `/${encodeURIComponent(collection)}/_apis/wit/workitems/${id}?api-version=${API}&$expand=all`
+    );
+  }
+
+  async createWorkItem(
+    collection: string,
+    project: string,
+    type: string,
+    patch: JsonPatchOp[]
+  ): Promise<AdoWorkItem> {
+    return this.http.ado<AdoWorkItem>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/workitems/${encodeURIComponent('$' + type)}?api-version=${API}`,
+      { method: 'POST', body: patch }
+    );
+  }
+
+  async updateWorkItem(collection: string, id: number, patch: JsonPatchOp[]): Promise<AdoWorkItem> {
+    return this.http.ado<AdoWorkItem>(
+      `/${encodeURIComponent(collection)}/_apis/wit/workitems/${id}?api-version=${API}`,
+      { method: 'PATCH', body: patch }
+    );
+  }
+
+  async queryWiql(collection: string, project: string, wiql: string): Promise<AdoWiqlResult> {
+    return this.http.ado<AdoWiqlResult>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/wiql?api-version=${API}`,
+      { method: 'POST', body: { query: wiql } }
+    );
+  }
+
+  async listComments(collection: string, project: string, workItemId: number): Promise<AdoWorkItemComment[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoWorkItemComment>>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/workItems/${workItemId}/comments?api-version=${API_PREVIEW}`
+    );
+    return result.value ?? [];
+  }
+
+  async addComment(collection: string, project: string, workItemId: number, text: string): Promise<AdoWorkItemComment> {
+    return this.http.ado<AdoWorkItemComment>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/workItems/${workItemId}/comments?api-version=${API_PREVIEW}`,
+      { method: 'POST', body: { text } }
+    );
+  }
+
+  async listWorkItemTypes(collection: string, project: string): Promise<AdoWorkItemType[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoWorkItemType>>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/workitemtypes?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+
+  async listTypeStates(collection: string, project: string, type: string): Promise<AdoWorkItemTypeState[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoWorkItemTypeState>>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/workitemtypes/${encodeURIComponent(type)}/states?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+
+  async listFields(collection: string, project?: string): Promise<AdoField[]> {
+    const scope = project
+      ? `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}`
+      : `/${encodeURIComponent(collection)}`;
+    const result = await this.http.ado<AdoPageResponse<AdoField>>(
+      `${scope}/_apis/wit/fields?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+}

--- a/src/services/ado/client/work.ts
+++ b/src/services/ado/client/work.ts
@@ -35,14 +35,14 @@ export class AdoWorkClient {
   ): Promise<AdoWorkItem> {
     return this.http.ado<AdoWorkItem>(
       `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/workitems/${encodeURIComponent('$' + type)}?api-version=${API}`,
-      { method: 'POST', body: patch }
+      { method: 'POST', body: patch, headers: { 'Content-Type': 'application/json-patch+json' } }
     );
   }
 
   async updateWorkItem(collection: string, id: number, patch: JsonPatchOp[]): Promise<AdoWorkItem> {
     return this.http.ado<AdoWorkItem>(
       `/${encodeURIComponent(collection)}/_apis/wit/workitems/${id}?api-version=${API}`,
-      { method: 'PATCH', body: patch }
+      { method: 'PATCH', body: patch, headers: { 'Content-Type': 'application/json-patch+json' } }
     );
   }
 
@@ -87,6 +87,13 @@ export class AdoWorkClient {
       : `/${encodeURIComponent(collection)}`;
     const result = await this.http.ado<AdoPageResponse<AdoField>>(
       `${scope}/_apis/wit/fields?api-version=${API}`
+    );
+    return result.value ?? [];
+  }
+
+  async listTypeFields(collection: string, project: string, type: string): Promise<AdoField[]> {
+    const result = await this.http.ado<AdoPageResponse<AdoField>>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/workitemtypes/${encodeURIComponent(type)}/fields?api-version=${API}`
     );
     return result.value ?? [];
   }

--- a/src/services/ado/commands/index.ts
+++ b/src/services/ado/commands/index.ts
@@ -1,0 +1,50 @@
+import { Command } from 'commander';
+import { registerAdoProjectCommands } from './project.js';
+import { registerAdoWorkCommands } from './work.js';
+import { registerAdoRepoCommands } from './repo.js';
+import { registerAdoPipelineCommands } from './pipeline.js';
+import { getAdoContext } from '../helpers.js';
+import { success, fail } from '../../../lib/output.js';
+
+export function registerAdoCommands(program: Command): void {
+  const ado = program
+    .command('ado')
+    .description('Azure DevOps Server operations')
+    .option('--collection <name>', 'Azure DevOps collection (organization)')
+    .option('--organization <name>', 'Alias for --collection')
+    .option('--project <name>', 'Azure DevOps team project')
+    .option('--repo <name>', 'Azure DevOps git repository name');
+
+  // ── Top-level commands ─────────────────────────────────────────────
+
+  ado
+    .command('whoami')
+    .description('Show current authenticated user')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { collection, coreClient } = getAdoContext(ado);
+        const data = await coreClient.getConnectionData(collection);
+        success(data, 'ado', 'whoami', start);
+      } catch (err) { fail(err, 'ado', 'whoami', start); }
+    });
+
+  ado
+    .command('connection-data')
+    .description('Show raw connection data from the ADO server')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { collection, coreClient } = getAdoContext(ado);
+        const data = await coreClient.getConnectionData(collection);
+        success(data, 'ado', 'connection-data', start);
+      } catch (err) { fail(err, 'ado', 'connection-data', start); }
+    });
+
+  // ── Subcommand groups ──────────────────────────────────────────────
+
+  registerAdoProjectCommands(ado);
+  registerAdoWorkCommands(ado);
+  registerAdoRepoCommands(ado);
+  registerAdoPipelineCommands(ado);
+}

--- a/src/services/ado/commands/pipeline.ts
+++ b/src/services/ado/commands/pipeline.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getAdoContext, pollUntilTerminal, isBuildTerminal } from '../helpers.js';
 import { success, fail, log } from '../../../lib/output.js';
 import { ExitCode } from '../../../lib/exitCodes.js';
+import { PncliError } from '../../../lib/errors.js';
 
 export function registerAdoPipelineCommands(ado: Command): void {
   const pipeline = ado
@@ -49,6 +50,10 @@ export function registerAdoPipelineCommands(ado: Command): void {
         const sourceBranch = opts.branch
           ? (opts.branch.startsWith('refs/') ? opts.branch : `refs/heads/${opts.branch}`)
           : undefined;
+
+        for (const p of opts.parameter) {
+          if (!p.includes('=')) throw new PncliError(`Invalid --parameter "${p}". Expected format: key=value`, 1);
+        }
         const parameters = opts.parameter.length > 0
           ? JSON.stringify(Object.fromEntries(opts.parameter.map(p => {
               const eq = p.indexOf('=');
@@ -65,6 +70,8 @@ export function registerAdoPipelineCommands(ado: Command): void {
         if (opts.wait) {
           const timeoutSec = parseInt(opts.timeout, 10);
           const pollSec = parseInt(opts.poll, 10);
+          if (isNaN(timeoutSec) || timeoutSec <= 0) throw new PncliError(`Invalid --timeout "${opts.timeout}". Expected a positive number of seconds.`, 1);
+          if (isNaN(pollSec) || pollSec <= 0) throw new PncliError(`Invalid --poll "${opts.poll}". Expected a positive number of seconds.`, 1);
           log(`Waiting for build #${build.id} to complete (timeout ${timeoutSec}s, poll ${pollSec}s)...`);
           build = await pollUntilTerminal(
             () => buildClient.getBuild(collection, project, build.id),

--- a/src/services/ado/commands/pipeline.ts
+++ b/src/services/ado/commands/pipeline.ts
@@ -1,0 +1,149 @@
+import { Command } from 'commander';
+import { getAdoContext, pollUntilTerminal, isBuildTerminal } from '../helpers.js';
+import { success, fail, log } from '../../../lib/output.js';
+import { ExitCode } from '../../../lib/exitCodes.js';
+
+export function registerAdoPipelineCommands(ado: Command): void {
+  const pipeline = ado
+    .command('pipeline')
+    .description('Azure DevOps pipeline (build) operations');
+
+  pipeline
+    .command('list')
+    .description('List pipeline definitions')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { collection, project, buildClient } = getAdoContext(ado);
+        const data = await buildClient.listDefinitions(collection, project);
+        success(data, 'ado', 'pipeline-list', start);
+      } catch (err) { fail(err, 'ado', 'pipeline-list', start); }
+    });
+
+  pipeline
+    .command('get')
+    .description('Get a pipeline definition by ID')
+    .requiredOption('--id <n>', 'Pipeline definition ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, buildClient } = getAdoContext(ado);
+        const data = await buildClient.getDefinition(collection, project, parseInt(opts.id, 10));
+        success(data, 'ado', 'pipeline-get', start);
+      } catch (err) { fail(err, 'ado', 'pipeline-get', start); }
+    });
+
+  pipeline
+    .command('run')
+    .description('Queue a pipeline run')
+    .requiredOption('--id <n>', 'Pipeline definition ID')
+    .option('--branch <ref>', 'Source branch (e.g. refs/heads/main or main)')
+    .option('--parameter <k=v>', 'Build parameter (repeatable)', (v: string, acc: string[]) => { acc.push(v); return acc; }, [] as string[])
+    .option('--wait', 'Wait for the run to complete before returning')
+    .option('--timeout <s>', 'Max wait time in seconds (default 600)', '600')
+    .option('--poll <s>', 'Poll interval in seconds (default 10)', '10')
+    .action(async (opts: { id: string; branch?: string; parameter: string[]; wait?: boolean; timeout: string; poll: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, buildClient } = getAdoContext(ado);
+        const sourceBranch = opts.branch
+          ? (opts.branch.startsWith('refs/') ? opts.branch : `refs/heads/${opts.branch}`)
+          : undefined;
+        const parameters = opts.parameter.length > 0
+          ? JSON.stringify(Object.fromEntries(opts.parameter.map(p => {
+              const eq = p.indexOf('=');
+              return [p.slice(0, eq), p.slice(eq + 1)];
+            })))
+          : undefined;
+
+        let build = await buildClient.queueBuild(collection, project, parseInt(opts.id, 10), {
+          sourceBranch,
+          parameters
+        });
+        log(`Queued build #${build.id} (${build.buildNumber}) — status: ${build.status}`);
+
+        if (opts.wait) {
+          const timeoutSec = parseInt(opts.timeout, 10);
+          const pollSec = parseInt(opts.poll, 10);
+          log(`Waiting for build #${build.id} to complete (timeout ${timeoutSec}s, poll ${pollSec}s)...`);
+          build = await pollUntilTerminal(
+            () => buildClient.getBuild(collection, project, build.id),
+            isBuildTerminal,
+            { timeoutSec, pollSec }
+          );
+          if (build.result && build.result !== 'succeeded') {
+            process.exitCode = ExitCode.GENERAL_ERROR;
+          }
+        }
+
+        success(build, 'ado', 'pipeline-run', start);
+      } catch (err) { fail(err, 'ado', 'pipeline-run', start); }
+    });
+
+  pipeline
+    .command('list-runs')
+    .description('List pipeline runs')
+    .option('--definition <id>', 'Filter by definition ID')
+    .option('--branch <ref>', 'Filter by branch name')
+    .option('--status <filter>', 'Filter by status (inProgress|completed|cancelling|...)')
+    .option('--top <n>', 'Maximum results', '50')
+    .action(async (opts: { definition?: string; branch?: string; status?: string; top: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, buildClient } = getAdoContext(ado);
+        const data = await buildClient.listBuilds(collection, project, {
+          definitionIds: opts.definition ? [parseInt(opts.definition, 10)] : undefined,
+          branchName: opts.branch,
+          statusFilter: opts.status,
+          top: parseInt(opts.top, 10)
+        });
+        success(data, 'ado', 'pipeline-list-runs', start);
+      } catch (err) { fail(err, 'ado', 'pipeline-list-runs', start); }
+    });
+
+  pipeline
+    .command('get-run')
+    .description('Get a pipeline run by build ID')
+    .requiredOption('--id <n>', 'Build ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, buildClient } = getAdoContext(ado);
+        const data = await buildClient.getBuild(collection, project, parseInt(opts.id, 10));
+        success(data, 'ado', 'pipeline-get-run', start);
+      } catch (err) { fail(err, 'ado', 'pipeline-get-run', start); }
+    });
+
+  pipeline
+    .command('cancel-run')
+    .description('Cancel a running pipeline build')
+    .requiredOption('--id <n>', 'Build ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, buildClient } = getAdoContext(ado);
+        const data = await buildClient.cancelBuild(collection, project, parseInt(opts.id, 10));
+        success(data, 'ado', 'pipeline-cancel-run', start);
+      } catch (err) { fail(err, 'ado', 'pipeline-cancel-run', start); }
+    });
+
+  pipeline
+    .command('logs')
+    .description('List or retrieve build logs')
+    .requiredOption('--id <n>', 'Build ID')
+    .option('--log-id <n>', 'Specific log ID (omit to list all logs)')
+    .action(async (opts: { id: string; logId?: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, buildClient } = getAdoContext(ado);
+        const buildId = parseInt(opts.id, 10);
+        if (opts.logId) {
+          const data = await buildClient.getLog(collection, project, buildId, parseInt(opts.logId, 10));
+          success({ log: data }, 'ado', 'pipeline-logs', start);
+        } else {
+          const data = await buildClient.listLogs(collection, project, buildId);
+          success(data, 'ado', 'pipeline-logs', start);
+        }
+      } catch (err) { fail(err, 'ado', 'pipeline-logs', start); }
+    });
+}

--- a/src/services/ado/commands/project.ts
+++ b/src/services/ado/commands/project.ts
@@ -1,0 +1,46 @@
+import { Command } from 'commander';
+import { getAdoContext } from '../helpers.js';
+import { success, fail } from '../../../lib/output.js';
+
+export function registerAdoProjectCommands(ado: Command): void {
+  const project = ado
+    .command('project')
+    .description('Azure DevOps project and collection operations');
+
+  project
+    .command('list-collections')
+    .description('List all project collections on the server')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { coreClient } = getAdoContext(ado);
+        const data = await coreClient.listCollections();
+        success(data, 'ado', 'project-list-collections', start);
+      } catch (err) { fail(err, 'ado', 'project-list-collections', start); }
+    });
+
+  project
+    .command('list')
+    .description('List team projects in a collection')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { collection, coreClient } = getAdoContext(ado);
+        const data = await coreClient.listProjects(collection);
+        success(data, 'ado', 'project-list', start);
+      } catch (err) { fail(err, 'ado', 'project-list', start); }
+    });
+
+  project
+    .command('get')
+    .description('Get a team project by name')
+    .requiredOption('--name <project>', 'Project name')
+    .action(async (opts: { name: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, coreClient } = getAdoContext(ado);
+        const data = await coreClient.getProject(collection, opts.name);
+        success(data, 'ado', 'project-get', start);
+      } catch (err) { fail(err, 'ado', 'project-get', start); }
+    });
+}

--- a/src/services/ado/commands/repo.ts
+++ b/src/services/ado/commands/repo.ts
@@ -1,0 +1,371 @@
+import { Command } from 'commander';
+import { getAdoContext, PR_VOTE } from '../helpers.js';
+import { success, fail } from '../../../lib/output.js';
+import type { AdoPRThread, AdoPRComment } from '../../../types/ado.js';
+
+/** Flatten all comments across all threads into a sorted list with threadContext attached */
+function flattenThreadComments(
+  threads: AdoPRThread[],
+  filterInlineOnly: boolean,
+  filterGeneralOnly: boolean
+): Array<AdoPRComment & { threadId: number; threadContext: AdoPRThread['threadContext'] | null }> {
+  const flat: Array<AdoPRComment & { threadId: number; threadContext: AdoPRThread['threadContext'] | null }> = [];
+  for (const thread of threads) {
+    if (thread.isDeleted) continue;
+    if (filterInlineOnly && !thread.threadContext) continue;
+    if (filterGeneralOnly && thread.threadContext) continue;
+    for (const comment of thread.comments) {
+      if (comment.isDeleted) continue;
+      flat.push({ ...comment, threadId: thread.id, threadContext: thread.threadContext ?? null });
+    }
+  }
+  return flat.sort((a, b) => a.publishedDate.localeCompare(b.publishedDate));
+}
+
+export function registerAdoRepoCommands(ado: Command): void {
+  const repo = ado
+    .command('repo')
+    .description('Azure DevOps repository and pull request operations');
+
+  // ── Repos ─────────────────────────────────────────────────────────
+
+  repo
+    .command('list')
+    .description('List git repositories in the project')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { collection, project, gitClient } = getAdoContext(ado);
+        const data = await gitClient.listRepos(collection, project);
+        success(data, 'ado', 'repo-list', start);
+      } catch (err) { fail(err, 'ado', 'repo-list', start); }
+    });
+
+  repo
+    .command('get')
+    .description('Get a specific repository')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo: repoName, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.getRepo(collection, project, repoName);
+        success(data, 'ado', 'repo-get', start);
+      } catch (err) { fail(err, 'ado', 'repo-get', start); }
+    });
+
+  // ── Pull Requests ─────────────────────────────────────────────────
+
+  repo
+    .command('list-prs')
+    .description('List pull requests')
+    .option('--state <state>', 'PR state: active|abandoned|completed|all', 'active')
+    .option('--creator <alias>', 'Filter by creator')
+    .option('--reviewer <alias>', 'Filter by reviewer')
+    .action(async (opts: { state?: string; creator?: string; reviewer?: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.listPRs(collection, project, repo, {
+          status: opts.state,
+          creatorAlias: opts.creator,
+          reviewerAlias: opts.reviewer
+        });
+        success(data, 'ado', 'repo-list-prs', start);
+      } catch (err) { fail(err, 'ado', 'repo-list-prs', start); }
+    });
+
+  repo
+    .command('get-pr')
+    .description('Get a pull request by ID')
+    .requiredOption('--id <n>', 'Pull request ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.getPR(collection, project, repo, parseInt(opts.id, 10));
+        success(data, 'ado', 'repo-get-pr', start);
+      } catch (err) { fail(err, 'ado', 'repo-get-pr', start); }
+    });
+
+  repo
+    .command('create-pr')
+    .description('Create a pull request')
+    .requiredOption('--title <title>', 'PR title')
+    .requiredOption('--source <branch>', 'Source branch')
+    .option('--target <branch>', 'Target branch (default: main)', 'main')
+    .option('--description <text>', 'PR description')
+    .option('--reviewers <ids>', 'Comma-separated reviewer IDs or display names')
+    .action(async (opts: { title: string; source: string; target: string; description?: string; reviewers?: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const reviewers = opts.reviewers
+          ? opts.reviewers.split(',').map(id => ({ id: id.trim() }))
+          : [];
+        const data = await gitClient.createPR(collection, project, repo, {
+          title: opts.title,
+          description: opts.description,
+          sourceRefName: `refs/heads/${opts.source}`,
+          targetRefName: `refs/heads/${opts.target}`,
+          reviewers
+        });
+        success(data, 'ado', 'repo-create-pr', start);
+      } catch (err) { fail(err, 'ado', 'repo-create-pr', start); }
+    });
+
+  repo
+    .command('update-pr')
+    .description('Update a pull request')
+    .requiredOption('--id <n>', 'Pull request ID')
+    .option('--title <title>', 'New title')
+    .option('--description <text>', 'New description')
+    .option('--reviewers <ids>', 'Comma-separated reviewer IDs')
+    .action(async (opts: { id: string; title?: string; description?: string; reviewers?: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const reviewers = opts.reviewers
+          ? opts.reviewers.split(',').map(id => ({ id: id.trim() }))
+          : undefined;
+        const body: Record<string, unknown> = {};
+        if (opts.title) body.title = opts.title;
+        if (opts.description !== undefined) body.description = opts.description;
+        if (reviewers) body.reviewers = reviewers;
+        const data = await gitClient.updatePR(collection, project, repo, parseInt(opts.id, 10), body);
+        success(data, 'ado', 'repo-update-pr', start);
+      } catch (err) { fail(err, 'ado', 'repo-update-pr', start); }
+    });
+
+  repo
+    .command('merge-pr')
+    .description('Complete (merge) a pull request')
+    .requiredOption('--id <n>', 'Pull request ID')
+    .option('--strategy <s>', 'Merge strategy: noFastForward|squash|rebase|rebaseMerge', 'noFastForward')
+    .option('--delete-source', 'Delete source branch after merge')
+    .action(async (opts: { id: string; strategy: string; deleteSource?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const prId = parseInt(opts.id, 10);
+        const pr = await gitClient.getPR(collection, project, repo, prId);
+        const data = await gitClient.completePR(
+          collection, project, repo, prId,
+          pr.lastMergeSourceCommit?.commitId ?? '',
+          {
+            mergeStrategy: opts.strategy as 'noFastForward' | 'squash' | 'rebase' | 'rebaseMerge',
+            deleteSourceBranch: opts.deleteSource ?? false
+          }
+        );
+        success(data, 'ado', 'repo-merge-pr', start);
+      } catch (err) { fail(err, 'ado', 'repo-merge-pr', start); }
+    });
+
+  repo
+    .command('abandon-pr')
+    .description('Abandon a pull request')
+    .requiredOption('--id <n>', 'Pull request ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.abandonPR(collection, project, repo, parseInt(opts.id, 10));
+        success(data, 'ado', 'repo-abandon-pr', start);
+      } catch (err) { fail(err, 'ado', 'repo-abandon-pr', start); }
+    });
+
+  // ── Comments (threads) ────────────────────────────────────────────
+
+  repo
+    .command('list-comments')
+    .description('List all comments on a pull request (general + inline)')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .option('--inline-only', 'Return only inline file comments')
+    .option('--general-only', 'Return only general PR comments')
+    .action(async (opts: { pr: string; inlineOnly?: boolean; generalOnly?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const threads = await gitClient.listThreads(collection, project, repo, parseInt(opts.pr, 10));
+        const flat = flattenThreadComments(threads, opts.inlineOnly ?? false, opts.generalOnly ?? false);
+        success(flat, 'ado', 'repo-list-comments', start);
+      } catch (err) { fail(err, 'ado', 'repo-list-comments', start); }
+    });
+
+  repo
+    .command('add-comment')
+    .description('Add a general comment to a pull request')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .requiredOption('--body <text>', 'Comment text')
+    .action(async (opts: { pr: string; body: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.createThread(collection, project, repo, parseInt(opts.pr, 10), {
+          comments: [{ content: opts.body, commentType: 'text' }],
+          status: 'active'
+        });
+        success(data, 'ado', 'repo-add-comment', start);
+      } catch (err) { fail(err, 'ado', 'repo-add-comment', start); }
+    });
+
+  repo
+    .command('add-inline-comment')
+    .description('Add an inline comment on a file in a pull request')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .requiredOption('--file <path>', 'File path')
+    .requiredOption('--line <n>', 'Line number')
+    .requiredOption('--body <text>', 'Comment text')
+    .option('--line-type <side>', 'Line side: left|right (default: right)', 'right')
+    .action(async (opts: { pr: string; file: string; line: string; body: string; lineType: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const lineNum = parseInt(opts.line, 10);
+        const isRight = opts.lineType !== 'left';
+        const lineRange = isRight
+          ? { rightFileStart: { line: lineNum, offset: 1 }, rightFileEnd: { line: lineNum, offset: 1 } }
+          : { leftFileStart: { line: lineNum, offset: 1 }, leftFileEnd: { line: lineNum, offset: 1 } };
+        const data = await gitClient.createThread(collection, project, repo, parseInt(opts.pr, 10), {
+          comments: [{ content: opts.body, commentType: 'text' }],
+          status: 'active',
+          threadContext: { filePath: opts.file, ...lineRange }
+        });
+        success(data, 'ado', 'repo-add-inline-comment', start);
+      } catch (err) { fail(err, 'ado', 'repo-add-inline-comment', start); }
+    });
+
+  repo
+    .command('reply-comment')
+    .description('Reply to a comment thread')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .requiredOption('--thread-id <id>', 'Thread ID')
+    .requiredOption('--body <text>', 'Reply text')
+    .action(async (opts: { pr: string; threadId: string; body: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.addCommentToThread(
+          collection, project, repo,
+          parseInt(opts.pr, 10), parseInt(opts.threadId, 10), opts.body
+        );
+        success(data, 'ado', 'repo-reply-comment', start);
+      } catch (err) { fail(err, 'ado', 'repo-reply-comment', start); }
+    });
+
+  repo
+    .command('resolve-comment')
+    .description('Mark a comment thread as resolved (fixed)')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .requiredOption('--thread-id <id>', 'Thread ID')
+    .action(async (opts: { pr: string; threadId: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.updateThread(
+          collection, project, repo,
+          parseInt(opts.pr, 10), parseInt(opts.threadId, 10), 'fixed'
+        );
+        success(data, 'ado', 'repo-resolve-comment', start);
+      } catch (err) { fail(err, 'ado', 'repo-resolve-comment', start); }
+    });
+
+  repo
+    .command('delete-comment')
+    .description('Delete a comment from a thread')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .requiredOption('--thread-id <id>', 'Thread ID')
+    .requiredOption('--comment-id <id>', 'Comment ID')
+    .action(async (opts: { pr: string; threadId: string; commentId: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        await gitClient.deleteComment(
+          collection, project, repo,
+          parseInt(opts.pr, 10), parseInt(opts.threadId, 10), parseInt(opts.commentId, 10)
+        );
+        success({ deleted: true }, 'ado', 'repo-delete-comment', start);
+      } catch (err) { fail(err, 'ado', 'repo-delete-comment', start); }
+    });
+
+  // ── Files ─────────────────────────────────────────────────────────
+
+  repo
+    .command('list-files')
+    .description('List files changed in a pull request')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .action(async (opts: { pr: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.listPRChanges(collection, project, repo, parseInt(opts.pr, 10));
+        success(data, 'ado', 'repo-list-files', start);
+      } catch (err) { fail(err, 'ado', 'repo-list-files', start); }
+    });
+
+  // ── Reviewers / Votes ─────────────────────────────────────────────
+
+  repo
+    .command('list-reviewers')
+    .description('List reviewers on a pull request')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .action(async (opts: { pr: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+        const data = await gitClient.listReviewers(collection, project, repo, parseInt(opts.pr, 10));
+        success(data, 'ado', 'repo-list-reviewers', start);
+      } catch (err) { fail(err, 'ado', 'repo-list-reviewers', start); }
+    });
+
+  const voteCmd = (
+    name: string,
+    description: string,
+    vote: number,
+    action: string
+  ) => {
+    repo
+      .command(name)
+      .description(description)
+      .requiredOption('--pr <n>', 'Pull request ID')
+      .action(async (opts: { pr: string }) => {
+        const start = Date.now();
+        try {
+          const globalOpts = ado.optsWithGlobals();
+          const { loadConfig: lc } = await import('../../../lib/config.js');
+          const config = lc({ configPath: globalOpts.config });
+          const { collection, project, repo, gitClient } = getAdoContext(ado, true);
+          // Self-identity: use connection data
+          const { AdoCoreClient } = await import('../client/core.js');
+          const { createHttpClient } = await import('../../../lib/http.js');
+          const http = createHttpClient(config, Boolean(globalOpts.dryRun));
+          const coreClient = new AdoCoreClient(http);
+          const me = await coreClient.getConnectionData(collection);
+          const myId = me.authenticatedUser.id;
+          const data = await gitClient.setPRVote(collection, project, repo, parseInt(opts.pr, 10), myId, vote);
+          success(data, 'ado', action, start);
+        } catch (err) { fail(err, 'ado', action, start); }
+      });
+  };
+
+  voteCmd('approve', 'Approve a pull request', PR_VOTE.APPROVE, 'repo-approve');
+  voteCmd('unapprove', 'Remove approval from a pull request', PR_VOTE.NO_VOTE, 'repo-unapprove');
+  voteCmd('wait-for-author', 'Mark a pull request as waiting for author', PR_VOTE.WAIT_FOR_AUTHOR, 'repo-wait-for-author');
+
+  // ── Builds for PR ─────────────────────────────────────────────────
+
+  repo
+    .command('list-builds')
+    .description('List builds associated with a pull request')
+    .requiredOption('--pr <n>', 'Pull request ID')
+    .action(async (opts: { pr: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, repo, gitClient, buildClient } = getAdoContext(ado, true);
+        const pr = await gitClient.getPR(collection, project, repo, parseInt(opts.pr, 10));
+        const data = await buildClient.listBuilds(collection, project, {
+          branchName: pr.sourceRefName
+        });
+        success(data, 'ado', 'repo-list-builds', start);
+      } catch (err) { fail(err, 'ado', 'repo-list-builds', start); }
+    });
+}

--- a/src/services/ado/commands/work.ts
+++ b/src/services/ado/commands/work.ts
@@ -1,0 +1,257 @@
+import { Command } from 'commander';
+import { getAdoContext, fieldArgsToPatch } from '../helpers.js';
+import { discoverFields, discoverTypes, buildDefaultAliases } from '../discovery.js';
+import { success, fail, warn } from '../../../lib/output.js';
+import { loadConfig, getGlobalConfigPath } from '../../../lib/config.js';
+
+export function registerAdoWorkCommands(ado: Command): void {
+  const work = ado
+    .command('work')
+    .description('Azure DevOps work item operations');
+
+  // ── Get ───────────────────────────────────────────────────────────
+
+  work
+    .command('get')
+    .description('Get a work item by ID')
+    .requiredOption('--id <n>', 'Work item ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, workClient } = getAdoContext(ado);
+        const data = await workClient.getWorkItem(collection, parseInt(opts.id, 10));
+        success(data, 'ado', 'work-get', start);
+      } catch (err) { fail(err, 'ado', 'work-get', start); }
+    });
+
+  // ── Create ────────────────────────────────────────────────────────
+
+  work
+    .command('create')
+    .description('Create a work item')
+    .requiredOption('--type <type>', 'Work item type (e.g. Bug, Task, User Story)')
+    .requiredOption('--title <title>', 'Work item title')
+    .option('--description <text>', 'Description')
+    .option('--assignee <user>', 'Assigned to (display name or email)')
+    .option('--priority <n>', 'Priority (1-4)')
+    .option('--field <name=value>', 'Additional field (repeatable)', (v: string, acc: string[]) => { acc.push(v); return acc; }, [] as string[])
+    .action(async (opts: { type: string; title: string; description?: string; assignee?: string; priority?: string; field: string[] }) => {
+      const start = Date.now();
+      try {
+        const globalOpts = ado.optsWithGlobals();
+        const config = loadConfig({ configPath: globalOpts.config });
+        const { collection, project, workClient } = getAdoContext(ado);
+        const builtIn: Record<string, string> = {
+          'System.Title': opts.title,
+          ...(opts.description ? { 'System.Description': opts.description } : {}),
+          ...(opts.assignee ? { 'System.AssignedTo': opts.assignee } : {}),
+          ...(opts.priority ? { 'Microsoft.VSTS.Common.Priority': opts.priority } : {})
+        };
+        const extra = fieldArgsToPatch(opts.field, config.ado.fieldAliases);
+        const patch = [
+          ...Object.entries(builtIn).map(([k, v]) => ({ op: 'add' as const, path: `/fields/${k}`, value: v })),
+          ...extra
+        ];
+        const data = await workClient.createWorkItem(collection, project, opts.type, patch);
+        success(data, 'ado', 'work-create', start);
+      } catch (err) { fail(err, 'ado', 'work-create', start); }
+    });
+
+  // ── Update ────────────────────────────────────────────────────────
+
+  work
+    .command('update')
+    .description('Update a work item field')
+    .requiredOption('--id <n>', 'Work item ID')
+    .option('--field <name=value>', 'Field to update (repeatable)', (v: string, acc: string[]) => { acc.push(v); return acc; }, [] as string[])
+    .action(async (opts: { id: string; field: string[] }) => {
+      const start = Date.now();
+      try {
+        const globalOpts = ado.optsWithGlobals();
+        const config = loadConfig({ configPath: globalOpts.config });
+        const { collection, workClient } = getAdoContext(ado);
+        const patch = fieldArgsToPatch(opts.field, config.ado.fieldAliases);
+        const data = await workClient.updateWorkItem(collection, parseInt(opts.id, 10), patch);
+        success(data, 'ado', 'work-update', start);
+      } catch (err) { fail(err, 'ado', 'work-update', start); }
+    });
+
+  // ── Transition (wrapper over update for System.State) ─────────────
+
+  work
+    .command('transition')
+    .description('Set the state of a work item')
+    .requiredOption('--id <n>', 'Work item ID')
+    .requiredOption('--state <state>', 'New state (e.g. Active, Resolved, Closed)')
+    .action(async (opts: { id: string; state: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, workClient } = getAdoContext(ado);
+        const patch = [{ op: 'add' as const, path: '/fields/System.State', value: opts.state }];
+        const data = await workClient.updateWorkItem(collection, parseInt(opts.id, 10), patch);
+        success(data, 'ado', 'work-transition', start);
+      } catch (err) { fail(err, 'ado', 'work-transition', start); }
+    });
+
+  // ── Assign ────────────────────────────────────────────────────────
+
+  work
+    .command('assign')
+    .description('Assign a work item to a user')
+    .requiredOption('--id <n>', 'Work item ID')
+    .requiredOption('--to <user>', 'User display name or email')
+    .action(async (opts: { id: string; to: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, workClient } = getAdoContext(ado);
+        const patch = [{ op: 'add' as const, path: '/fields/System.AssignedTo', value: opts.to }];
+        const data = await workClient.updateWorkItem(collection, parseInt(opts.id, 10), patch);
+        success(data, 'ado', 'work-assign', start);
+      } catch (err) { fail(err, 'ado', 'work-assign', start); }
+    });
+
+  // ── Link ──────────────────────────────────────────────────────────
+
+  work
+    .command('link')
+    .description('Link two work items')
+    .requiredOption('--id <a>', 'Source work item ID')
+    .requiredOption('--to <b>', 'Target work item ID')
+    .option('--type <rel>', 'Link type (related|parent|child|duplicate|duplicate-of)', 'related')
+    .action(async (opts: { id: string; to: string; type: string }) => {
+      const start = Date.now();
+      try {
+        const globalOpts = ado.optsWithGlobals();
+        const config = loadConfig({ configPath: globalOpts.config });
+        const { collection, workClient } = getAdoContext(ado);
+        // AzDO rel strings
+        const relMap: Record<string, string> = {
+          related: 'System.LinkTypes.Related',
+          parent: 'System.LinkTypes.Hierarchy-Reverse',
+          child: 'System.LinkTypes.Hierarchy-Forward',
+          duplicate: 'System.LinkTypes.Duplicate-Forward',
+          'duplicate-of': 'System.LinkTypes.Duplicate-Reverse'
+        };
+        const rel = relMap[opts.type] ?? opts.type;
+        const baseUrl = config.ado.baseUrl?.replace(/\/$/, '');
+        const targetUrl = `${baseUrl}/${encodeURIComponent(collection)}/_apis/wit/workitems/${opts.to}`;
+        const patch = [{ op: 'add' as const, path: '/relations/-', value: { rel, url: targetUrl } }];
+        const data = await workClient.updateWorkItem(collection, parseInt(opts.id, 10), patch);
+        success(data, 'ado', 'work-link', start);
+      } catch (err) { fail(err, 'ado', 'work-link', start); }
+    });
+
+  // ── Search ────────────────────────────────────────────────────────
+
+  work
+    .command('search')
+    .description('Run a WIQL query')
+    .requiredOption('--wiql <query>', 'WIQL query string')
+    .action(async (opts: { wiql: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const data = await workClient.queryWiql(collection, project, opts.wiql);
+        success(data, 'ado', 'work-search', start);
+      } catch (err) { fail(err, 'ado', 'work-search', start); }
+    });
+
+  // ── Comments ──────────────────────────────────────────────────────
+
+  work
+    .command('list-comments')
+    .description('List comments on a work item')
+    .requiredOption('--id <n>', 'Work item ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const data = await workClient.listComments(collection, project, parseInt(opts.id, 10));
+        success(data, 'ado', 'work-list-comments', start);
+      } catch (err) { fail(err, 'ado', 'work-list-comments', start); }
+    });
+
+  work
+    .command('add-comment')
+    .description('Add a comment to a work item')
+    .requiredOption('--id <n>', 'Work item ID')
+    .requiredOption('--body <text>', 'Comment text')
+    .action(async (opts: { id: string; body: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const data = await workClient.addComment(collection, project, parseInt(opts.id, 10), opts.body);
+        success(data, 'ado', 'work-add-comment', start);
+      } catch (err) { fail(err, 'ado', 'work-add-comment', start); }
+    });
+
+  // ── Type / Field discovery ────────────────────────────────────────
+
+  work
+    .command('types')
+    .description('List work item types in the project')
+    .option('--discover', 'Fetch from server (always true for this command)')
+    .option('--save', 'Save discovered types to ~/.pncli/config.json')
+    .action(async (opts: { save?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const globalOpts = ado.optsWithGlobals();
+        const types = await discoverTypes(workClient, collection, project);
+        if (opts.save) {
+          const globalConfigPath = getGlobalConfigPath(globalOpts.config);
+          const fs = await import('fs');
+          const existing = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8') || '{}');
+          existing.ado = { ...(existing.ado ?? {}), discoveredTypes: types };
+          fs.writeFileSync(globalConfigPath, JSON.stringify(existing, null, 2) + '\n', 'utf8');
+          warn(`Saved ${types.length} types to ${globalConfigPath}`);
+        }
+        success(types, 'ado', 'work-types', start);
+      } catch (err) { fail(err, 'ado', 'work-types', start); }
+    });
+
+  work
+    .command('list-states')
+    .description('List valid states for a work item type')
+    .requiredOption('--type <type>', 'Work item type name (e.g. Bug)')
+    .action(async (opts: { type: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const data = await workClient.listTypeStates(collection, project, opts.type);
+        success(data, 'ado', 'work-list-states', start);
+      } catch (err) { fail(err, 'ado', 'work-list-states', start); }
+    });
+
+  work
+    .command('fields')
+    .description('List work item fields available in the collection')
+    .option('--type <type>', 'Scope to a specific work item type')
+    .option('--custom-only', 'Exclude System.* and Microsoft.VSTS.* fields')
+    .option('--discover', 'Fetch from server (always true for this command)')
+    .option('--save', 'Save discovered fields and aliases to ~/.pncli/config.json')
+    .action(async (opts: { type?: string; customOnly?: boolean; save?: boolean }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const globalOpts = ado.optsWithGlobals();
+        let fields = await discoverFields(workClient, collection, opts.type ? project : undefined);
+        if (opts.customOnly) {
+          fields = fields.filter(f =>
+            !f.referenceName.startsWith('System.') &&
+            !f.referenceName.startsWith('Microsoft.VSTS.')
+          );
+        }
+        if (opts.save) {
+          const globalConfigPath = getGlobalConfigPath(globalOpts.config);
+          const fs = await import('fs');
+          const existing = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8') || '{}');
+          const aliases = buildDefaultAliases(fields);
+          existing.ado = { ...(existing.ado ?? {}), discoveredFields: fields, fieldAliases: aliases };
+          fs.writeFileSync(globalConfigPath, JSON.stringify(existing, null, 2) + '\n', 'utf8');
+          warn(`Saved ${fields.length} fields and ${Object.keys(aliases).length} aliases to ${globalConfigPath}`);
+        }
+        success(fields, 'ado', 'work-fields', start);
+      } catch (err) { fail(err, 'ado', 'work-fields', start); }
+    });
+}

--- a/src/services/ado/commands/work.ts
+++ b/src/services/ado/commands/work.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { getAdoContext, fieldArgsToPatch } from '../helpers.js';
-import { discoverFields, discoverTypes, buildDefaultAliases } from '../discovery.js';
+import { discoverFields, discoverTypeFields, discoverTypes, buildDefaultAliases } from '../discovery.js';
 import { success, fail, warn } from '../../../lib/output.js';
 import { loadConfig, getGlobalConfigPath } from '../../../lib/config.js';
 
@@ -226,7 +226,7 @@ export function registerAdoWorkCommands(ado: Command): void {
   work
     .command('fields')
     .description('List work item fields available in the collection')
-    .option('--type <type>', 'Scope to a specific work item type')
+    .option('--type <type>', 'Scope to fields for a specific work item type (e.g. Bug)')
     .option('--custom-only', 'Exclude System.* and Microsoft.VSTS.* fields')
     .option('--discover', 'Fetch from server (always true for this command)')
     .option('--save', 'Save discovered fields and aliases to ~/.pncli/config.json')
@@ -235,21 +235,26 @@ export function registerAdoWorkCommands(ado: Command): void {
       try {
         const { collection, project, workClient } = getAdoContext(ado);
         const globalOpts = ado.optsWithGlobals();
-        let fields = await discoverFields(workClient, collection, opts.type ? project : undefined);
-        if (opts.customOnly) {
-          fields = fields.filter(f =>
-            !f.referenceName.startsWith('System.') &&
-            !f.referenceName.startsWith('Microsoft.VSTS.')
-          );
-        }
+        // Fetch full field list (used for alias generation and --save)
+        const allFields = opts.type
+          ? await discoverTypeFields(workClient, collection, project, opts.type)
+          : await discoverFields(workClient, collection);
+        // Apply --custom-only filter only to displayed/saved output
+        const fields = opts.customOnly
+          ? allFields.filter(f =>
+              !f.referenceName.startsWith('System.') &&
+              !f.referenceName.startsWith('Microsoft.VSTS.')
+            )
+          : allFields;
         if (opts.save) {
           const globalConfigPath = getGlobalConfigPath(globalOpts.config);
           const fs = await import('fs');
           const existing = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8') || '{}');
-          const aliases = buildDefaultAliases(fields);
-          existing.ado = { ...(existing.ado ?? {}), discoveredFields: fields, fieldAliases: aliases };
+          // Generate aliases from the full (unfiltered) set so System/VSTS aliases are included
+          const aliases = buildDefaultAliases(allFields);
+          existing.ado = { ...(existing.ado ?? {}), discoveredFields: allFields, fieldAliases: aliases };
           fs.writeFileSync(globalConfigPath, JSON.stringify(existing, null, 2) + '\n', 'utf8');
-          warn(`Saved ${fields.length} fields and ${Object.keys(aliases).length} aliases to ${globalConfigPath}`);
+          warn(`Saved ${allFields.length} fields and ${Object.keys(aliases).length} aliases to ${globalConfigPath}`);
         }
         success(fields, 'ado', 'work-fields', start);
       } catch (err) { fail(err, 'ado', 'work-fields', start); }

--- a/src/services/ado/discovery.ts
+++ b/src/services/ado/discovery.ts
@@ -1,0 +1,85 @@
+import type { AdoWorkClient } from './client/work.js';
+import type { AdoFieldMeta, AdoWorkItemTypeMeta } from '../../types/config.js';
+
+/**
+ * Discovers all work item fields in the collection and maps them to AdoFieldMeta.
+ */
+export async function discoverFields(
+  client: AdoWorkClient,
+  collection: string,
+  project?: string
+): Promise<AdoFieldMeta[]> {
+  const fields = await client.listFields(collection, project);
+  return fields.map(f => ({
+    referenceName: f.referenceName,
+    name: f.name,
+    type: f.type,
+    readOnly: f.readOnly,
+    ...(f.picklistId ? { picklistId: f.picklistId } : {})
+  }));
+}
+
+/**
+ * Discovers all work item types and their valid states per type.
+ */
+export async function discoverTypes(
+  client: AdoWorkClient,
+  collection: string,
+  project: string
+): Promise<AdoWorkItemTypeMeta[]> {
+  const types = await client.listWorkItemTypes(collection, project);
+  const result: AdoWorkItemTypeMeta[] = [];
+
+  for (const t of types) {
+    const states = await client.listTypeStates(collection, project, t.name);
+    const requiredFields = (t.fields ?? [])
+      .filter(f => f.alwaysRequired)
+      .map(f => f.referenceName);
+    result.push({
+      name: t.name,
+      states: states.map(s => s.name),
+      requiredFields
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Generates a default alias map for the most common field reference names.
+ * Only includes aliases for fields actually present in the discovered set.
+ */
+export function buildDefaultAliases(fields: AdoFieldMeta[]): Record<string, string> {
+  const refNames = new Set(fields.map(f => f.referenceName));
+
+  const candidates: Array<[string, string]> = [
+    ['title',         'System.Title'],
+    ['state',         'System.State'],
+    ['assignedto',    'System.AssignedTo'],
+    ['assigned-to',   'System.AssignedTo'],
+    ['description',   'System.Description'],
+    ['areapath',      'System.AreaPath'],
+    ['area-path',     'System.AreaPath'],
+    ['iterationpath', 'System.IterationPath'],
+    ['iteration',     'System.IterationPath'],
+    ['tags',          'System.Tags'],
+    ['priority',      'Microsoft.VSTS.Common.Priority'],
+    ['severity',      'Microsoft.VSTS.Common.Severity'],
+    ['effort',        'Microsoft.VSTS.Scheduling.Effort'],
+    ['storypoints',   'Microsoft.VSTS.Scheduling.StoryPoints'],
+    ['story-points',  'Microsoft.VSTS.Scheduling.StoryPoints'],
+    ['remainingwork', 'Microsoft.VSTS.Scheduling.RemainingWork'],
+    ['remaining',     'Microsoft.VSTS.Scheduling.RemainingWork'],
+    ['acceptancecriteria', 'Microsoft.VSTS.Common.AcceptanceCriteria'],
+    ['reprosteps',    'Microsoft.VSTS.TCM.ReproSteps'],
+    ['foundinsource', 'Microsoft.VSTS.Build.FoundIn']
+  ];
+
+  const aliases: Record<string, string> = {};
+  for (const [alias, ref] of candidates) {
+    if (refNames.has(ref)) {
+      aliases[alias] = ref;
+    }
+  }
+  return aliases;
+}

--- a/src/services/ado/discovery.ts
+++ b/src/services/ado/discovery.ts
@@ -10,13 +10,30 @@ export async function discoverFields(
   project?: string
 ): Promise<AdoFieldMeta[]> {
   const fields = await client.listFields(collection, project);
-  return fields.map(f => ({
+  return fields.map(toFieldMeta);
+}
+
+/**
+ * Discovers fields scoped to a specific work item type.
+ */
+export async function discoverTypeFields(
+  client: AdoWorkClient,
+  collection: string,
+  project: string,
+  type: string
+): Promise<AdoFieldMeta[]> {
+  const fields = await client.listTypeFields(collection, project, type);
+  return fields.map(toFieldMeta);
+}
+
+function toFieldMeta(f: { referenceName: string; name: string; type: string; readOnly?: boolean; picklistId?: string }): AdoFieldMeta {
+  return {
     referenceName: f.referenceName,
     name: f.name,
     type: f.type,
     readOnly: f.readOnly,
     ...(f.picklistId ? { picklistId: f.picklistId } : {})
-  }));
+  };
 }
 
 /**

--- a/src/services/ado/helpers.ts
+++ b/src/services/ado/helpers.ts
@@ -82,7 +82,7 @@ export function getAdoContext(program: Command, requireRepo = false): AdoContext
 
 /**
  * Parses repeated --field name=value arguments into a Record.
- * Accepts both "name=value" (split on first =) and paired [name, value] arrays.
+ * Accepts "name=value" strings (split on first =). Throws on missing `=`.
  */
 export function parseFieldArgs(fields: string[]): Record<string, string> {
   const result: Record<string, string> = {};

--- a/src/services/ado/helpers.ts
+++ b/src/services/ado/helpers.ts
@@ -1,0 +1,167 @@
+import { Command } from 'commander';
+import { loadConfig } from '../../lib/config.js';
+import { createHttpClient } from '../../lib/http.js';
+import { getGitContext } from '../../lib/git-context.js';
+import { PncliError } from '../../lib/errors.js';
+import { log } from '../../lib/output.js';
+import { AdoCoreClient } from './client/core.js';
+import { AdoWorkClient } from './client/work.js';
+import { AdoGitClient } from './client/git.js';
+import { AdoBuildClient } from './client/build.js';
+import type { JsonPatchOp } from './client/work.js';
+import type { AdoBuild } from '../../types/ado.js';
+
+export interface AdoContext {
+  collection: string;
+  project: string;
+  repo: string;
+  coreClient: AdoCoreClient;
+  workClient: AdoWorkClient;
+  gitClient: AdoGitClient;
+  buildClient: AdoBuildClient;
+}
+
+/**
+ * Resolves ADO (collection, project, repo) from CLI flags → git remote → config defaults.
+ * Mirrors the getClient() helper in bitbucket/commands.ts.
+ */
+export function getAdoContext(program: Command, requireRepo = false): AdoContext {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config });
+  const http = createHttpClient(config, Boolean(opts.dryRun));
+  const ctx = getGitContext(config);
+
+  const collection: string =
+    opts.collection ?? opts.organization ??
+    ctx?.ado?.collection ??
+    config.defaults.ado?.collection ?? '';
+
+  const project: string =
+    opts.project ??
+    ctx?.ado?.project ??
+    config.defaults.ado?.project ?? '';
+
+  const repo: string =
+    opts.repo ??
+    ctx?.ado?.repo ??
+    config.defaults.ado?.repo ?? '';
+
+  if (!collection) {
+    throw new PncliError(
+      'Could not determine Azure DevOps collection. Pass --collection, or run pncli config init.',
+      1
+    );
+  }
+
+  if (!project) {
+    throw new PncliError(
+      'Could not determine Azure DevOps project. Pass --project, or run pncli config init.',
+      1
+    );
+  }
+
+  if (requireRepo && !repo) {
+    throw new PncliError(
+      'Could not determine Azure DevOps repo. Pass --repo, or run from inside a checked-out ADO repo.',
+      1
+    );
+  }
+
+  return {
+    collection,
+    project,
+    repo,
+    coreClient: new AdoCoreClient(http),
+    workClient: new AdoWorkClient(http),
+    gitClient: new AdoGitClient(http),
+    buildClient: new AdoBuildClient(http)
+  };
+}
+
+// ── Field helpers ─────────────────────────────────────────────────────
+
+/**
+ * Parses repeated --field name=value arguments into a Record.
+ * Accepts both "name=value" (split on first =) and paired [name, value] arrays.
+ */
+export function parseFieldArgs(fields: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const f of fields) {
+    const eq = f.indexOf('=');
+    if (eq <= 0) throw new PncliError(`Invalid --field value "${f}". Expected format: name=value`, 1);
+    result[f.slice(0, eq)] = f.slice(eq + 1);
+  }
+  return result;
+}
+
+/**
+ * Resolves field keys against the loaded alias map, then builds JSON Patch ops.
+ * If a key is in fieldAliases → use the reference name. Otherwise use the key as-is.
+ */
+export function buildFieldPatch(
+  fields: Record<string, string>,
+  fieldAliases: Record<string, string>
+): JsonPatchOp[] {
+  return Object.entries(fields).map(([key, value]) => {
+    const refName = fieldAliases[key.toLowerCase()] ?? fieldAliases[key] ?? key;
+    return { op: 'add' as const, path: `/fields/${refName}`, value };
+  });
+}
+
+/** Convenience: parse --field args and immediately build the patch ops. */
+export function fieldArgsToPatch(
+  fieldArgs: string[],
+  fieldAliases: Record<string, string>
+): JsonPatchOp[] {
+  return buildFieldPatch(parseFieldArgs(fieldArgs), fieldAliases);
+}
+
+// ── Vote constants ────────────────────────────────────────────────────
+
+export const PR_VOTE = {
+  APPROVE: 10,
+  APPROVE_WITH_SUGGESTIONS: 5,
+  NO_VOTE: 0,
+  WAIT_FOR_AUTHOR: -5,
+  REJECT: -10
+} as const;
+
+// ── Build polling ─────────────────────────────────────────────────────
+
+const TERMINAL_STATUSES = new Set(['completed']);
+
+export function isBuildTerminal(build: AdoBuild): boolean {
+  return TERMINAL_STATUSES.has(build.status);
+}
+
+export interface PollOpts {
+  timeoutSec: number;
+  pollSec: number;
+}
+
+/**
+ * Polls fetchStatus() until isTerminal() returns true or timeout is reached.
+ * Progress lines emitted via log() (verbose-only stderr); stdout stays clean.
+ */
+export async function pollUntilTerminal<T>(
+  fetchStatus: () => Promise<T>,
+  isTerminal: (s: T) => boolean,
+  opts: PollOpts
+): Promise<T> {
+  const deadline = Date.now() + opts.timeoutSec * 1000;
+  let status = await fetchStatus();
+
+  while (!isTerminal(status)) {
+    if (Date.now() >= deadline) {
+      throw new PncliError(
+        `Timed out waiting for completion after ${opts.timeoutSec}s`,
+        1
+      );
+    }
+    log(`Waiting ${opts.pollSec}s...`);
+    await new Promise(resolve => setTimeout(resolve, opts.pollSec * 1000));
+    status = await fetchStatus();
+  }
+
+  return status;
+}

--- a/src/services/bitbucket/client.ts
+++ b/src/services/bitbucket/client.ts
@@ -141,7 +141,14 @@ export class BitbucketClient {
     );
   }
 
-  async listComments(project: string, repo: string, prId: number): Promise<BitbucketComment[]> {
+  async listComments(
+    project: string,
+    repo: string,
+    prId: number,
+    opts: { withReplies?: boolean; inlineOnly?: boolean; generalOnly?: boolean } = {}
+  ): Promise<BitbucketComment[]> {
+    const { withReplies = true, inlineOnly = false, generalOnly = false } = opts;
+
     interface Activity { action: string; comment?: BitbucketComment }
     const activities = await this.http.paginate<Activity>((start, limit) =>
       this.http.bitbucket<BitbucketPageResponse<Activity>>(
@@ -149,9 +156,33 @@ export class BitbucketClient {
         { params: { start, limit } }
       )
     );
-    return activities
+
+    const topLevel = activities
       .filter(a => a.action === 'COMMENTED' && a.comment)
       .map(a => a.comment!);
+
+    if (!withReplies) {
+      return topLevel
+        .filter(c => !inlineOnly || !!c.anchor)
+        .filter(c => !generalOnly || !c.anchor);
+    }
+
+    // Recursively flatten nested replies, tagging each with its parentId
+    function flatten(comment: BitbucketComment, parentId?: number): BitbucketComment[] {
+      const node: BitbucketComment = {
+        ...comment,
+        comments: undefined,
+        ...(parentId !== undefined ? { parentId } : {})
+      };
+      const replies = (comment.comments ?? []).flatMap(c => flatten(c, comment.id));
+      return [node, ...replies];
+    }
+
+    const flat = topLevel.flatMap(c => flatten(c));
+    return flat
+      .filter(c => !inlineOnly || !!c.anchor)
+      .filter(c => !generalOnly || !c.anchor)
+      .sort((a, b) => a.createdDate - b.createdDate);
   }
 
   async addComment(project: string, repo: string, prId: number, text: string): Promise<BitbucketComment> {

--- a/src/services/bitbucket/commands.ts
+++ b/src/services/bitbucket/commands.ts
@@ -131,13 +131,20 @@ export function registerBitbucketCommands(program: Command): void {
   // ── Comments ───────────────────────────────────────────────────────
 
   bb.command('list-comments')
-    .description('List comments on a pull request')
+    .description('List comments on a pull request (includes threaded replies by default)')
     .requiredOption('--pr <pr-id>', 'Pull request ID')
-    .action(async (opts: { pr: string }) => {
+    .option('--no-with-replies', 'Exclude replies; return top-level comments only')
+    .option('--inline-only', 'Return only inline file comments')
+    .option('--general-only', 'Return only general (non-inline) PR comments')
+    .action(async (opts: { pr: string; withReplies: boolean; inlineOnly?: boolean; generalOnly?: boolean }) => {
       const start = Date.now();
       try {
         const { client, project, repo } = getClient(program);
-        const data = await client.listComments(project, repo, parseInt(opts.pr, 10));
+        const data = await client.listComments(project, repo, parseInt(opts.pr, 10), {
+          withReplies: opts.withReplies,
+          inlineOnly: opts.inlineOnly,
+          generalOnly: opts.generalOnly
+        });
         success(data, 'bitbucket', 'list-comments', start);
       } catch (err) { fail(err, 'bitbucket', 'list-comments', start); }
     });

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -9,6 +9,9 @@ import {
   getGlobalConfigPath
 } from '../../lib/config.js';
 import { createHttpClient } from '../../lib/http.js';
+import { AdoCoreClient } from '../ado/client/core.js';
+import { AdoWorkClient } from '../ado/client/work.js';
+import { discoverFields, discoverTypes, buildDefaultAliases } from '../ado/discovery.js';
 import { success, fail, warn } from '../../lib/output.js';
 import { ExitCode } from '../../lib/exitCodes.js';
 import fs from 'fs';
@@ -134,6 +137,21 @@ export function registerConfigCommands(program: Command): void {
           }
         } else {
           results.sde = { ok: null, message: 'not configured' };
+        }
+
+        if (cfg.ado.baseUrl) {
+          try {
+            const collection = cfg.defaults.ado?.collection;
+            const path = collection
+              ? `/${encodeURIComponent(collection)}/_apis/connectionData?api-version=7.1`
+              : '/_apis/projectCollections?api-version=7.1';
+            await http.ado<unknown>(path);
+            results.ado = { ok: true, message: 'connected' };
+          } catch (err) {
+            results.ado = { ok: false, message: err instanceof Error ? err.message : String(err) };
+          }
+        } else {
+          results.ado = { ok: null, message: 'not configured' };
         }
 
         success(results, 'config', 'test', start);
@@ -284,6 +302,98 @@ async function initGlobalConfig(start: number): Promise<void> {
     }
   }
 
+  process.stderr.write('\n── Azure DevOps Server ───────────────────────────\n');
+  const useAdo = await confirm({
+    message: 'Configure Azure DevOps Server for work items, repos, and pipelines?',
+    default: false
+  });
+
+  let adoBaseUrl = '';
+  let adoPat = '';
+  let adoCollection = '';
+  let adoProject = '';
+  let adoFieldAliases: Record<string, string> = {};
+  let adoDiscoveredFields: import('../../types/config.js').AdoFieldMeta[] = [];
+  let adoDiscoveredTypes: import('../../types/config.js').AdoWorkItemTypeMeta[] = [];
+
+  if (useAdo) {
+    adoBaseUrl = await input({
+      message: 'Azure DevOps Server base URL (e.g. https://tfs.company.com or https://devops.company.com/tfs):',
+      default: ''
+    });
+
+    const useWindowsAuth = await confirm({
+      message: 'Use Windows Integrated Authentication (current logged-in user)?',
+      default: process.platform === 'win32'
+    });
+
+    if (!useWindowsAuth) {
+      adoPat = await password({
+        message: 'Azure DevOps personal access token:'
+      });
+    }
+
+    adoCollection = await input({
+      message: 'Default collection name (e.g. DefaultCollection):',
+      default: ''
+    });
+
+    adoProject = await input({
+      message: 'Default team project name:',
+      default: ''
+    });
+
+    // Validate connectivity before asking discovery questions
+    if (adoBaseUrl && adoCollection) {
+      process.stderr.write('\n  Verifying connection...\n');
+      try {
+        const tempConfig = {
+          ...loadConfig(),
+          ado: {
+            baseUrl: adoBaseUrl,
+            pat: adoPat || undefined,
+            fieldAliases: {},
+            discoveredFields: [],
+            discoveredTypes: []
+          }
+        };
+        const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
+        const tempCore = new AdoCoreClient(tempHttp);
+        await tempCore.getConnectionData(adoCollection);
+        process.stderr.write('  Connected.\n');
+
+        // Optional field/type discovery
+        if (adoProject) {
+          const doDiscover = await confirm({
+            message: 'Discover work item types and fields from this collection now? (recommended)',
+            default: true
+          });
+
+          if (doDiscover) {
+            process.stderr.write('  Fetching work item types and fields...\n');
+            const tempWork = new AdoWorkClient(tempHttp);
+            adoDiscoveredFields = await discoverFields(tempWork, adoCollection);
+            process.stderr.write(`  Found ${adoDiscoveredFields.length} fields.\n`);
+            adoDiscoveredTypes = await discoverTypes(tempWork, adoCollection, adoProject);
+            process.stderr.write(`  Found ${adoDiscoveredTypes.length} work item types.\n`);
+
+            const doAliases = await confirm({
+              message: 'Save friendly aliases for common fields? (e.g. "priority" → reference name)',
+              default: true
+            });
+            if (doAliases) {
+              adoFieldAliases = buildDefaultAliases(adoDiscoveredFields as Parameters<typeof buildDefaultAliases>[0]);
+              process.stderr.write(`  Generated ${Object.keys(adoFieldAliases).length} aliases.\n`);
+            }
+          }
+        }
+      } catch (err) {
+        warn(`Could not connect to Azure DevOps: ${err instanceof Error ? err.message : String(err)}`);
+        warn('Config will be saved anyway. Check your URL and credentials and re-run pncli config init or pncli config test.');
+      }
+    }
+  }
+
   process.stderr.write('\n── Defaults ──────────────────────────────────────\n');
   const jiraProject = await input({
     message: 'Default Jira project key (optional):',
@@ -351,6 +461,15 @@ async function initGlobalConfig(start: number): Promise<void> {
         connection: `${sdeToken}@${sdeBaseUrl}`
       }
     } : {}),
+    ...(useAdo && adoBaseUrl ? {
+      ado: {
+        baseUrl: adoBaseUrl,
+        ...(adoPat ? { pat: adoPat } : {}),
+        ...(Object.keys(adoFieldAliases).length ? { fieldAliases: adoFieldAliases } : {}),
+        ...(adoDiscoveredFields.length ? { discoveredFields: adoDiscoveredFields } : {}),
+        ...(adoDiscoveredTypes.length ? { discoveredTypes: adoDiscoveredTypes } : {})
+      }
+    } : {}),
     defaults: {
       jira: {
         project: jiraProject || undefined
@@ -363,6 +482,12 @@ async function initGlobalConfig(start: number): Promise<void> {
       ...(useSde && sdeProject ? {
         sde: {
           project: sdeProject || undefined
+        }
+      } : {}),
+      ...(useAdo && (adoCollection || adoProject) ? {
+        ado: {
+          collection: adoCollection || undefined,
+          project: adoProject || undefined
         }
       } : {})
     }
@@ -394,6 +519,21 @@ async function initRepoConfig(start: number): Promise<void> {
   const targetBranch = await input({
     message: 'Default target branch for PRs:',
     default: 'main'
+  });
+
+  const adoRepoCollection = await input({
+    message: 'Default Azure DevOps collection for this repo (leave blank to use global):',
+    default: ''
+  });
+
+  const adoRepoProject = await input({
+    message: 'Default Azure DevOps project for this repo (leave blank to use global):',
+    default: ''
+  });
+
+  const adoRepoRepo = await input({
+    message: 'Default Azure DevOps repo name for this repo (leave blank to auto-detect):',
+    default: ''
   });
 
   const confirmed = await confirm({
@@ -429,7 +569,14 @@ async function initRepoConfig(start: number): Promise<void> {
       },
       bitbucket: {
         targetBranch: targetBranch || undefined
-      }
+      },
+      ...(adoRepoCollection || adoRepoProject || adoRepoRepo ? {
+        ado: {
+          collection: adoRepoCollection || undefined,
+          project: adoRepoProject || undefined,
+          repo: adoRepoRepo || undefined
+        }
+      } : {})
     }
   });
 

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -322,16 +322,9 @@ async function initGlobalConfig(start: number): Promise<void> {
       default: ''
     });
 
-    const useWindowsAuth = await confirm({
-      message: 'Use Windows Integrated Authentication (current logged-in user)?',
-      default: process.platform === 'win32'
+    adoPat = await password({
+      message: 'Azure DevOps personal access token:'
     });
-
-    if (!useWindowsAuth) {
-      adoPat = await password({
-        message: 'Azure DevOps personal access token:'
-      });
-    }
 
     adoCollection = await input({
       message: 'Default collection name (e.g. DefaultCollection):',

--- a/src/types/ado.ts
+++ b/src/types/ado.ts
@@ -1,0 +1,303 @@
+// Azure DevOps Server REST API response types (api-version 7.1)
+
+// ── Core ─────────────────────────────────────────────────────────────
+
+export interface AdoConnectionData {
+  authenticatedUser: AdoIdentity;
+  authorizedUser: AdoIdentity;
+  instanceId: string;
+  deploymentType: string;
+  webApplicationRelativeDirectory: string;
+}
+
+export interface AdoIdentity {
+  id: string;
+  providerDisplayName: string;
+  isActive: boolean;
+  properties?: Record<string, unknown>;
+}
+
+export interface AdoProject {
+  id: string;
+  name: string;
+  description?: string;
+  url: string;
+  state: string;
+  revision: number;
+  visibility: string;
+  lastUpdateTime?: string;
+}
+
+export interface AdoProjectCollection {
+  id: string;
+  name: string;
+  url: string;
+  collectionUrl: string;
+  state: string;
+}
+
+// ── Work Items ───────────────────────────────────────────────────────
+
+export interface AdoWorkItem {
+  id: number;
+  rev: number;
+  fields: Record<string, unknown>;
+  relations?: AdoWorkItemRelation[];
+  _links?: Record<string, { href: string }>;
+  url: string;
+}
+
+export interface AdoWorkItemRelation {
+  rel: string;
+  url: string;
+  attributes?: Record<string, unknown>;
+}
+
+export interface AdoWorkItemComment {
+  id: number;
+  workItemId: number;
+  version: number;
+  text: string;
+  createdBy: AdoIdentityRef;
+  createdDate: string;
+  modifiedBy?: AdoIdentityRef;
+  modifiedDate?: string;
+  url: string;
+}
+
+export interface AdoWorkItemType {
+  name: string;
+  description?: string;
+  xmlForm?: string;
+  fields?: AdoWorkItemTypeField[];
+  transitions?: Record<string, AdoWorkItemTypeTransition[]>;
+  url: string;
+}
+
+export interface AdoWorkItemTypeField {
+  referenceName: string;
+  name: string;
+  url: string;
+  alwaysRequired?: boolean;
+  defaultValue?: unknown;
+  allowedValues?: unknown[];
+}
+
+export interface AdoWorkItemTypeTransition {
+  to: string;
+  actions?: string[];
+}
+
+export interface AdoWorkItemTypeState {
+  name: string;
+  color: string;
+  category: string;
+}
+
+export interface AdoField {
+  referenceName: string;
+  name: string;
+  type: string;
+  usage: string;
+  readOnly: boolean;
+  canSortBy?: boolean;
+  isQueryable?: boolean;
+  picklistId?: string;
+  isIdentity?: boolean;
+  isPicklist?: boolean;
+  isPicklistSuggested?: boolean;
+  url: string;
+}
+
+export interface AdoWiqlResult {
+  queryType: string;
+  queryResultType: string;
+  asOf: string;
+  workItems?: Array<{ id: number; url: string }>;
+  workItemRelations?: Array<{ rel: string | null; source: { id: number } | null; target: { id: number } }>;
+}
+
+// ── Identity ref (lightweight, used in many contexts) ────────────────
+
+export interface AdoIdentityRef {
+  id: string;
+  displayName: string;
+  uniqueName: string;
+  url?: string;
+  imageUrl?: string;
+  descriptor?: string;
+}
+
+// ── Git / Repos ──────────────────────────────────────────────────────
+
+export interface AdoGitRepo {
+  id: string;
+  name: string;
+  url: string;
+  remoteUrl: string;
+  sshUrl?: string;
+  project: AdoProject;
+  defaultBranch?: string;
+  size?: number;
+  isDisabled?: boolean;
+}
+
+export interface AdoGitRef {
+  name: string;
+  objectId: string;
+  creator?: AdoIdentityRef;
+  url: string;
+}
+
+export interface AdoPullRequest {
+  pullRequestId: number;
+  codeReviewId?: number;
+  status: 'active' | 'abandoned' | 'completed' | 'notSet';
+  createdBy: AdoIdentityRef;
+  creationDate: string;
+  closedDate?: string;
+  title: string;
+  description?: string;
+  sourceRefName: string;
+  targetRefName: string;
+  mergeStatus?: string;
+  mergeId?: string;
+  lastMergeSourceCommit?: AdoGitCommitRef;
+  lastMergeTargetCommit?: AdoGitCommitRef;
+  lastMergeCommit?: AdoGitCommitRef;
+  reviewers: AdoPRReviewer[];
+  url: string;
+  supportsIterations?: boolean;
+  autoCompleteSetBy?: AdoIdentityRef;
+  completionOptions?: AdoPRCompletionOptions;
+}
+
+export interface AdoGitCommitRef {
+  commitId: string;
+  url?: string;
+}
+
+export interface AdoPRReviewer {
+  vote: number;
+  id: string;
+  displayName: string;
+  uniqueName: string;
+  url?: string;
+  imageUrl?: string;
+  isRequired?: boolean;
+  hasDeclined?: boolean;
+}
+
+export interface AdoPRCompletionOptions {
+  mergeStrategy?: 'noFastForward' | 'squash' | 'rebase' | 'rebaseMerge';
+  deleteSourceBranch?: boolean;
+  squashMerge?: boolean;
+  mergeCommitMessage?: string;
+  transitionWorkItems?: boolean;
+}
+
+export interface AdoPRThread {
+  id: number;
+  publishedDate: string;
+  lastUpdatedDate: string;
+  comments: AdoPRComment[];
+  status: 'active' | 'byDesign' | 'closed' | 'fixed' | 'pending' | 'unknown' | 'wontFix';
+  threadContext?: AdoPRThreadContext;
+  isDeleted?: boolean;
+  identities?: Record<string, AdoIdentityRef>;
+  properties?: Record<string, unknown>;
+}
+
+export interface AdoPRComment {
+  id: number;
+  parentCommentId?: number;
+  author: AdoIdentityRef;
+  content?: string;
+  publishedDate: string;
+  lastUpdatedDate: string;
+  lastContentUpdatedDate?: string;
+  commentType: 'unknown' | 'text' | 'codeChange' | 'system';
+  usersLiked?: AdoIdentityRef[];
+  isDeleted?: boolean;
+}
+
+export interface AdoPRThreadContext {
+  filePath: string;
+  leftFileStart?: AdoPRFilePosition;
+  leftFileEnd?: AdoPRFilePosition;
+  rightFileStart?: AdoPRFilePosition;
+  rightFileEnd?: AdoPRFilePosition;
+}
+
+export interface AdoPRFilePosition {
+  line: number;
+  offset: number;
+}
+
+export interface AdoGitDiff {
+  changes?: AdoGitChange[];
+  commonCommit?: string;
+  aheadCount?: number;
+  behindCount?: number;
+}
+
+export interface AdoGitChange {
+  item: { path: string; isFolder?: boolean };
+  changeType: string;
+  originalPath?: string;
+}
+
+// ── Build / Pipelines ────────────────────────────────────────────────
+
+export interface AdoBuildDefinition {
+  id: number;
+  name: string;
+  path: string;
+  type: string;
+  queueStatus: string;
+  revision: number;
+  project: AdoProject;
+  process?: { type: number; yamlFilename?: string };
+  queue?: { id: number; name: string };
+  repository?: { id: string; name: string; type: string };
+  latestBuild?: AdoBuild;
+  url: string;
+}
+
+export interface AdoBuild {
+  id: number;
+  buildNumber: string;
+  status: 'none' | 'inProgress' | 'completed' | 'cancelling' | 'postponed' | 'notStarted' | 'all';
+  result?: 'none' | 'succeeded' | 'partiallySucceeded' | 'failed' | 'canceled';
+  queueTime?: string;
+  startTime?: string;
+  finishTime?: string;
+  url: string;
+  definition: { id: number; name: string };
+  project: AdoProject;
+  requestedFor?: AdoIdentityRef;
+  requestedBy?: AdoIdentityRef;
+  sourceBranch?: string;
+  sourceVersion?: string;
+  parameters?: string;
+  priority?: string;
+  reason?: string;
+  keepForever?: boolean;
+  tags?: string[];
+}
+
+export interface AdoBuildLog {
+  id: number;
+  type: string;
+  url: string;
+  createdOn?: string;
+  lastChangedOn?: string;
+  lineCount?: number;
+}
+
+// ── Shared pagination wrapper ────────────────────────────────────────
+
+export interface AdoPageResponse<T> {
+  value: T[];
+  count: number;
+}

--- a/src/types/bitbucket.ts
+++ b/src/types/bitbucket.ts
@@ -38,11 +38,17 @@ export interface BitbucketComment {
   updatedDate: number;
   resolved?: boolean;
   threadResolved?: boolean;
+  /** ID of the parent comment if this is a reply */
+  parentId?: number;
+  /** Inline anchor — present for inline comments, absent for general PR comments */
   anchor?: {
     path: string;
     line: number;
     lineType: 'ADDED' | 'REMOVED' | 'CONTEXT';
+    fileType?: 'FROM' | 'TO';
   };
+  /** Nested replies — present in raw API responses; flattened out in listComments() */
+  comments?: BitbucketComment[];
 }
 
 export interface BitbucketPageResponse<T> {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -51,11 +51,40 @@ export interface BitbucketDefaults {
   targetBranch?: string;
 }
 
+export interface AdoConfig {
+  baseUrl?: string;
+  pat?: string;
+  fieldAliases?: Record<string, string>;
+  discoveredFields?: AdoFieldMeta[];
+  discoveredTypes?: AdoWorkItemTypeMeta[];
+}
+
+export interface AdoFieldMeta {
+  referenceName: string;
+  name: string;
+  type: string;
+  readOnly?: boolean;
+  picklistId?: string;
+}
+
+export interface AdoWorkItemTypeMeta {
+  name: string;
+  states: string[];
+  requiredFields: string[];
+}
+
+export interface AdoDefaults {
+  collection?: string;
+  project?: string;
+  repo?: string;
+}
+
 export interface Defaults {
   jira?: JiraDefaults;
   bitbucket?: BitbucketDefaults;
   sonar?: SonarDefaults;
   sde?: SdeDefaults;
+  ado?: AdoDefaults;
 }
 
 export interface UserConfig {
@@ -71,6 +100,7 @@ export interface GlobalConfig {
   artifactory?: ArtifactoryConfig;
   sonar?: SonarConfig;
   sde?: SdeConfig;
+  ado?: AdoConfig;
   defaults?: Defaults;
 }
 
@@ -106,10 +136,18 @@ export interface ResolvedConfig {
     baseUrl: string | undefined;
     token: string | undefined;
   };
+  ado: {
+    baseUrl: string | undefined;
+    pat: string | undefined;
+    fieldAliases: Record<string, string>;
+    discoveredFields: AdoFieldMeta[];
+    discoveredTypes: AdoWorkItemTypeMeta[];
+  };
   defaults: {
     jira: JiraDefaults;
     bitbucket: BitbucketDefaults;
     sonar: SonarDefaults;
     sde: SdeDefaults;
+    ado: AdoDefaults;
   };
 }

--- a/src/types/node-expose-sspi.d.ts
+++ b/src/types/node-expose-sspi.d.ts
@@ -1,0 +1,7 @@
+// Ambient type declaration for the optional Windows-only native module.
+// Only loaded dynamically on win32 when SSPI auth is needed.
+declare module 'node-expose-sspi' {
+  export class Client {
+    fetch(url: string | URL | Request, init?: RequestInit): Promise<Response>;
+  }
+}

--- a/src/types/node-expose-sspi.d.ts
+++ b/src/types/node-expose-sspi.d.ts
@@ -1,7 +1,0 @@
-// Ambient type declaration for the optional Windows-only native module.
-// Only loaded dynamically on win32 when SSPI auth is needed.
-declare module 'node-expose-sspi' {
-  export class Client {
-    fetch(url: string | URL | Request, init?: RequestInit): Promise<Response>;
-  }
-}


### PR DESCRIPTION
## Summary

- Removes Windows Integrated Authentication (`node-expose-sspi`) entirely
- PAT is now the sole auth method — cross-platform, no optional native dependency
- Simplifies `adoFetch.ts` from ~75 lines to ~35, config wizard removes the Windows auth branch
- Deletes `src/types/node-expose-sspi.d.ts` and removes `optionalDependencies` from `package.json`

## Test plan

- [ ] `pncli config init` — confirm ADO section prompts directly for PAT, no Windows auth question
- [ ] `pncli config test` — confirm ADO connects successfully with a valid PAT
- [ ] `pncli config test` — confirm clear error when PAT is missing/invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)