### PR TITLE
feat(cli): add --output-file global option for large command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ pncli is designed agent-first:
 ## Global Flags
 
 ```
---pretty          Human-readable formatted output (default: compact JSON)
---verbose         Include full API response metadata
---dry-run         Print the API request without executing
---config <path>   Override global config file location
+--pretty                Human-readable formatted output (default: compact JSON)
+--verbose               Include full API response metadata
+--dry-run               Print the API request without executing
+--config <path>         Override global config file location
+--output-file <path>    Write JSON output to file instead of stdout
 ```
 
 ## Commit Convention

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -640,5 +640,6 @@ Always check `ok` before accessing `data`.
 - Use `--dry-run` to preview API calls without executing
 - Use `--verbose` to see full response metadata for debugging
 - Use `--pretty` when running manually for readable output
+- Use `--output-file <path>` to write JSON output to a file instead of stdout — recommended for commands that produce large payloads (search, logs, `--all` pagination) to avoid flooding agent context
 - Pipe output through `jq` for ad-hoc filtering (if available)
 - Defaults from `.pncli.json` are applied automatically — you rarely need to pass `--project`, `--type`, or `--priority` flags for Jira

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,14 +39,16 @@ program
   .option('--pretty', 'Human-readable formatted output', false)
   .option('--verbose', 'Include full response metadata', false)
   .option('--dry-run', 'Print API requests without executing', false)
