### PR TITLE
refactor: replace SSPI auth with PAT-only for Azure DevOps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "chalk": "^5.4.1",
     "commander": "^13.1.0"
   },
-  "optionalDependencies": {
-    "node-expose-sspi": "^1.1.10"
-  },
   "devDependencies": {
     "@types/node": "^22.15.3",
     "@typescript-eslint/eslint-plugin": "^8.31.0",

--- a/src/lib/adoFetch.ts
+++ b/src/lib/adoFetch.ts
@@ -1,23 +1,12 @@
 import type { ResolvedConfig } from '../types/config.js';
 import { PncliError } from './errors.js';
 
-// Module-level SSPI client singleton — lazily initialized on first use.
-// Only ever loaded on win32 when SSPI is needed.
-let sspiClient: { fetch: typeof fetch } | null = null;
-
 /**
- * Returns a fetch-compatible function for Azure DevOps Server requests.
- *
- * Precedence:
- *   1. PAT configured → native fetch + Basic auth header injected
- *   2. Windows platform + node-expose-sspi loadable → SSPI fetch (current Windows user)
- *   3. Otherwise → throw (clear message pointing user at config init)
- *
- * IMPORTANT: pass dryRun=true to skip SSPI initialisation in CI/dry-run contexts.
+ * Returns a fetch-compatible function for Azure DevOps Server requests,
+ * with Basic auth (PAT) injected into every call.
  */
 export async function buildAdoFetcher(
-  config: ResolvedConfig,
-  dryRun = false
+  config: ResolvedConfig
 ): Promise<typeof fetch> {
   const { pat, baseUrl } = config.ado;
 
@@ -25,49 +14,23 @@ export async function buildAdoFetcher(
     throw new PncliError('Azure DevOps baseUrl not configured. Run: pncli config init', 1);
   }
 
-  // PAT path — simple, cross-platform
-  if (pat) {
-    const encoded = Buffer.from(':' + pat).toString('base64');
-    const authHeader = `Basic ${encoded}`;
-    return (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
-      fetch(url, {
-        ...init,
-        headers: {
-          ...(init?.headers as Record<string, string> | undefined),
-          'Authorization': authHeader,
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        }
-      });
-  }
-
-  // SSPI path — Windows only, no native module loaded under dry-run
-  if (dryRun) {
-    // Return a stub that returns a 200 so the dryRun block in http.ts fires first
-    return () => Promise.resolve(new Response('{}', { status: 200 }));
-  }
-
-  if (process.platform !== 'win32') {
+  if (!pat) {
     throw new PncliError(
-      'Azure DevOps Windows Integrated Authentication is only available on Windows. ' +
-      'Set a PAT via pncli config init or PNCLI_ADO_PAT env var.',
+      'Azure DevOps PAT not configured. Set a PAT via pncli config init or PNCLI_ADO_PAT env var.',
       1
     );
   }
 
-  // Lazy-load node-expose-sspi (optionalDependency)
-  if (!sspiClient) {
-    try {
-      const sso = await import('node-expose-sspi');
-      sspiClient = new sso.Client() as unknown as { fetch: typeof fetch };
-    } catch {
-      throw new PncliError(
-        'Could not load Windows authentication module (node-expose-sspi). ' +
-        'Run: npm install node-expose-sspi, or configure a PAT via pncli config init.',
-        1
-      );
-    }
-  }
-
-  return sspiClient.fetch.bind(sspiClient) as typeof fetch;
+  const encoded = Buffer.from(':' + pat).toString('base64');
+  const authHeader = `Basic ${encoded}`;
+  return (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+    fetch(url, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        'Authorization': authHeader,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    });
 }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -300,7 +300,7 @@ export class HttpClient {
 
   private async getAdoFetcher(): Promise<typeof fetch> {
     if (!this.adoFetcher) {
-      this.adoFetcher = await buildAdoFetcher(this.config, this.dryRun);
+      this.adoFetcher = await buildAdoFetcher(this.config);
     }
     return this.adoFetcher;
   }

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -322,16 +322,9 @@ async function initGlobalConfig(start: number): Promise<void> {
       default: ''
     });
 
-    const useWindowsAuth = await confirm({
-      message: 'Use Windows Integrated Authentication (current logged-in user)?',
-      default: process.platform === 'win32'
+    adoPat = await password({
+      message: 'Azure DevOps personal access token:'
     });
-
-    if (!useWindowsAuth) {
-      adoPat = await password({
-        message: 'Azure DevOps personal access token:'
-      });
-    }
 
     adoCollection = await input({
       message: 'Default collection name (e.g. DefaultCollection):',

--- a/src/types/node-expose-sspi.d.ts
+++ b/src/types/node-expose-sspi.d.ts
@@ -1,7 +1,0 @@
-// Ambient type declaration for the optional Windows-only native module.
-// Only loaded dynamically on win32 when SSPI auth is needed.
-declare module 'node-expose-sspi' {
-  export class Client {
-    fetch(url: string | URL | Request, init?: RequestInit): Promise<Response>;
-  }
-}


### PR DESCRIPTION
## Summary

- Removes Windows Integrated Authentication (`node-expose-sspi`) entirely
- PAT is now the sole auth method — cross-platform, no optional native dependency
- Simplifies `adoFetch.ts` from ~75 lines to ~35, config wizard removes the Windows auth branch
- Deletes `src/types/node-expose-sspi.d.ts` and removes `optionalDependencies` from `package.json`

## Test plan

- [ ] `pncli config init` — confirm ADO section prompts directly for PAT, no Windows auth question
- [ ] `pncli config test` — confirm ADO connects successfully with a valid PAT
- [ ] `pncli config test` — confirm clear error when PAT is missing/invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)