### PR TITLE
feat(udeploy): IBM UrbanCode Deploy integration with PAT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > One command does what three meetings couldn't.
 
-pncli gives AI coding agents (and humans) structured CLI access to Jira, Bitbucket, Confluence, SonarQube, and SDElements. No MCP servers required. No meetings to schedule. No forms to fill out.
+pncli gives AI coding agents (and humans) structured CLI access to Jira, Bitbucket, Confluence, SonarQube, SDElements, Azure DevOps Server, and IBM UrbanCode Deploy. No MCP servers required. No meetings to schedule. No forms to fill out.
 
 ## Why?
 
@@ -51,6 +51,8 @@ pncli uses a three-layer config system (highest priority wins):
 | `PNCLI_SONAR_BASE_URL` | SonarQube Server base URL |
 | `PNCLI_SONAR_TOKEN` | SonarQube personal access token |
 | `PNCLI_SDE_CONNECTION` | SDElements connection string (`api-token@hostname`, e.g. `mytoken@myorg.sdelements.com`) |
+| `PNCLI_UDEPLOY_BASE_URL` | IBM UrbanCode Deploy base URL |
+| `PNCLI_UDEPLOY_PAT` | IBM UrbanCode Deploy personal access token |
 | `PNCLI_CONFIG_PATH` | Override global config file path |
 
 ## For AI Agents
@@ -90,6 +92,7 @@ This project uses Conventional Commits for automatic versioning:
 | Artifactory | 🔜 Coming | The nightmare never ends |
 | Jenkins | 🔜 Coming | REST API |
 | Azure DevOps Server | ✅ Active | REST API v7.1 (on-prem, Windows auth + PAT) |
+| IBM UrbanCode Deploy | ✅ Active | REST API v7.x (on-prem, PAT auth) |
 
 ## License
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -548,6 +548,43 @@ pncli ado repo
 pncli ado pipeline
 ```
 
+### Udeploy
+
+```
+pncli udeploy
+  --application <name>  Application name or ID (or set defaults.udeploy.application in config)
+  --environment <name>  Environment name or ID (or set defaults.udeploy.environment in config)
+
+pncli udeploy apps
+
+pncli udeploy environments
+
+pncli udeploy components
+
+pncli udeploy versions
+  --component <name>  Component name or ID [required]
+
+pncli udeploy import-version
+  --component <name>  Component name or ID [required]
+  --version <name>    Version name [required]
+  --no-finish         Skip marking the version as finished importing
+
+pncli udeploy run
+  --process <name>    Application process name or ID [required]
+  --component <name>  Component name (repeatable)
+  --version <name>    Component version (repeatable; positionally paired with --component)
+  --snapshot <name>   Snapshot name or ID (alternative to --component/--version)
+  --only-changed      Deploy only changed components
+  --wait              Poll until the process completes
+  --timeout <ms>      Max wait time in milliseconds (default: 600000)
+
+pncli udeploy request-status
+  --request-id <id>   Request ID returned by udeploy run [required]
+
+pncli udeploy request-info
+  --request-id <id>   Request ID returned by udeploy run [required]
+```
+
 ### Skills
 
 ```

--- a/site/src/components/ServiceGrid.astro
+++ b/site/src/components/ServiceGrid.astro
@@ -10,6 +10,7 @@ const services = [
   { name: 'SonarQube',    description: 'Code quality & security',        active: true  },
   { name: 'SDElements',   description: 'Security requirements',          active: true  },
   { name: 'Azure DevOps', description: 'Work items, pipelines',          active: true  },
+  { name: 'IBM UDeploy',  description: 'Component versions, deploys',    active: true  },
   { name: 'Artifactory',  description: 'Artifact repository',            active: true  },
   { name: 'Jenkins',      description: 'CI/CD pipelines',               active: false },
 ];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { registerSdeCommands } from './services/sde/commands.js';
 import { registerDepsCommands } from './services/deps/commands.js';
 import { registerConfigCommands } from './services/config/commands.js';
 import { registerAdoCommands } from './services/ado/commands/index.js';
