### PR TITLE
fix: append .git suffix to claude-marketplace URL

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,7 @@ jobs:
           classify_inline_comments: 'true'
           include_fix_links: 'true'
           plugin_marketplaces: |
-            https://github.com/kolatts/claude-marketplace
+            https://github.com/kolatts/claude-marketplace.git
           plugins: |
             sunny
           prompt: |


### PR DESCRIPTION
## Summary
- The `claude-code-action` validates `plugin_marketplaces` URLs against a regex requiring a `.git` suffix
- Our URL was `https://github.com/kolatts/claude-marketplace` — missing `.git`
- This caused all Claude review runs to fail immediately with `Invalid marketplace URL format`

## Test plan
- [ ] PR auto-triggers the Claude Review workflow — confirm it passes and the `sunny` plugin loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)