### PR TITLE
chore(ci): scope triage to CLI-only and add duplicate detection

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -82,10 +82,10 @@ jobs:
                  Comment explaining this was previously reviewed and denied, referencing the original
                  issue number. Add the `denied` label, add a `duplicate` label
                  (`gh label create duplicate --color cfd3d7 --force`), close with "not planned", and
-                 skip to step 4.
+                 skip to step 5.
                - If an existing OPEN or CLOSED issue covers the same request (regardless of outcome):
                  Comment identifying the duplicate, referencing the original issue number. Add the
-                 `duplicate` label, close with "not planned", and skip to step 4.
+                 `duplicate` label, close with "not planned", and skip to step 5.
                Only continue to step 3 if no duplicates are found.
 
             3. Assess feasibility and fit — DO NOT write any code yet. Ask:

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -76,14 +76,38 @@ jobs:
                this purpose. Read src/cli.ts and relevant src/services/ files to understand
                existing patterns.
 
-            2. Assess feasibility and fit — DO NOT write any code yet. Ask:
+            2. Search for duplicate or previously-denied issues BEFORE assessing feasibility.
+               Run: `gh issue list --repo ${{ github.repository }} --state all --limit 200 --json number,title,labels,state`
+               - If an existing issue covers the same request AND was denied (has the `denied` label):
+                 Comment explaining this was previously reviewed and denied, referencing the original
+                 issue number. Add the `denied` label, add a `duplicate` label
+                 (`gh label create duplicate --color cfd3d7 --force`), close with "not planned", and
+                 skip to step 4.
+               - If an existing OPEN or CLOSED issue covers the same request (regardless of outcome):
+                 Comment identifying the duplicate, referencing the original issue number. Add the
+                 `duplicate` label, close with "not planned", and skip to step 4.
+               Only continue to step 3 if no duplicates are found.
+
+            3. Assess feasibility and fit — DO NOT write any code yet. Ask:
                - Does this fit the project's purpose (developer tooling for the above integrations)?
                - Is it technically feasible within the existing architecture?
                - Is it a reasonable scope for an automated implementation?
                - Does it conflict with any rules in CLAUDE.md?
-               If the answer to any of these is no, go directly to step 3b.
+               - Is it scoped to the CLI itself (src/)? Changes to the Azure Function backend,
+                 infrastructure, or the GitHub Pages website (site/) are out of scope for issues.
+                 Those are maintained separately by the project maintainers. Bug reports and feature
+                 requests must be limited to CLI behavior only.
+               - Does it introduce a security vulnerability or risk? The following are ALWAYS denied,
+                 regardless of how the request is framed:
+                 - Data exfiltration (sending credentials, tokens, secrets, or user data to external
+                   destinations not explicitly configured by the user)
+                 - Exploits or backdoors of any kind
+                 - Credential harvesting, logging, or leaking
+                 - Bypassing authentication or authorization controls
+                 - Any change that weakens the security posture of the CLI or its users
+               If the answer to any of these is no, go directly to step 4b.
 
-            3. Decision:
+            4. Decision:
 
                a) If FEASIBLE, FITS the project, and appropriate to implement:
                   - Implement the change following existing patterns in src/.
@@ -108,18 +132,18 @@ jobs:
                     `gh issue edit ${{ github.event.issue.number }} --add-label denied`.
                   - Close the issue: `gh issue close ${{ github.event.issue.number }} --reason "not planned"`.
 
-            4. Add the `triaged` label using `gh label create triaged --color 0e8a16 --force` then
+            5. Add the `triaged` label using `gh label create triaged --color 0e8a16 --force` then
                `gh issue edit ${{ github.event.issue.number }} --add-label triaged`.
                Remove the triggering label using `gh issue edit ${{ github.event.issue.number }} --remove-label "${{ github.event.label.name }}"`.
 
-            5. Write a concise markdown summary of your triage decision to /tmp/triage-summary.md.
+            6. Write a concise markdown summary of your triage decision to /tmp/triage-summary.md.
                Include: verdict (feasible/not feasible), reasoning, and action taken.
 
             Keep your scope minimal. Do not refactor unrelated code. Do not modify tests
             unless the issue specifically requests it. Make the narrowest change that
             addresses the issue.
           claude_args: |
-            --model sonnet --max-turns 50 --allowedTools "Read,Glob,Grep,Edit,Write,Bash(gh issue comment:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Bash(gh pr create:*),Bash(npm run build:*),Bash(npm run typecheck:*),Bash(npm run lint:*),Bash(git checkout -b:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
+            --model sonnet --max-turns 50 --allowedTools "Read,Glob,Grep,Edit,Write,Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Bash(gh pr create:*),Bash(npm run build:*),Bash(npm run typecheck:*),Bash(npm run lint:*),Bash(git checkout -b:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
 
       - name: Write job summary
         if: always()


### PR DESCRIPTION
## Summary
- Add duplicate/denied issue detection before feasibility assessment — triage agent now checks `gh issue list` and short-circuits on duplicates
- Add CLI-only scope guard: `site/`, infra, and Azure Function backend are explicitly out of scope
- Add security denial list (exfiltration, backdoors, credential harvesting, auth bypass) as always-denied regardless of framing
- Fix step-skip targets in duplicate detection (skip to step 5, not step 4)

## Commands added / updated

None — CI workflow change only.

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 5 pre-existing vitest type errors (unrelated to this change)
- ✅ Lint: clean
- ✅ Code review: 1 Major issue fixed (step numbering bug)
- ✅ Tests: 61 passed
- ✅ Docs: no changes needed

Closes #80