+import { registerUdeployCommands } from './services/udeploy/commands.js';
 import { registerSkillsCommands } from './services/skills/commands.js';
 
 const require = createRequire(import.meta.url);
@@ -62,6 +63,7 @@ registerSdeCommands(program);
 registerDepsCommands(program);
 registerConfigCommands(program);
 registerAdoCommands(program);
+registerUdeployCommands(program);
 registerSkillsCommands(program);
 
 program.addHelpText('after', `
@@ -74,6 +76,7 @@ Services:
   sonar        SonarQube Server (quality gates, issues, metrics, hotspots)
   sde          SDElements (threat modeling, countermeasures, compliance)
   ado          Azure DevOps Server (work items, repos, PRs, pipelines)
+  udeploy      IBM UrbanCode Deploy (component versions, deployment processes)
   config       Manage pncli configuration
   skills       Download and manage Claude Code skills
 `);

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -12,7 +12,8 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     sonar: { baseUrl: 'https://sonar.example.com', token: 'secret-sonar' },
     sde: { baseUrl: 'https://sde.example.com', token: 'secret-sde' },
     ado: { baseUrl: 'https://ado.example.com', pat: 'secret-ado', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {} },
+    udeploy: { baseUrl: undefined, pat: undefined },
+    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, SonarDefaults, SdeDefaults, AdoDefaults } from '../types/config.js';
+import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, SonarDefaults, SdeDefaults, AdoDefaults, UdeployDefaults } from '../types/config.js';
 import type { CustomFieldDefinition } from '../types/jira.js';
 
 const ENV_KEYS = {
@@ -24,6 +24,8 @@ const ENV_KEYS = {
   SDE_CONNECTION: 'PNCLI_SDE_CONNECTION',
   ADO_BASE_URL: 'PNCLI_ADO_BASE_URL',
   ADO_PAT: 'PNCLI_ADO_PAT',
+  UDEPLOY_BASE_URL: 'PNCLI_UDEPLOY_BASE_URL',
+  UDEPLOY_PAT: 'PNCLI_UDEPLOY_PAT',
   CONFIG_PATH: 'PNCLI_CONFIG_PATH'
 } as const;
 
@@ -73,13 +75,14 @@ function mergeCustomFields(
 function mergeDefaults(
   global: GlobalConfig['defaults'],
   repo: RepoConfig['defaults']
-): { jira: JiraDefaults; bitbucket: BitbucketDefaults; sonar: SonarDefaults; sde: SdeDefaults; ado: AdoDefaults } {
+): { jira: JiraDefaults; bitbucket: BitbucketDefaults; sonar: SonarDefaults; sde: SdeDefaults; ado: AdoDefaults; udeploy: UdeployDefaults } {
   return {
     jira: { ...global?.jira, ...repo?.jira },
     bitbucket: { ...global?.bitbucket, ...repo?.bitbucket },
     sonar: { ...global?.sonar, ...repo?.sonar },
     sde: { ...global?.sde, ...repo?.sde },
-    ado: { ...global?.ado, ...repo?.ado }
+    ado: { ...global?.ado, ...repo?.ado },
+    udeploy: { ...global?.udeploy, ...repo?.udeploy }
   };
 }
 
@@ -143,6 +146,10 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
       fieldAliases: globalConfig.ado?.fieldAliases ?? {},
       discoveredFields: globalConfig.ado?.discoveredFields ?? [],
       discoveredTypes: globalConfig.ado?.discoveredTypes ?? []
+    },
+    udeploy: {
+      baseUrl: process.env[ENV_KEYS.UDEPLOY_BASE_URL] ?? globalConfig.udeploy?.baseUrl,
+      pat: process.env[ENV_KEYS.UDEPLOY_PAT] ?? globalConfig.udeploy?.pat,
     },
     defaults: mergedDefaults
   };
