### PR TITLE
fix(jenkins): handle multi-level folder paths in pipeline commands

### DIFF
--- a/src/services/jenkins/client.ts
+++ b/src/services/jenkins/client.ts
@@ -8,6 +8,13 @@ import type {
   JenkinsQueueItem
 } from '../../types/jenkins.js';
 
+/** Converts a multi-level Jenkins job name (e.g. `A/B/C`) into the correct
+ *  URL path segment (e.g. `A/job/B/job/C`). Single-level names are unchanged.
+ *  Each segment is individually percent-encoded. */
+function jobPath(name: string): string {
+  return name.split('/').map(encodeURIComponent).join('/job/');
+}
+
 export class JenkinsClient {
   constructor(private http: HttpClient) {}
 
@@ -21,7 +28,7 @@ export class JenkinsClient {
 
   async getJob(name: string): Promise<JenkinsJobDetail> {
     return this.http.jenkins<JenkinsJobDetail>(
-      `/job/${encodeURIComponent(name)}/api/json`,
+      `/job/${jobPath(name)}/api/json`,
       { params: { tree: 'name,url,color,description,buildable,nextBuildNumber,inQueue,lastBuild[number,url,result],builds[number,url,result,duration,timestamp,building,displayName]{0,10}' } }
     );
   }
@@ -32,8 +39,8 @@ export class JenkinsClient {
   ): Promise<{ queueItemId: number }> {
     const hasParams = params && Object.keys(params).length > 0;
     const endpoint = hasParams
-      ? `/job/${encodeURIComponent(name)}/buildWithParameters`
-      : `/job/${encodeURIComponent(name)}/build`;
+      ? `/job/${jobPath(name)}/buildWithParameters`
+      : `/job/${jobPath(name)}/build`;
 
     const res = await this.http.jenkinsRaw(endpoint, {
       method: 'POST',
@@ -53,7 +60,7 @@ export class JenkinsClient {
 
   async listBuilds(name: string, top = 25): Promise<Pick<JenkinsBuild, 'number' | 'url' | 'result' | 'duration' | 'timestamp' | 'building' | 'displayName' | 'fullDisplayName' | 'description' | 'id' | 'queueId'>[]> {
     const data = await this.http.jenkins<{ builds: Pick<JenkinsBuild, 'number' | 'url' | 'result' | 'duration' | 'timestamp' | 'building' | 'displayName' | 'fullDisplayName' | 'description' | 'id' | 'queueId'>[] }>(
-      `/job/${encodeURIComponent(name)}/api/json`,
+      `/job/${jobPath(name)}/api/json`,
       { params: { tree: `builds[number,url,result,duration,timestamp,building,displayName,fullDisplayName,description,id,queueId]{0,${top}}` } }
     );
     return data.builds ?? [];
@@ -61,13 +68,13 @@ export class JenkinsClient {
 
   async getBuild(name: string, buildNumber: number): Promise<JenkinsBuild> {
     return this.http.jenkins<JenkinsBuild>(
-      `/job/${encodeURIComponent(name)}/${buildNumber}/api/json`
+      `/job/${jobPath(name)}/${buildNumber}/api/json`
     );
   }
 
   async getConsoleLog(name: string, buildNumber: number): Promise<string> {
     const res = await this.http.jenkinsRaw(
-      `/job/${encodeURIComponent(name)}/${buildNumber}/consoleText`,
+      `/job/${jobPath(name)}/${buildNumber}/consoleText`,
       { method: 'GET' }
     );
     return res.text;


### PR DESCRIPTION
Closes #91

Replaces `encodeURIComponent(name)` with a `jobPath()` helper that splits on `/` and joins with `/job/` so multi-level names like `A/B/C` correctly map to `/job/A/job/B/job/C` instead of 404ing via %-encoded slashes.

Generated with [Claude Code](https://claude.ai/code)