### PR TITLE
fix(udeploy): remove username/password auth, PAT-only

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -13,7 +13,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     sde: { baseUrl: 'https://sde.example.com', token: 'secret-sde' },
     ado: { baseUrl: 'https://ado.example.com', pat: 'secret-ado', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'secret-jenkins' },
-    udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
+    udeploy: { baseUrl: undefined, pat: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -29,8 +29,6 @@ const ENV_KEYS = {
   JENKINS_API_TOKEN: 'PNCLI_JENKINS_API_TOKEN',
   UDEPLOY_BASE_URL: 'PNCLI_UDEPLOY_BASE_URL',
   UDEPLOY_PAT: 'PNCLI_UDEPLOY_PAT',
-  UDEPLOY_USERNAME: 'PNCLI_UDEPLOY_USERNAME',
-  UDEPLOY_PASSWORD: 'PNCLI_UDEPLOY_PASSWORD',
   CONFIG_PATH: 'PNCLI_CONFIG_PATH'
 } as const;
 
@@ -160,8 +158,6 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
     udeploy: {
       baseUrl: process.env[ENV_KEYS.UDEPLOY_BASE_URL] ?? globalConfig.udeploy?.baseUrl,
       pat: process.env[ENV_KEYS.UDEPLOY_PAT] ?? globalConfig.udeploy?.pat,
-      username: process.env[ENV_KEYS.UDEPLOY_USERNAME] ?? globalConfig.udeploy?.username,
-      password: process.env[ENV_KEYS.UDEPLOY_PASSWORD] ?? globalConfig.udeploy?.password,
     },
     defaults: mergedDefaults
   };
@@ -260,8 +256,7 @@ export function maskConfig(config: ResolvedConfig): unknown {
     },
     udeploy: {
       ...config.udeploy,
-      pat: config.udeploy.pat ? '***' : undefined,
-      password: config.udeploy.password ? '***' : undefined
+      pat: config.udeploy.pat ? '***' : undefined
     }
   };
 }

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -13,7 +13,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     sde: { baseUrl: 'https://sde.example.com', token: 'tok' },
     ado: { baseUrl: 'https://ado.example.com', pat: 'tok', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'tok' },