@@ -234,6 +241,10 @@ export function maskConfig(config: ResolvedConfig): unknown {
     ado: {
       ...config.ado,
       pat: config.ado.pat ? '***' : undefined
+    },
+    udeploy: {
+      ...config.udeploy,
+      pat: config.udeploy.pat ? '***' : undefined
     }
   };
 }

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -12,7 +12,8 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     sonar: { baseUrl: 'https://sonar.example.com', token: 'tok' },
     sde: { baseUrl: 'https://sde.example.com', token: 'tok' },
     ado: { baseUrl: 'https://ado.example.com', pat: 'tok', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {} },
+    udeploy: { baseUrl: undefined, pat: undefined },
+    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };
 }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -431,6 +431,45 @@ export class HttpClient {
     return results;
   }
 
+  private udeployHeaders(): Record<string, string> {
+    const { pat } = this.config.udeploy;
+    if (!pat) throw new PncliError('UDeploy credentials not configured. Run: pncli config init');
+    const encoded = Buffer.from(`PasswordIsAuthToken:${pat}`).toString('base64');
+    return {
+      'Authorization': `Basic ${encoded}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'Connection': 'close'
+    };
+  }
+
+  async udeploy<T>(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<T> {
+    const baseUrl = this.config.udeploy.baseUrl;
+    if (!baseUrl) throw new PncliError('UDeploy baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+    const headers = this.udeployHeaders();
+    const init: RequestInit = {
+      method: opts.method ?? 'GET',
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
+    };
+
+    if (this.dryRun) {
+      const safeHeaders = { ...headers, Authorization: '[REDACTED]' };
+      const msg = `DRY RUN: ${init.method} ${url}\nHeaders: ${JSON.stringify(safeHeaders, null, 2)}\n`
+        + (opts.body ? `Body: ${JSON.stringify(opts.body, null, 2)}\n` : '');
+      fs.writeSync(process.stderr.fd, msg);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    return request<T>(url, init, opts.timeoutMs ?? 30000);
+  }
+
   private sonarHeaders(): Record<string, string> {
     const { token } = this.config.sonar;
     if (!token) throw new PncliError('SonarQube credentials not configured. Run: pncli config init');

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -163,7 +163,7 @@ export function registerConfigCommands(program: Command): void {
           results.ado = { ok: null, message: 'not configured' };
         }
 
-        if (cfg.udeploy.baseUrl) {
+        if (cfg.udeploy.baseUrl && cfg.udeploy.pat) {
           try {
             await http.udeploy<unknown>('/cli/application');
             results.udeploy = { ok: true, message: 'connected' };

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -163,6 +163,17 @@ export function registerConfigCommands(program: Command): void {
           results.ado = { ok: null, message: 'not configured' };
         }
 
+        if (cfg.udeploy.baseUrl) {
+          try {
+            await http.udeploy<unknown>('/cli/application');
+            results.udeploy = { ok: true, message: 'connected' };
+          } catch (err) {
+            results.udeploy = { ok: false, message: err instanceof Error ? err.message : String(err) };
+          }
+        } else {
+          results.udeploy = { ok: null, message: 'not configured' };
+        }
+
         success(results, 'config', 'test', start);
       } catch (err) {
         fail(err, 'config', 'test', start);
@@ -287,6 +298,20 @@ export function registerConfigCommands(program: Command): void {
           }
         }
 
+        // UDeploy
+        if (!cfg.udeploy.pat) {
+          results.udeploy = { status: 'blank', message: 'not configured' };
+        } else if (!cfg.udeploy.baseUrl) {
+          results.udeploy = { status: 'error', message: 'baseUrl not configured' };
+        } else {
+          try {
+            await http.udeploy<unknown>('/cli/application', { timeoutMs: 10_000 });
+            results.udeploy = { status: 'valid', message: 'ok' };
+          } catch (err) {
+            results.udeploy = categorize(err);
+          }
+        }
+
         // Artifactory — reuse existing helper
         const artResult = await checkArtifactoryConnectivity(cfg.artifactory);
         if (!artResult.configured) {
@@ -306,7 +331,7 @@ export function registerConfigCommands(program: Command): void {
 
         if (cmdOpts.output === 'table') {
           // Human-readable table to stdout
-          const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'artifactory'] as const;
+          const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'udeploy', 'artifactory'] as const;
           const labelWidth = 14;
           const statusWidth = 9;
           for (const svc of services) {
@@ -324,7 +349,7 @@ export function registerConfigCommands(program: Command): void {
         } else {
           // Pretty table on stderr when --pretty is set (stdout stays JSON)
           if (opts.pretty) {
-            const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'artifactory'] as const;
+            const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'udeploy', 'artifactory'] as const;
             const labelWidth = 14;
             const statusWidth = 9;
             for (const svc of services) {
@@ -574,6 +599,54 @@ async function initGlobalConfig(start: number): Promise<void> {
     }
   }
 
+  process.stderr.write('\n── IBM UrbanCode Deploy ──────────────────────────\n');
+  const useUdeploy = await confirm({
+    message: 'Configure IBM UrbanCode Deploy for component imports and deployment processes?',
+    default: false
+  });
+
+  let udeployBaseUrl = '';
+  let udeployPat = '';
+  let udeployDefaultApp = '';
+  let udeployDefaultEnv = '';
+
+  if (useUdeploy) {
+    udeployBaseUrl = await input({
+      message: 'UDeploy base URL (e.g. https://ucd.company.com:8443):',
+      default: ''
+    });
+
+    udeployPat = await password({
+      message: 'UDeploy personal access token (leave blank if none):'
+    });
+
+    udeployDefaultApp = await input({
+      message: 'Default application name (optional):',
+      default: ''
+    });
+
+    udeployDefaultEnv = await input({
+      message: 'Default environment name (optional):',
+      default: ''
+    });
+
+    if (udeployBaseUrl && udeployPat) {
+      process.stderr.write('\n  Verifying connection...\n');
+      try {
+        const tempConfig = {
+          ...loadConfig(),
+          udeploy: { baseUrl: udeployBaseUrl, pat: udeployPat }
+        };
+        const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
+        await tempHttp.udeploy<unknown>('/cli/application');
+        process.stderr.write('  Connected.\n');
+      } catch (err) {
+        warn(`Could not connect to UDeploy: ${err instanceof Error ? err.message : String(err)}`);
+        warn('Config will be saved anyway. Check your URL and PAT and re-run pncli config init or pncli config test.');
+      }
+    }
+  }
+
   process.stderr.write('\n── Defaults ──────────────────────────────────────\n');
   const jiraProject = await input({
     message: 'Default Jira project key (optional):',
@@ -650,6 +723,12 @@ async function initGlobalConfig(start: number): Promise<void> {
         ...(adoDiscoveredTypes.length ? { discoveredTypes: adoDiscoveredTypes } : {})
       }
     } : {}),
+    ...(useUdeploy && udeployBaseUrl ? {
+      udeploy: {
+        baseUrl: udeployBaseUrl,
+        ...(udeployPat ? { pat: udeployPat } : {})
+      }
+    } : {}),
     defaults: {
       jira: {
         project: jiraProject || undefined
@@ -668,6 +747,12 @@ async function initGlobalConfig(start: number): Promise<void> {
         ado: {
           collection: adoCollection || undefined,
           project: adoProject || undefined
+        }
+      } : {}),
+      ...(useUdeploy && (udeployDefaultApp || udeployDefaultEnv) ? {
+        udeploy: {
+          application: udeployDefaultApp || undefined,
+          environment: udeployDefaultEnv || undefined
         }
       } : {})
     }

--- a/src/services/udeploy/client.ts
+++ b/src/services/udeploy/client.ts
@@ -1,0 +1,86 @@
+import type { HttpClient } from '../../lib/http.js';
+import type {
+  UdeployApplication,
+  UdeployComponent,
+  UdeployEnvironment,
+  UdeployProcessRequest,
+  UdeployRequestInfo,
+  UdeployRequestStatus,
+  UdeployVersion,
+  UdeployVersionCreateResult,
+} from '../../types/udeploy.js';
+
+export interface UdeployRunProcessOptions {
+  application: string;
+  applicationProcess: string;
+  environment: string;
+  onlyChanged?: boolean;
+  versions?: Array<{ component: string; version: string }>;
+  snapshot?: string;
+  properties?: Record<string, string>;
+}
+
+export class UdeployClient {
+  constructor(private http: HttpClient) {}
+
+  listApplications(): Promise<UdeployApplication[]> {
+    return this.http.udeploy<UdeployApplication[]>('/cli/application');
+  }
+
+  listEnvironments(application: string): Promise<UdeployEnvironment[]> {
+    return this.http.udeploy<UdeployEnvironment[]>('/cli/application/environmentsInApplication', {
+      params: { application }
+    });
+  }
+
+  listComponents(): Promise<UdeployComponent[]> {
+    return this.http.udeploy<UdeployComponent[]>('/cli/component');
+  }
+
+  listVersions(component: string): Promise<UdeployVersion[]> {
+    return this.http.udeploy<UdeployVersion[]>('/cli/component/versions', {
+      params: { component }
+    });
+  }
+
+  createVersion(component: string, name: string): Promise<UdeployVersionCreateResult> {
+    return this.http.udeploy<UdeployVersionCreateResult>('/cli/version/createVersion', {
+      method: 'POST',
+      params: { component, name }
+    });
+  }
+
+  finishImporting(component: string, version: string): Promise<void> {
+    return this.http.udeploy<void>('/cli/version/finishedImporting', {
+      method: 'POST',
+      params: { component, version }
+    });
+  }
+
+  runProcess(opts: UdeployRunProcessOptions): Promise<UdeployProcessRequest> {
+    return this.http.udeploy<UdeployProcessRequest>('/cli/applicationProcessRequest/request', {
+      method: 'PUT',
+      body: {
+        application: opts.application,
+        applicationProcess: opts.applicationProcess,
+        environment: opts.environment,
+        onlyChanged: opts.onlyChanged ?? false,
+        ...(opts.versions ? { versions: opts.versions } : {}),
+        ...(opts.snapshot ? { snapshot: opts.snapshot } : {}),
+        ...(opts.properties ? { properties: opts.properties } : {}),
+      }
+    });
+  }
+
+  getRequestStatus(requestId: string): Promise<UdeployRequestStatus> {
+    return this.http.udeploy<UdeployRequestStatus>('/cli/applicationProcessRequest/requestStatus', {
+      params: { requestId }
+    });
+  }
+
+  getRequestInfo(requestId: string): Promise<UdeployRequestInfo> {
+    return this.http.udeploy<UdeployRequestInfo>('/cli/applicationProcessRequest/requestInfo', {
+      params: { requestId }
+    });
+  }
+}

--- a/src/services/udeploy/commands.ts
+++ b/src/services/udeploy/commands.ts
@@ -1,0 +1,237 @@
+import { Command } from 'commander';
+import { loadConfig } from '../../lib/config.js';
+import { createHttpClient } from '../../lib/http.js';
+import { success, fail, log } from '../../lib/output.js';
+import { PncliError } from '../../lib/errors.js';
+import { UdeployClient } from './client.js';
+
+const POLL_INTERVAL_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+function getClient(program: Command): { client: UdeployClient; config: ReturnType<typeof loadConfig> } {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config });
+  if (!config.udeploy.baseUrl) {
+    throw new PncliError('UDeploy baseUrl not configured. Run: pncli config init', 78);
+  }
+  const http = createHttpClient(config, opts.dryRun);
+  return { client: new UdeployClient(http), config };
+}
+
+function resolveApplication(config: ReturnType<typeof loadConfig>, cliValue?: string): string {
+  const app = cliValue ?? config.defaults.udeploy.application;
+  if (!app) throw new PncliError('--application is required (or set defaults.udeploy.application in config)', 2);
+  return app;
+}
+
+function resolveEnvironment(config: ReturnType<typeof loadConfig>, cliValue?: string): string {
+  const env = cliValue ?? config.defaults.udeploy.environment;
+  if (!env) throw new PncliError('--environment is required (or set defaults.udeploy.environment in config)', 2);
+  return env;
+}
+
+export function registerUdeployCommands(program: Command): void {
+  const udeploy = program
+    .command('udeploy')
+    .description('IBM UrbanCode Deploy — component versions and deployment processes')
+    .option('--application <name>', 'Application name or ID')
+    .option('--environment <name>', 'Environment name or ID');
+
+  udeploy
+    .command('apps')
+    .description('List all applications')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const apps = await client.listApplications();
+        success(apps, 'udeploy', 'apps', start);
+      } catch (err) {
+        fail(err, 'udeploy', 'apps', start);
+      }
+    });
+
+  udeploy
+    .command('environments')
+    .description('List environments for an application')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { client, config } = getClient(program);
+        const parentOpts = udeploy.opts<{ application?: string }>();
+        const application = resolveApplication(config, parentOpts.application);
+        const envs = await client.listEnvironments(application);
+        success(envs, 'udeploy', 'environments', start);
+      } catch (err) {
+        fail(err, 'udeploy', 'environments', start);
+      }
+    });
+
+  udeploy
+    .command('components')
+    .description('List all components')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const components = await client.listComponents();
+        success(components, 'udeploy', 'components', start);
+      } catch (err) {
+        fail(err, 'udeploy', 'components', start);
+      }
+    });
+
+  udeploy
+    .command('versions')
+    .description('List versions for a component')
+    .requiredOption('--component <name>', 'Component name or ID')
+    .action(async (cmdOpts: { component: string }) => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const versions = await client.listVersions(cmdOpts.component);
+        success(versions, 'udeploy', 'versions', start);
+      } catch (err) {
+        fail(err, 'udeploy', 'versions', start);
+      }
+    });
+
+  udeploy
+    .command('import-version')
+    .description('Create a component version and mark it ready for deployment')
+    .requiredOption('--component <name>', 'Component name or ID')
+    .requiredOption('--version <name>', 'Version name')
+    .option('--no-finish', 'Skip marking the version as finished importing')
+    .action(async (cmdOpts: { component: string; version: string; finish: boolean }) => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const created = await client.createVersion(cmdOpts.component, cmdOpts.version);
+        if (cmdOpts.finish) {
+          await client.finishImporting(cmdOpts.component, cmdOpts.version);
+        }
+        success({ ...created, finishedImporting: cmdOpts.finish }, 'udeploy', 'import-version', start);
+      } catch (err) {
+        fail(err, 'udeploy', 'import-version', start);
+      }
+    });
+
+  udeploy
+    .command('run')
+    .description('Run an application deployment process')
+    .requiredOption('--process <name>', 'Application process name or ID')
+    .option('--component <name>', 'Component name (repeatable)', collect, [])
+    .option('--version <name>', 'Component version (repeatable; positionally paired with --component)', collect, [])
+    .option('--snapshot <name>', 'Snapshot name or ID (alternative to specifying versions)')
+    .option('--only-changed', 'Deploy only changed components', false)
+    .option('--wait', 'Poll until the process completes', false)
+    .option('--timeout <ms>', 'Max wait time in milliseconds', String(DEFAULT_TIMEOUT_MS))
+    .action(async (cmdOpts: {
+      process: string;
+      component: string[];
+      version: string[];
+      snapshot?: string;
+      onlyChanged: boolean;
+      wait: boolean;
+      timeout: string;
+    }) => {
+      const start = Date.now();
+      try {
+        const { client, config } = getClient(program);
+        const parentOpts = udeploy.opts<{ application?: string; environment?: string }>();
+        const application = resolveApplication(config, parentOpts.application);
+        const environment = resolveEnvironment(config, parentOpts.environment);
+
+        const components = cmdOpts.component;
+        const versions = cmdOpts.version;
+        const versionEntries = components.map((c, i) => ({
+          component: c,
+          version: versions[i] ?? 'latest'
+        }));
+
+        const result = await client.runProcess({
+          application,
+          applicationProcess: cmdOpts.process,
+          environment,
+          onlyChanged: cmdOpts.onlyChanged,
+          ...(versionEntries.length > 0 ? { versions: versionEntries } : {}),
+          ...(cmdOpts.snapshot ? { snapshot: cmdOpts.snapshot } : {}),
+        });
+
+        if (!cmdOpts.wait) {
+          success(result, 'udeploy', 'run', start);
+          return;
+        }
+
+        const timeoutMs = parseInt(cmdOpts.timeout, 10);
+        const requestId = result.requestId;
+        log(`Process started. Request ID: ${requestId}. Polling for completion...`);
+
+        while (true) {
+          const elapsed = Date.now() - start;
+          if (elapsed >= timeoutMs) {
+            throw new PncliError(`Timed out after ${timeoutMs}ms waiting for request ${requestId}`, 1);
+          }
+
+          await sleep(POLL_INTERVAL_MS);
+
+          const status = await client.getRequestStatus(requestId);
+
+          if (status.status === 'CLOSED') {
+            const outcome = { requestId, status: status.status, result: status.result, elapsed_ms: Date.now() - start };
+            if (status.result === 'SUCCEEDED') {
+              success(outcome, 'udeploy', 'run', start);
+            } else {
+              throw new PncliError(
+                `Deployment ${status.result ?? 'failed'} (requestId: ${requestId})`,
+                1
+              );
+            }
+            return;
+          }
+
+          log(`Status: ${status.status} (${Math.round((Date.now() - start) / 1000)}s elapsed)`);
+        }
+      } catch (err) {
+        fail(err, 'udeploy', 'run', start);
+      }
+    });
+
+  udeploy
+    .command('request-status')
+    .description('Get the current status of a deployment process request')
+    .requiredOption('--request-id <id>', 'Request ID returned by udeploy run')
+    .action(async (cmdOpts: { requestId: string }) => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const status = await client.getRequestStatus(cmdOpts.requestId);
+        success(status, 'udeploy', 'request-status', start);
+      } catch (err) {
+        fail(err, 'udeploy', 'request-status', start);
+      }
+    });
+
+  udeploy
+    .command('request-info')
+    .description('Get full details of a deployment process request')
+    .requiredOption('--request-id <id>', 'Request ID returned by udeploy run')
+    .action(async (cmdOpts: { requestId: string }) => {
+      const start = Date.now();
+      try {
+        const { client } = getClient(program);
+        const info = await client.getRequestInfo(cmdOpts.requestId);
+        success(info, 'udeploy', 'request-info', start);
+      } catch (err) {
+        fail(err, 'udeploy', 'request-info', start);
+      }
+    });
+}
+
+function collect(val: string, prev: string[]): string[] {
+  return [...prev, val];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -79,12 +79,23 @@ export interface AdoDefaults {
   repo?: string;
 }
 
+export interface UdeployConfig {
+  baseUrl?: string;
+  pat?: string;
+}
+
+export interface UdeployDefaults {
+  application?: string;
+  environment?: string;
+}
+
 export interface Defaults {
   jira?: JiraDefaults;
   bitbucket?: BitbucketDefaults;
   sonar?: SonarDefaults;
   sde?: SdeDefaults;
   ado?: AdoDefaults;
+  udeploy?: UdeployDefaults;
 }
 
 export interface UserConfig {
@@ -101,6 +112,7 @@ export interface GlobalConfig {
   sonar?: SonarConfig;
   sde?: SdeConfig;
   ado?: AdoConfig;
+  udeploy?: UdeployConfig;
   defaults?: Defaults;
 }
 
@@ -145,11 +157,16 @@ export interface ResolvedConfig {
     discoveredFields: AdoFieldMeta[];
     discoveredTypes: AdoWorkItemTypeMeta[];
   };
+  udeploy: {
+    baseUrl: string | undefined;
+    pat: string | undefined;
+  };
   defaults: {
     jira: JiraDefaults;
     bitbucket: BitbucketDefaults;
     sonar: SonarDefaults;
     sde: SdeDefaults;
     ado: AdoDefaults;
+    udeploy: UdeployDefaults;
   };
 }

--- a/src/types/udeploy.ts
+++ b/src/types/udeploy.ts
@@ -1,0 +1,53 @@
+export interface UdeployApplication {
+  id: string;
+  name: string;
+  description?: string;
+  active: boolean;
+}
+
+export interface UdeployEnvironment {
+  id: string;
+  name: string;
+  description?: string;
+  active: boolean;
+}
+
+export interface UdeployComponent {
+  id: string;
+  name: string;
+  description?: string;
+  active: boolean;
+}
+
+export interface UdeployVersion {
+  id: string;
+  name: string;
+  created: number;
+  active: boolean;
+  status?: string;
+}
+
+export interface UdeployVersionCreateResult {
+  id: string;
+  name: string;
+  component: { id: string; name: string };
+}
+
+export interface UdeployProcessRequest {
+  requestId: string;
+}
+
+export interface UdeployRequestStatus {
+  status: 'EXECUTING' | 'CLOSED' | string;
+  result?: 'SUCCEEDED' | 'FAULTED' | 'CANCELED' | string;
+}
+
+export interface UdeployRequestInfo {
+  id: string;
+  application: { id: string; name: string };
+  environment: { id: string; name: string };
+  applicationProcess: { id: string; name: string };
+  startTime?: number;
+  result?: string;
+  status: string;
+}


### PR DESCRIPTION
## Summary
- Add `pncli udeploy` command group with full support for applications, environments, components, versions, and deployment process execution
- PAT-based Basic auth using the `PasswordIsAuthToken` scheme
- Wire UDeploy into `pncli config init`, `config test`, and `config check`
- Add `PNCLI_UDEPLOY_BASE_URL` and `PNCLI_UDEPLOY_PAT` env var support

## Commands added / updated
- `pncli udeploy` — IBM UrbanCode Deploy service group
  - `--application <name>` — Application name or ID (or set `defaults.udeploy.application` in config)
  - `--environment <name>` — Environment name or ID (or set `defaults.udeploy.environment` in config)
- `pncli udeploy apps` — List all applications
- `pncli udeploy environments` — List environments for an application
- `pncli udeploy components` — List all components
- `pncli udeploy versions --component <name>` — List versions for a component
- `pncli udeploy import-version --component <name> --version <name> [--no-finish]` — Create a component version and mark it ready
- `pncli udeploy run --process <name> [--component <name>] [--version <name>] [--snapshot <name>] [--only-changed] [--wait] [--timeout <ms>]` — Run an application deployment process
- `pncli udeploy request-status --request-id <id>` — Get current status of a deployment request
- `pncli udeploy request-info --request-id <id>` — Get full details of a deployment request

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: issues fixed (test fixtures, config test PAT guard)
- ✅ Tests: 61 passed
- ✅ Docs: README, ServiceGrid.astro, copilot-instructions.md updated

Closes #81