-  .option('--config <path>', 'Override global config file location');
+  .option('--config <path>', 'Override global config file location')
+  .option('--output-file <path>', 'Write JSON output to file instead of stdout');
 
 // Propagate global options and user identity before any command runs
 program.hook('preAction', (thisCommand) => {
   const opts = thisCommand.optsWithGlobals();
   setGlobalOptions({
     pretty: Boolean(opts.pretty),
-    verbose: Boolean(opts.verbose)
+    verbose: Boolean(opts.verbose),
+    outputFile: opts.outputFile as string | undefined
   });
   try {
     const config = loadConfig({ configPath: opts.config as string | undefined });

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -6,9 +6,11 @@ import { ExitCode, exitCodeFromStatus } from './exitCodes.js';
 
 let globalOptions = { pretty: false, verbose: false };
 let globalUser: { email: string | undefined; userId: string | undefined } = { email: undefined, userId: undefined };
+let outputFile: string | undefined;
 
-export function setGlobalOptions(opts: { pretty: boolean; verbose: boolean }): void {
-  globalOptions = opts;
+export function setGlobalOptions(opts: { pretty: boolean; verbose: boolean; outputFile?: string }): void {
+  globalOptions = { pretty: opts.pretty, verbose: opts.verbose };
+  outputFile = opts.outputFile;
 }
 
 export function setGlobalUser(user: { email: string | undefined; userId: string | undefined }): void {
@@ -25,15 +27,28 @@ function buildMeta(service: string, action: string, startTime: number): Meta {
   };
 }
 
+function writeToFile(filePath: string, content: string): void {
+  try {
+    fs.writeFileSync(filePath, content, { encoding: 'utf8', flag: 'w' });
+  } catch (writeErr) {
+    process.stderr.write(
+      `Warning: could not write to output file "${filePath}": ${(writeErr as NodeJS.ErrnoException).message}\n`
+    );
+  }
+}
+
 export function success<T>(data: T, service: string, action: string, startTime: number): void {
   const envelope: SuccessEnvelope<T> = {
     ok: true,
     data,
     meta: buildMeta(service, action, startTime)
   };
-  process.stdout.write(
-    (globalOptions.pretty ? JSON.stringify(envelope, null, 2) : JSON.stringify(envelope)) + '\n'
-  );
+  const out = (globalOptions.pretty ? JSON.stringify(envelope, null, 2) : JSON.stringify(envelope)) + '\n';
+  if (outputFile) {
+    writeToFile(outputFile, out);
+  } else {
+    process.stdout.write(out);
+  }
 }
 
 export function fail(
@@ -62,10 +77,14 @@ export function fail(
 
   const output = (globalOptions.pretty ? JSON.stringify(envelope, null, 2) : JSON.stringify(envelope)) + '\n';
   const exitCode = err instanceof PncliError ? exitCodeFromStatus(err.status) : ExitCode.GENERAL_ERROR;
-  try {
-    fs.writeSync(process.stdout.fd, output);
-  } catch (writeErr) {
-    if ((writeErr as NodeJS.ErrnoException).code !== 'EPIPE') throw writeErr;
+  if (outputFile) {
+    writeToFile(outputFile, output);
+  } else {
+    try {
+      fs.writeSync(process.stdout.fd, output);
+    } catch (writeErr) {
+      if ((writeErr as NodeJS.ErrnoException).code !== 'EPIPE') throw writeErr;
+    }
   }
   process.exitCode = exitCode;
   throw new PncliError(errorDetail.message, errorDetail.status);

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -29,11 +29,12 @@ function buildMeta(service: string, action: string, startTime: number): Meta {
 
 function writeToFile(filePath: string, content: string): void {
   try {
-    fs.writeFileSync(filePath, content, { encoding: 'utf8', flag: 'w' });
+    fs.writeFileSync(filePath, content, 'utf8');
   } catch (writeErr) {
     process.stderr.write(
       `Warning: could not write to output file "${filePath}": ${(writeErr as NodeJS.ErrnoException).message}\n`
     );
+    process.exitCode = ExitCode.GENERAL_ERROR;
   }
 }
 

--- a/src/services/ado/commands/pipeline.ts
+++ b/src/services/ado/commands/pipeline.ts
@@ -136,7 +136,7 @@ export function registerAdoPipelineCommands(ado: Command): void {
 
   pipeline
     .command('logs')
-    .description('List or retrieve build logs')
+    .description('List or retrieve build logs (consider --output-file for large logs)')
     .requiredOption('--id <n>', 'Build ID')
     .option('--log-id <n>', 'Specific log ID (omit to list all logs)')
     .action(async (opts: { id: string; logId?: string }) => {

--- a/src/services/ado/commands/work.ts
+++ b/src/services/ado/commands/work.ts
@@ -145,7 +145,7 @@ export function registerAdoWorkCommands(ado: Command): void {
 
   work
     .command('search')
-    .description('Run a WIQL query')
+    .description('Run a WIQL query (consider --output-file for large results)')
     .requiredOption('--wiql <query>', 'WIQL query string')
     .action(async (opts: { wiql: string }) => {
       const start = Date.now();
@@ -225,7 +225,7 @@ export function registerAdoWorkCommands(ado: Command): void {
 
   work
     .command('fields')
-    .description('List work item fields available in the collection')
+    .description('List work item fields available in the collection (consider --output-file for large results)')
     .option('--type <type>', 'Scope to fields for a specific work item type (e.g. Bug)')
     .option('--custom-only', 'Exclude System.* and Microsoft.VSTS.* fields')
     .option('--discover', 'Fetch from server (always true for this command)')

--- a/src/services/artifactory/commands.ts
+++ b/src/services/artifactory/commands.ts
@@ -95,7 +95,7 @@ export function registerArtifactoryCommands(program: Command): void {
   // ── AQL search ────────────────────────────────────────────────────────────
 
   art.command('search')
-    .description('Search artifacts using AQL (Artifactory Query Language)')
+    .description('Search artifacts using AQL (Artifactory Query Language) (consider --output-file for large results)')
     .option('--repo <name>', 'Filter by repository key')
     .option('--name <pattern>', 'Filter by artifact name (supports * and ? wildcards)')
     .option('--path <pattern>', 'Filter by artifact path (supports * and ? wildcards)')

--- a/src/services/confluence/commands.ts
+++ b/src/services/confluence/commands.ts
@@ -46,7 +46,7 @@ export function registerConfluenceCommands(program: Command): void {
     });
 
   confluence.command('list-pages')
-    .description('List pages in a Confluence space')
+    .description('List pages in a Confluence space (consider --output-file for large results)')
     .requiredOption('--space <key>', 'Space key')
     .option('--limit <n>', 'Max results per page (default: all)')
     .option('--start <n>', 'Offset for first result')

--- a/src/services/jenkins/commands.ts
+++ b/src/services/jenkins/commands.ts
@@ -160,7 +160,7 @@ export function registerJenkinsCommands(program: Command): void {
 
   pipeline
     .command('logs')
-    .description('Fetch console log for a build')
+    .description('Fetch console log for a build (consider --output-file for large logs)')
     .requiredOption('--name <job>', 'Job name')
     .requiredOption('--number <n>', 'Build number')
     .action(async (opts: { name: string; number: string }) => {

--- a/src/services/jira/commands.ts
+++ b/src/services/jira/commands.ts
@@ -157,7 +157,7 @@ export function registerJiraCommands(program: Command): void {
     });
 
   jira.command('search')
-    .description('Search Jira issues with JQL')
+    .description('Search Jira issues with JQL (consider --output-file for large results)')
     .requiredOption('--jql <query>', 'JQL query string')
     .option('--max-results <n>', 'Maximum number of results')
     .action(async (opts: { jql: string; maxResults?: string }) => {
@@ -203,7 +203,7 @@ export function registerJiraCommands(program: Command): void {
     });
 
   jira.command('fields')
-    .description('List custom fields (configured or discovered from Jira API)')
+    .description('List custom fields (configured or discovered from Jira API) (consider --output-file for large results)')
     .option('--discover', 'Fetch field metadata from Jira API')
     .option('--custom-only', 'Show only custom fields (requires --discover)')
     .action(async (opts: { discover?: boolean; customOnly?: boolean }) => {

--- a/src/services/sde/commands.ts
+++ b/src/services/sde/commands.ts
@@ -75,7 +75,7 @@ export function registerSdeCommands(program: Command): void {
     .option('--active <bool>', 'Filter by active status: true or false')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page', '100')
-    .option('--all', 'Fetch all pages')
+    .option('--all', 'Fetch all pages (consider --output-file for large results)')
     .action(async (opts: { email?: string; firstName?: string; lastName?: string; active?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {
@@ -112,7 +112,7 @@ export function registerSdeCommands(program: Command): void {
     .option('--include <fields>', 'Include extra fields (comma-separated): task_counts,permissions')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page', '100')
-    .option('--all', 'Fetch all pages')
+    .option('--all', 'Fetch all pages (consider --output-file for large results)')
     .action(async (opts: { name?: string; search?: string; active?: string; ordering?: string; expand?: string; include?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {
@@ -174,7 +174,7 @@ export function registerSdeCommands(program: Command): void {
     .option('--include <fields>', 'Include extra fields (comma-separated): how_tos,last_note,references,regulation_sections')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page', '100')
-    .option('--all', 'Fetch all pages')
+    .option('--all', 'Fetch all pages (consider --output-file for large results)')
     .action(async (opts: { project?: string; phase?: string; priority?: string; status?: string; assignedTo?: string; source?: string; verification?: string; tag?: string; accepted?: string; relevant?: string; expand?: string; include?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {
@@ -238,7 +238,7 @@ export function registerSdeCommands(program: Command): void {
     .option('--component-id <id>', 'Filter by component ID')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page', '100')
-    .option('--all', 'Fetch all pages')
+    .option('--all', 'Fetch all pages (consider --output-file for large results)')
     .action(async (opts: { project?: string; severity?: string; search?: string; ordering?: string; capecId?: string; componentId?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {

--- a/src/services/sonar/commands.ts
+++ b/src/services/sonar/commands.ts
@@ -52,7 +52,7 @@ export function registerSonarCommands(program: Command): void {
     .option('--resolved <bool>', 'Filter resolved issues: true or false')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page (max 500)', '100')
-    .option('--all', 'Fetch all pages — consider --output-file for large results (ignores --page/--page-size)')
+    .option('--all', 'Fetch all pages (consider --output-file for large results; ignores --page/--page-size)')
     .action(async (opts: { project?: string; severities?: string; types?: string; statuses?: string; branch?: string; resolved?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {

--- a/src/services/sonar/commands.ts
+++ b/src/services/sonar/commands.ts
@@ -52,7 +52,7 @@ export function registerSonarCommands(program: Command): void {
     .option('--resolved <bool>', 'Filter resolved issues: true or false')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page (max 500)', '100')
-    .option('--all', 'Fetch all pages (ignores --page/--page-size)')
+    .option('--all', 'Fetch all pages — consider --output-file for large results (ignores --page/--page-size)')
     .action(async (opts: { project?: string; severities?: string; types?: string; statuses?: string; branch?: string; resolved?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {
@@ -108,7 +108,7 @@ export function registerSonarCommands(program: Command): void {
     .option('--query <text>', 'Search query')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page', '100')
-    .option('--all', 'Fetch all pages')
+    .option('--all', 'Fetch all pages (consider --output-file for large results)')
     .action(async (opts: { query?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {
@@ -137,7 +137,7 @@ export function registerSonarCommands(program: Command): void {
     .option('--branch <name>', 'Branch name')
     .option('--page <n>', 'Page number (1-based)', '1')
     .option('--page-size <n>', 'Results per page', '100')
-    .option('--all', 'Fetch all pages')
+    .option('--all', 'Fetch all pages (consider --output-file for large results)')
     .action(async (opts: { project?: string; status?: string; resolution?: string; branch?: string; page: string; pageSize: string; all?: boolean }) => {
       const start = Date.now();
       try {


### PR DESCRIPTION
## Summary
- Add global `--output-file <path>` option — JSON output goes to file instead of stdout, keeping agent context clean
- `src/lib/output.ts`: new `outputFile` module var, `writeToFile` helper (warns to stderr + sets non-zero exit on write failure), branching in `success()` and `fail()`
- Hint text added to high-volume commands: `sonar issues/projects/hotspots --all`, `sde tasks/threats/projects/users --all`, `jira search/fields`, `ado work search/fields`, `ado pipeline logs`, `jenkins pipeline logs`, `confluence list-pages`, `artifactory search`
- `README.md` and `copilot-instructions.md` updated with the new flag

## Commands added / updated

**New global option (applies to every command):**
- `pncli --output-file <path> <any command>` — writes the JSON envelope to `<path>` instead of stdout; combinable with `--pretty`; on write failure, emits a warning to stderr and exits non-zero

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: approved (exit code on write failure fixed, hint phrasing normalized, docs updated)
- ✅ Tests: 63 passed
- ✅ Docs: README.md and copilot-instructions.md updated

Closes #100