-    udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
+    udeploy: { baseUrl: undefined, pat: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -455,15 +455,9 @@ export class HttpClient {
   }
 
   private udeployHeaders(): Record<string, string> {
-    const { pat, username, password } = this.config.udeploy;
-    let encoded: string;
-    if (username && password) {
-      encoded = Buffer.from(`${username}:${password}`).toString('base64');
-    } else if (pat) {
-      encoded = Buffer.from(`PasswordIsAuthToken:${pat}`).toString('base64');
-    } else {
-      throw new PncliError('UDeploy credentials not configured. Run: pncli config init');
-    }
+    const { pat } = this.config.udeploy;
+    if (!pat) throw new PncliError('UDeploy credentials not configured. Run: pncli config init');
+    const encoded = Buffer.from(`PasswordIsAuthToken:${pat}`).toString('base64');
     return {
       'Authorization': `Basic ${encoded}`,
       'Content-Type': 'application/json',

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -185,8 +185,7 @@ export function registerConfigCommands(program: Command): void {
           results.artifactory = { ok: null, message: 'not configured' };
         }
 
-        const udeployHasAuth = cfg.udeploy.pat || (cfg.udeploy.username && cfg.udeploy.password);
-        if (cfg.udeploy.baseUrl && udeployHasAuth) {
+        if (cfg.udeploy.baseUrl && cfg.udeploy.pat) {
           try {
             await http.udeploy<unknown>('/cli/application');
             results.udeploy = { ok: true, message: 'connected' };
@@ -336,8 +335,7 @@ export function registerConfigCommands(program: Command): void {
         }
 
         // UDeploy
-        const udeployHasAuth = cfg.udeploy.pat || (cfg.udeploy.username && cfg.udeploy.password);
-        if (!udeployHasAuth) {
+        if (!cfg.udeploy.pat) {
           results.udeploy = { status: 'blank', message: 'not configured' };
         } else if (!cfg.udeploy.baseUrl) {
           results.udeploy = { status: 'error', message: 'baseUrl not configured' };
@@ -671,8 +669,6 @@ async function initGlobalConfig(start: number): Promise<void> {
 
   let udeployBaseUrl = '';
   let udeployPat = '';
-  let udeployUsername = '';
-  let udeployPassword = '';
   let udeployDefaultApp = '';
   let udeployDefaultEnv = '';
 
@@ -682,25 +678,9 @@ async function initGlobalConfig(start: number): Promise<void> {
       default: ''
     });
 
-    const useBasicAuth = await confirm({
-      message: 'Use username + password auth instead of an auth token?',
-      default: false
+    udeployPat = await password({
+      message: 'UDeploy personal access token (leave blank if none):'
     });
-
-    if (useBasicAuth) {
-      udeployUsername = await input({
-        message: 'UDeploy username:',
-        default: ''
-      });
-
-      udeployPassword = await password({
-        message: 'UDeploy password:'
-      });
-    } else {
-      udeployPat = await password({
-        message: 'UDeploy personal access token (leave blank if none):'
-      });
-    }
 
     udeployDefaultApp = await input({
       message: 'Default application name (optional):',
@@ -712,25 +692,19 @@ async function initGlobalConfig(start: number): Promise<void> {
       default: ''
     });
 
-    const udeployHasAuth = udeployPat || (udeployUsername && udeployPassword);
-    if (udeployBaseUrl && udeployHasAuth) {
+    if (udeployBaseUrl && udeployPat) {
       process.stderr.write('\n  Verifying connection...\n');
       try {
         const tempConfig = {
           ...loadConfig(),
-          udeploy: {
-            baseUrl: udeployBaseUrl,
-            pat: udeployPat || undefined,
-            username: udeployUsername || undefined,
-            password: udeployPassword || undefined
-          }
+          udeploy: { baseUrl: udeployBaseUrl, pat: udeployPat }
         };
         const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
         await tempHttp.udeploy<unknown>('/cli/application');
         process.stderr.write('  Connected.\n');
       } catch (err) {
         warn(`Could not connect to UDeploy: ${err instanceof Error ? err.message : String(err)}`);
-        warn('Config will be saved anyway. Check your URL and credentials and re-run pncli config init or pncli config test.');
+        warn('Config will be saved anyway. Check your URL and PAT and re-run pncli config init or pncli config test.');
       }
     }
   }
@@ -821,9 +795,7 @@ async function initGlobalConfig(start: number): Promise<void> {
     ...(useUdeploy && udeployBaseUrl ? {
       udeploy: {
         baseUrl: udeployBaseUrl,
-        ...(udeployPat ? { pat: udeployPat } : {}),
-        ...(udeployUsername ? { username: udeployUsername } : {}),
-        ...(udeployPassword ? { password: udeployPassword } : {})
+        ...(udeployPat ? { pat: udeployPat } : {})
       }
     } : {}),
     defaults: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -88,8 +88,6 @@ export interface JenkinsConfig {
 export interface UdeployConfig {
   baseUrl?: string;
   pat?: string;
-  username?: string;
-  password?: string;
 }
 
 export interface UdeployDefaults {
@@ -174,8 +172,6 @@ export interface ResolvedConfig {
   udeploy: {
     baseUrl: string | undefined;
     pat: string | undefined;
-    username: string | undefined;
-    password: string | undefined;
   };
   defaults: {
     jira: JiraDefaults;


### PR DESCRIPTION
## Summary
- Remove username/password basic auth support from UDeploy integration
- Restore PAT-only auth (PasswordIsAuthToken encoding)
- Drop `PNCLI_UDEPLOY_USERNAME` / `PNCLI_UDEPLOY_PASSWORD` env vars
- Simplify `config init` wizard — remove the basic/token auth branch prompt

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: Approve
- ✅ Tests: 63 passed
- ✅ Docs: no changes needed

Closes #102