### PR TITLE
refactor: extract shared skill category definitions into lib module

### DIFF
--- a/site/src/components/SkillGallery.astro
+++ b/site/src/components/SkillGallery.astro
@@ -1,68 +1,15 @@
 ---
 import { getCollection } from 'astro:content';
 import SkillCard from './SkillCard.astro';
+import { categories, categoryOrder, getSkillsForCategory, getUncategorizedSkills } from '../lib/skill-categories';
 
 const entries = await getCollection('skills');
-
-const categories: Record<string, { label: string; order: string[] }> = {
-  'setup': {
-    label: 'Getting Started',
-    order: [
-      'local-setup',
-    ],
-  },
-  'pr-workflow': {
-    label: 'PR Workflow',
-    order: [
-      'review-pull-request',
-      'address-pr-feedback',
-      'create-bug-from-pr-finding',
-      'check-build-status',
-    ],
-  },
-  'security': {
-    label: 'Security & Vulnerability',
-    order: [
-      'review-vulnerabilities',
-      'vulnerability-triage-to-tickets',
-      'dependency-cve-remediation',
-      'threat-model-to-backlog',
-    ],
-  },
-  'code-quality': {
-    label: 'Code Quality & Compliance',
-    order: [
-      'pre-merge-quality-check',
-      'tech-debt-to-backlog',
-      'license-audit-to-tickets',
-    ],
-  },
-  'planning': {
-    label: 'Planning',
-    order: [
-      'daily-standup-prep',
-    ],
-  },
-};
-
-const categoryOrder = ['setup', 'pr-workflow', 'security', 'code-quality', 'planning'];
-
-function getSkillsForCategory(catKey: string) {
-  const cat = categories[catKey];
-  if (!cat) return [];
-  const getIdx = (id: string) => { const i = cat.order.indexOf(id); return i === -1 ? Infinity : i; };
-  return [...entries]
-    .filter(e => (e.data.category ?? 'other') === catKey)
-    .sort((a, b) => getIdx(a.id) - getIdx(b.id));
-}
-
-const knownIds = new Set(Object.values(categories).flatMap(c => c.order));
-const uncategorized = entries.filter(e => !knownIds.has(e.id));
+const uncategorized = getUncategorizedSkills(entries);
 ---
 
 {categoryOrder.map(catKey => {
   const cat = categories[catKey];
-  const skills = getSkillsForCategory(catKey);
+  const skills = getSkillsForCategory(entries, catKey);
   if (!skills.length) return null;
   return (
     <div class="not-prose mb-8">

--- a/site/src/lib/skill-categories.ts
+++ b/site/src/lib/skill-categories.ts
@@ -1,0 +1,63 @@
+import type { CollectionEntry } from 'astro:content';
+
+export const categories: Record<string, { label: string; order: string[] }> = {
+  'setup': {
+    label: 'Getting Started',
+    order: [
+      'local-setup',
+    ],
+  },
+  'pr-workflow': {
+    label: 'PR Workflow',
+    order: [
+      'review-pull-request',
+      'address-pr-feedback',
+      'create-bug-from-pr-finding',
+      'check-build-status',
+    ],
+  },
+  'security': {
+    label: 'Security & Vulnerability',
+    order: [
+      'review-vulnerabilities',
+      'vulnerability-triage-to-tickets',
+      'dependency-cve-remediation',
+      'threat-model-to-backlog',
+    ],
+  },
+  'code-quality': {
+    label: 'Code Quality & Compliance',
+    order: [
+      'pre-merge-quality-check',
+      'tech-debt-to-backlog',
+      'license-audit-to-tickets',
+    ],
+  },
+  'planning': {
+    label: 'Planning',
+    order: [
+      'daily-standup-prep',
+    ],
+  },
+};
+
+export const categoryOrder = ['setup', 'pr-workflow', 'security', 'code-quality', 'planning'];
+
+export function getSkillsForCategory(
+  entries: CollectionEntry<'skills'>[],
+  catKey: string,
+): CollectionEntry<'skills'>[] {
+  const cat = categories[catKey];
+  if (!cat) return [];
+  const getIdx = (id: string) => { const i = cat.order.indexOf(id); return i === -1 ? Infinity : i; };
+  return [...entries]
+    .filter(e => (e.data.category ?? 'other') === catKey)
+    .sort((a, b) => getIdx(a.id) - getIdx(b.id));
+}
+
+export function getUncategorizedSkills(
+  entries: CollectionEntry<'skills'>[],
+): CollectionEntry<'skills'>[] {
+  const knownIds = new Set(Object.values(categories).flatMap(c => c.order));
+  return entries.filter(e => !knownIds.has(e.id));
+}

--- a/site/src/pages/skills/index.astro
+++ b/site/src/pages/skills/index.astro
@@ -2,64 +2,10 @@
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
 import SkillCard from '../../components/SkillCard.astro';
+import { categories, categoryOrder, getSkillsForCategory, getUncategorizedSkills } from '../../lib/skill-categories';
 
 const entries = await getCollection('skills');
-
-const categories: Record<string, { label: string; order: string[] }> = {
-  'setup': {
-    label: 'Getting Started',
-    order: [
-      'local-setup',
-    ],
-  },
-  'pr-workflow': {
-    label: 'PR Workflow',
-    order: [
-      'review-pull-request',
-      'address-pr-feedback',
-      'create-bug-from-pr-finding',
-      'check-build-status',
-    ],
-  },
-  'security': {
-    label: 'Security & Vulnerability',
-    order: [
-      'review-vulnerabilities',
-      'vulnerability-triage-to-tickets',
-      'dependency-cve-remediation',
-      'threat-model-to-backlog',
-    ],
-  },
-  'code-quality': {
-    label: 'Code Quality & Compliance',
-    order: [
-      'pre-merge-quality-check',
-      'tech-debt-to-backlog',
-      'license-audit-to-tickets',
-    ],
-  },
-  'planning': {
-    label: 'Planning',
-    order: [
-      'daily-standup-prep',
-    ],
-  },
-};
-
-const categoryOrder = ['setup', 'pr-workflow', 'security', 'code-quality', 'planning'];
-
-function getSkillsForCategory(catKey: string) {
-  const cat = categories[catKey];
-  if (!cat) return [];
-  const getIdx = (id: string) => { const i = cat.order.indexOf(id); return i === -1 ? Infinity : i; };
-  return [...entries]
-    .filter(e => (e.data.category ?? 'other') === catKey)
-    .sort((a, b) => getIdx(a.id) - getIdx(b.id));
-}
-
-// Collect any skills not in a known category
-const knownIds = new Set(Object.values(categories).flatMap(c => c.order));
-const uncategorized = entries.filter(e => !knownIds.has(e.id));
+const uncategorized = getUncategorizedSkills(entries);
 ---
 
 <Base
@@ -91,7 +37,7 @@ const uncategorized = entries.filter(e => !knownIds.has(e.id));
 
     {categoryOrder.map(catKey => {
       const cat = categories[catKey];
-      const skills = getSkillsForCategory(catKey);
+      const skills = getSkillsForCategory(entries, catKey);
       if (!skills.length) return null;
       return (
         <div class="mb-10">


### PR DESCRIPTION
Moves the duplicated category config from both `index.astro` and `SkillGallery.astro` into `site/src/lib/skill-categories.ts`. Also extracts `getUncategorizedSkills` to eliminate the inline knownIds/filter pattern.

Closes #33

Generated with [Claude Code](https://claude.ai/code)