### PR TITLE
feat(udeploy): re-add username/password auth and fix PAT token encoding

### DIFF
--- a/.claude/skills/local-setup/SKILL.md
+++ b/.claude/skills/local-setup/SKILL.md
@@ -86,6 +86,28 @@ pncli config set sonar.token <token>
 pncli config set sde.connection <token@hostname>
 ```
 
+**IBM UrbanCode Deploy** — "Do you use IBM UrbanCode Deploy for component imports or deployment processes?"
+
+```
+pncli config set udeploy.baseUrl <url>
+```
+
+Ask whether they authenticate with a PAT or username/password:
+
+- If **PAT**: `pncli config set udeploy.pat <token>`
+- If **username/password**:
+  ```
+  pncli config set udeploy.username <username>
+  pncli config set udeploy.password <password>
+  ```
+
+Optionally set defaults to avoid repeating flags on every command:
+
+```
+pncli config set defaults.udeploy.application <app-name>
+pncli config set defaults.udeploy.environment <env-name>
+```
+
 **Artifactory** — "Do you use Artifactory for package management?"
 
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pncli uses a three-layer config system (highest priority wins):
 | `PNCLI_SDE_CONNECTION` | SDElements connection string (`api-token@hostname`, e.g. `mytoken@myorg.sdelements.com`) |
 | `PNCLI_UDEPLOY_BASE_URL` | IBM UrbanCode Deploy base URL |
 | `PNCLI_UDEPLOY_PAT` | IBM UrbanCode Deploy personal access token |
+| `PNCLI_UDEPLOY_USERNAME` | IBM UrbanCode Deploy username (alternative to PAT) |
+| `PNCLI_UDEPLOY_PASSWORD` | IBM UrbanCode Deploy password (used with `PNCLI_UDEPLOY_USERNAME`) |
 | `PNCLI_CONFIG_PATH` | Override global config file path |
 | `PNCLI_JENKINS_BASE_URL` | Jenkins base URL |
 | `PNCLI_JENKINS_USERNAME` | Jenkins username |
@@ -96,7 +98,7 @@ This project uses Conventional Commits for automatic versioning:
 | Artifactory | 🔜 Coming | The nightmare never ends |
 | Jenkins | ✅ Active | REST API (Data Center 2.x) |
 | Azure DevOps Server | ✅ Active | REST API v7.1 (on-prem, Windows auth + PAT) |
-| IBM UrbanCode Deploy | ✅ Active | REST API v7.x (on-prem, PAT auth) |
+| IBM UrbanCode Deploy | ✅ Active | REST API v7.x (on-prem, PAT or username/password auth) |
 
 ## License
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -13,7 +13,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     sde: { baseUrl: 'https://sde.example.com', token: 'secret-sde' },
     ado: { baseUrl: 'https://ado.example.com', pat: 'secret-ado', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'secret-jenkins' },
-    udeploy: { baseUrl: undefined, pat: undefined },
+    udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -76,4 +76,16 @@ describe('maskConfig', () => {
     expect(masked.jira.baseUrl).toBe('https://jira.example.com');
     expect(masked.user.email).toBe('user@example.com');
   });
+
+  it('masks udeploy password when present', () => {
+    const config = baseConfig({ udeploy: { baseUrl: 'https://ucd.example.com', pat: undefined, username: 'alice', password: 'secret' } });
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect((masked.udeploy as { password?: string }).password).toBe('***');
+  });
+
+  it('leaves udeploy password undefined when not set', () => {
+    const config = baseConfig({ udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined } });
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect((masked.udeploy as { password?: string }).password).toBeUndefined();
+  });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -29,6 +29,8 @@ const ENV_KEYS = {
   JENKINS_API_TOKEN: 'PNCLI_JENKINS_API_TOKEN',
   UDEPLOY_BASE_URL: 'PNCLI_UDEPLOY_BASE_URL',
   UDEPLOY_PAT: 'PNCLI_UDEPLOY_PAT',
+  UDEPLOY_USERNAME: 'PNCLI_UDEPLOY_USERNAME',
+  UDEPLOY_PASSWORD: 'PNCLI_UDEPLOY_PASSWORD',
   CONFIG_PATH: 'PNCLI_CONFIG_PATH'
 } as const;
 
@@ -158,6 +160,8 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
     udeploy: {
       baseUrl: process.env[ENV_KEYS.UDEPLOY_BASE_URL] ?? globalConfig.udeploy?.baseUrl,
       pat: process.env[ENV_KEYS.UDEPLOY_PAT] ?? globalConfig.udeploy?.pat,
+      username: process.env[ENV_KEYS.UDEPLOY_USERNAME] ?? globalConfig.udeploy?.username,
+      password: process.env[ENV_KEYS.UDEPLOY_PASSWORD] ?? globalConfig.udeploy?.password,
     },
     defaults: mergedDefaults
   };
@@ -256,7 +260,8 @@ export function maskConfig(config: ResolvedConfig): unknown {
     },
     udeploy: {
       ...config.udeploy,
-      pat: config.udeploy.pat ? '***' : undefined
+      pat: config.udeploy.pat ? '***' : undefined,
+      password: config.udeploy.password ? '***' : undefined
     }
   };
 }

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -13,7 +13,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     sde: { baseUrl: 'https://sde.example.com', token: 'tok' },
     ado: { baseUrl: 'https://ado.example.com', pat: 'tok', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'tok' },
-    udeploy: { baseUrl: undefined, pat: undefined },
+    udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -76,6 +76,69 @@ describe('HttpClient — missing credentials', () => {
     const client = new HttpClient(config);
     await expect(client.ado('/_apis/projects')).rejects.toMatchObject({ name: 'PncliError' });
   });
+
+  it('throws on missing udeploy credentials', async () => {
+    const config = baseConfig();
+    config.udeploy = { baseUrl: 'https://ucd.example.com', pat: undefined, username: undefined, password: undefined };
+    const client = new HttpClient(config);
+    await expect(client.udeploy('/cli/application')).rejects.toMatchObject({ name: 'PncliError' });
+  });
+});
+
+describe('HttpClient — udeploy auth encoding', () => {
+  it('encodes PAT using PasswordIsAuthToken JSON format', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      capturedHeaders.push(Object.fromEntries(new Headers(init.headers as Record<string, string>).entries()));
+      return new Response('[]', { status: 200 });
+    });
+    try {
+      const config = baseConfig({ udeploy: { baseUrl: 'https://ucd.example.com', pat: 'my-pat', username: undefined, password: undefined } });
+      const client = new HttpClient(config);
+      await client.udeploy('/cli/application');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const auth = capturedHeaders[0]?.['authorization'] ?? '';
+    const decoded = Buffer.from(auth.replace('Basic ', ''), 'base64').toString();
+    expect(decoded).toBe('PasswordIsAuthToken:{"token":"my-pat"}');
+  });
+
+  it('encodes username:password as standard Basic auth', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      capturedHeaders.push(Object.fromEntries(new Headers(init.headers as Record<string, string>).entries()));
+      return new Response('[]', { status: 200 });
+    });
+    try {
+      const config = baseConfig({ udeploy: { baseUrl: 'https://ucd.example.com', pat: undefined, username: 'alice', password: 'secret' } });
+      const client = new HttpClient(config);
+      await client.udeploy('/cli/application');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const auth = capturedHeaders[0]?.['authorization'] ?? '';
+    const decoded = Buffer.from(auth.replace('Basic ', ''), 'base64').toString();
+    expect(decoded).toBe('alice:secret');
+  });
+
+  it('prefers username:password over PAT when both are set', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      capturedHeaders.push(Object.fromEntries(new Headers(init.headers as Record<string, string>).entries()));
+      return new Response('[]', { status: 200 });
+    });
+    try {
+      const config = baseConfig({ udeploy: { baseUrl: 'https://ucd.example.com', pat: 'my-pat', username: 'alice', password: 'secret' } });
+      const client = new HttpClient(config);
+      await client.udeploy('/cli/application');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const auth = capturedHeaders[0]?.['authorization'] ?? '';
+    const decoded = Buffer.from(auth.replace('Basic ', ''), 'base64').toString();
+    expect(decoded).toBe('alice:secret');
+  });
 });
 
 describe('HttpClient — sdePaginate', () => {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -455,9 +455,15 @@ export class HttpClient {
   }
 
   private udeployHeaders(): Record<string, string> {
-    const { pat } = this.config.udeploy;
-    if (!pat) throw new PncliError('UDeploy credentials not configured. Run: pncli config init');
-    const encoded = Buffer.from(`PasswordIsAuthToken:${pat}`).toString('base64');
+    const { pat, username, password } = this.config.udeploy;
+    let encoded: string;
+    if (username && password) {
+      encoded = Buffer.from(`${username}:${password}`).toString('base64');
+    } else if (pat) {
+      encoded = Buffer.from(`PasswordIsAuthToken:{"token":"${pat}"}`).toString('base64');
+    } else {
+      throw new PncliError('UDeploy credentials not configured. Run: pncli config init');
+    }
     return {
       'Authorization': `Basic ${encoded}`,
       'Content-Type': 'application/json',

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -460,7 +460,7 @@ export class HttpClient {
     if (username && password) {
       encoded = Buffer.from(`${username}:${password}`).toString('base64');
     } else if (pat) {
-      encoded = Buffer.from(`PasswordIsAuthToken:{"token":"${pat}"}`).toString('base64');
+      encoded = Buffer.from(`PasswordIsAuthToken:${JSON.stringify({ token: pat })}`).toString('base64');
     } else {
       throw new PncliError('UDeploy credentials not configured. Run: pncli config init');
     }

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -185,7 +185,7 @@ export function registerConfigCommands(program: Command): void {
           results.artifactory = { ok: null, message: 'not configured' };
         }
 
-        if (cfg.udeploy.baseUrl && cfg.udeploy.pat) {
+        if (cfg.udeploy.baseUrl && (cfg.udeploy.pat || (cfg.udeploy.username && cfg.udeploy.password))) {
           try {
             await http.udeploy<unknown>('/cli/application');
             results.udeploy = { ok: true, message: 'connected' };
@@ -335,7 +335,7 @@ export function registerConfigCommands(program: Command): void {
         }
 
         // UDeploy
-        if (!cfg.udeploy.pat) {
+        if (!cfg.udeploy.pat && !(cfg.udeploy.username && cfg.udeploy.password)) {
           results.udeploy = { status: 'blank', message: 'not configured' };
         } else if (!cfg.udeploy.baseUrl) {
           results.udeploy = { status: 'error', message: 'baseUrl not configured' };
@@ -669,6 +669,8 @@ async function initGlobalConfig(start: number): Promise<void> {
 
   let udeployBaseUrl = '';
   let udeployPat = '';
+  let udeployUsername = '';
+  let udeployPassword = '';
   let udeployDefaultApp = '';
   let udeployDefaultEnv = '';
 
@@ -678,9 +680,20 @@ async function initGlobalConfig(start: number): Promise<void> {
       default: ''
     });
 
-    udeployPat = await password({
-      message: 'UDeploy personal access token (leave blank if none):'
+    udeployUsername = await input({
+      message: 'UDeploy username (leave blank to use a PAT instead):',
+      default: ''
     });
+
+    if (udeployUsername) {
+      udeployPassword = await password({
+        message: 'UDeploy password:'
+      });
+    } else {
+      udeployPat = await password({
+        message: 'UDeploy personal access token:'
+      });
+    }
 
     udeployDefaultApp = await input({
       message: 'Default application name (optional):',
@@ -692,19 +705,25 @@ async function initGlobalConfig(start: number): Promise<void> {
       default: ''
     });
 
-    if (udeployBaseUrl && udeployPat) {
+    const hasCredentials = udeployBaseUrl && (udeployPat || (udeployUsername && udeployPassword));
+    if (hasCredentials) {
       process.stderr.write('\n  Verifying connection...\n');
       try {
         const tempConfig = {
           ...loadConfig(),
-          udeploy: { baseUrl: udeployBaseUrl, pat: udeployPat }
+          udeploy: {
+            baseUrl: udeployBaseUrl,
+            pat: udeployPat || undefined,
+            username: udeployUsername || undefined,
+            password: udeployPassword || undefined
+          }
         };
         const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
         await tempHttp.udeploy<unknown>('/cli/application');
         process.stderr.write('  Connected.\n');
       } catch (err) {
         warn(`Could not connect to UDeploy: ${err instanceof Error ? err.message : String(err)}`);
-        warn('Config will be saved anyway. Check your URL and PAT and re-run pncli config init or pncli config test.');
+        warn('Config will be saved anyway. Check your URL and credentials and re-run pncli config init or pncli config test.');
       }
     }
   }
@@ -795,7 +814,9 @@ async function initGlobalConfig(start: number): Promise<void> {
     ...(useUdeploy && udeployBaseUrl ? {
       udeploy: {
         baseUrl: udeployBaseUrl,
-        ...(udeployPat ? { pat: udeployPat } : {})
+        ...(udeployPat ? { pat: udeployPat } : {}),
+        ...(udeployUsername ? { username: udeployUsername } : {}),
+        ...(udeployPassword ? { password: udeployPassword } : {})
       }
     } : {}),
     defaults: {

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -687,7 +687,8 @@ async function initGlobalConfig(start: number): Promise<void> {
 
     if (udeployUsername) {
       udeployPassword = await password({
-        message: 'UDeploy password:'
+        message: 'UDeploy password:',
+        validate: (v) => v.length > 0 || 'Password cannot be blank'
       });
     } else {
       udeployPat = await password({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -88,6 +88,8 @@ export interface JenkinsConfig {
 export interface UdeployConfig {
   baseUrl?: string;
   pat?: string;
+  username?: string;
+  password?: string;
 }
 
 export interface UdeployDefaults {
@@ -172,6 +174,8 @@ export interface ResolvedConfig {
   udeploy: {
     baseUrl: string | undefined;
     pat: string | undefined;
+    username: string | undefined;
+    password: string | undefined;
   };
   defaults: {
     jira: JiraDefaults;


### PR DESCRIPTION
## Summary
- Re-adds username/password Basic auth support for IBM UrbanCode Deploy (reverts the removal from #103)
- Fixes PAT token encoding from bare string to correct JSON format: `PasswordIsAuthToken:{"token":"<PAT>"}` per udclient source spec
- Adds `PNCLI_UDEPLOY_USERNAME` and `PNCLI_UDEPLOY_PASSWORD` env var support
- `config init` wizard now prompts for username first and falls back to PAT if blank
- Blank-password validation added to prevent silently broken configs

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: issues fixed (JSON.stringify for PAT, blank-password guard, 4 new uDeploy auth tests, README + local-setup skill updated)
- ✅ Tests: 69 passed
- ✅ Docs: README env vars table + services table updated; local-setup skill updated with UDeploy section

Closes #104