### PR TITLE
feat(checkmarx): add CxSAST 9.x integration with OAuth2 token exchange

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -97,6 +97,12 @@ jobs:
                  infrastructure, or the GitHub Pages website (site/) are out of scope for issues.
                  Those are maintained separately by the project maintainers. Bug reports and feature
                  requests must be limited to CLI behavior only.
+               - Does it require any external CLI (e.g. `az`, `gcloud`, `kubectl`, `aws`) to be
+                 installed on the user's workstation at runtime? pncli integrations must be
+                 self-contained — credentials come from env vars or config, and the CLI itself must
+                 perform any token exchange natively via HTTP. If the feature can only work by
+                 shelling out to another CLI or by having users run an external command to obtain
+                 a bearer token, go directly to step 4b (deny).
                - Does it introduce a security vulnerability or risk? The following are ALWAYS denied,
                  regardless of how the request is framed:
                  - Data exfiltration (sending credentials, tokens, secrets, or user data to external

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-pncli (The Paperwork Nightmare CLI) is a structured JSON CLI that gives AI coding agents and humans unified access to Jira, Bitbucket, Confluence, SonarQube, SDElements, and Azure DevOps Server. Built with TypeScript, Commander.js, and published as `@kolatts/pncli`.
+pncli (The Paperwork Nightmare CLI) is a structured JSON CLI that gives AI coding agents and humans unified access to Jira, Bitbucket, Confluence, SonarQube, SDElements, Azure DevOps Server, Jenkins, JFrog Artifactory, IBM UrbanCode Deploy, and Checkmarx. Built with TypeScript, Commander.js, and published as `@kolatts/pncli`.
 
 ## Key Directories
 
@@ -46,6 +46,14 @@ When adding a new service integration (new entry under `src/services/`), these f
 6. **`skills/local-setup/SKILL.md`** — add setup instructions for the new service in Step 4 (optional services), including all config keys and what they enable
 
 Never ship a new integration without updating all six of these. The local-setup skill is the onboarding contract — if it's missing a service, new users won't know it exists.
+
+## Self-Containment Rule
+
+pncli integrations must be self-contained. Users cannot be required to have any other CLI installed (e.g. `az`, `gcloud`, `kubectl`, `aws`) to obtain credentials, exchange tokens, or otherwise use a pncli command. If an integration needs a bearer token from an OAuth2 exchange, pncli performs the exchange itself using credentials the user supplies (username/password, client ID, refresh token, etc.). The only external dependency allowed at runtime is the target service's HTTP API.
+
+## Testing Rule
+
+Unit tests must exercise internal logic — auth header construction, URL building, response parsing, config resolution, token-cache expiry — by stubbing `fetch` (see `src/lib/http.test.ts` for the pattern). Tests must never depend on a live external service being reachable; a developer running `npm test` offline or on a locked-down CI runner must get the same pass/fail result as one with full network access. Connectivity against real services is what `pncli config test` is for, not the unit test suite.
 
 ## Commit Conventions
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > One command does what three meetings couldn't.
 
-pncli gives AI coding agents (and humans) structured CLI access to Jira, Bitbucket, Confluence, SonarQube, SDElements, Azure DevOps Server, and IBM UrbanCode Deploy. No MCP servers required. No meetings to schedule. No forms to fill out.
+pncli gives AI coding agents (and humans) structured CLI access to Jira, Bitbucket, Confluence, SonarQube, SDElements, Azure DevOps Server, Jenkins, JFrog Artifactory, IBM UrbanCode Deploy, and Checkmarx. No MCP servers required. No meetings to schedule. No forms to fill out.
 
 ## Why?
 
@@ -43,22 +43,35 @@ pncli uses a three-layer config system (highest priority wins):
 
 | Variable | Description |
 |----------|-------------|
+| `PNCLI_EMAIL` | Your email address (used across Jira, Bitbucket, etc.) |
+| `PNCLI_USERID` | Your user ID or username |
 | `PNCLI_JIRA_BASE_URL` | Jira base URL |
-| `PNCLI_JIRA_EMAIL` | Jira email |
 | `PNCLI_JIRA_API_TOKEN` | Jira API token |
 | `PNCLI_BITBUCKET_BASE_URL` | Bitbucket Server base URL |
 | `PNCLI_BITBUCKET_PAT` | Bitbucket personal access token |
+| `PNCLI_CONFLUENCE_BASE_URL` | Confluence base URL |
+| `PNCLI_CONFLUENCE_API_TOKEN` | Confluence API token (falls back to Jira token if unset) |
 | `PNCLI_SONAR_BASE_URL` | SonarQube Server base URL |
 | `PNCLI_SONAR_TOKEN` | SonarQube personal access token |
 | `PNCLI_SDE_CONNECTION` | SDElements connection string (`api-token@hostname`, e.g. `mytoken@myorg.sdelements.com`) |
+| `PNCLI_ADO_BASE_URL` | Azure DevOps Server base URL |
+| `PNCLI_ADO_PAT` | Azure DevOps Server personal access token |
+| `PNCLI_JENKINS_BASE_URL` | Jenkins base URL |
+| `PNCLI_JENKINS_USERNAME` | Jenkins username |
+| `PNCLI_JENKINS_API_TOKEN` | Jenkins API token |
+| `PNCLI_ARTIFACTORY_BASE_URL` | JFrog Artifactory base URL |
+| `PNCLI_ARTIFACTORY_TOKEN` | Artifactory access token |
+| `PNCLI_ARTIFACTORY_REPO_NPM` | Artifactory virtual npm repository name |
+| `PNCLI_ARTIFACTORY_REPO_NUGET` | Artifactory virtual NuGet repository name |
+| `PNCLI_ARTIFACTORY_REPO_MAVEN` | Artifactory virtual Maven repository name |
 | `PNCLI_UDEPLOY_BASE_URL` | IBM UrbanCode Deploy base URL |
 | `PNCLI_UDEPLOY_PAT` | IBM UrbanCode Deploy personal access token |
 | `PNCLI_UDEPLOY_USERNAME` | IBM UrbanCode Deploy username (alternative to PAT) |
 | `PNCLI_UDEPLOY_PASSWORD` | IBM UrbanCode Deploy password (used with `PNCLI_UDEPLOY_USERNAME`) |
+| `PNCLI_CHECKMARX_BASE_URL` | Checkmarx CxSAST base URL |
+| `PNCLI_CHECKMARX_USERNAME` | Checkmarx username |
+| `PNCLI_CHECKMARX_PASSWORD` | Checkmarx password |
 | `PNCLI_CONFIG_PATH` | Override global config file path |
-| `PNCLI_JENKINS_BASE_URL` | Jenkins base URL |
-| `PNCLI_JENKINS_USERNAME` | Jenkins username |
-| `PNCLI_JENKINS_API_TOKEN` | Jenkins API token |
 
 ## For AI Agents
 
@@ -87,18 +100,19 @@ This project uses Conventional Commits for automatic versioning:
 
 ## Services
 
-| Service | Status | API |
-|---------|--------|-----|
-| Git (local) | ✅ Active | Local git commands |
-| Jira | ✅ Active | Data Cloud REST v3 |
-| Bitbucket | ✅ Active | Server REST v1.0 |
-| Confluence | ✅ Active | Server REST v1 |
-| SonarQube | ✅ Active | Server Web API |
-| SDElements | ✅ Active | REST API v2 (cloud + on-prem) |
-| Artifactory | 🔜 Coming | The nightmare never ends |
-| Jenkins | ✅ Active | REST API (Data Center 2.x) |
-| Azure DevOps Server | ✅ Active | REST API v7.1 (on-prem, Windows auth + PAT) |
-| IBM UrbanCode Deploy | ✅ Active | REST API v7.x (on-prem, PAT or username/password auth) |
+| Service | Status | Designed for | Auth methods |
+|---------|--------|--------------|--------------|
+| Git (local) | ✅ Active | Any git version | — (local git commands) |
+| Jira | ✅ Active | Jira Data Center 9.x / 10.x | email + API token |
+| Bitbucket | ✅ Active | Bitbucket Server / Data Center 8.x–9.x | HTTP access token (PAT) |
+| Confluence | ✅ Active | Confluence Data Center 8.x / 9.x | email + API token |
+| SonarQube | ✅ Active | SonarQube Server 9.x / 10.x | user token |
+| SDElements | ✅ Active | SDElements cloud + on-prem (REST API v2) | connection string (`token@hostname`) |
+| Azure DevOps Server | ✅ Active | ADO Server 2020+ (REST API 7.1) | personal access token (PAT) |
+| Jenkins | ✅ Active | Jenkins 2.x LTS (Data Center) | username + API token |
+| JFrog Artifactory | ✅ Active | Artifactory 7.x | bearer token |
+| IBM UrbanCode Deploy | ✅ Active | UCD 7.x | PAT **or** username + password |
+| Checkmarx | ✅ Active | CxSAST 9.x (on-prem) | username + password (OAuth2 password grant — pncli handles token exchange) |
 
 ## License
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 ## What is pncli?
 
-pncli is a CLI tool that provides structured JSON access to Jira, Bitbucket, Confluence, SonarQube, SDElements, and local git state. Use it for all interactions with these services. It exists because MCP servers aren't available in this environment — pncli is your agent-friendly shim layer.
+pncli is a CLI tool that provides structured JSON access to Jira, Bitbucket, Confluence, SonarQube, SDElements, Azure DevOps Server, Jenkins, JFrog Artifactory, IBM UrbanCode Deploy, Checkmarx, and local git state. Use it for all interactions with these services. It exists because MCP servers aren't available in this environment — pncli is your agent-friendly shim layer.
 
 ## Important
 
@@ -372,7 +372,8 @@ pncli sonar issues
   --resolved <bool>    Filter resolved issues: true or false
   --page <n>           Page number (1-based) (default: "1")
   --page-size <n>      Results per page (max 500) (default: "100")
-  --all                Fetch all pages (ignores --page/--page-size)
+  --all                Fetch all pages (consider --output-file for large
+  results; ignores --page/--page-size)
 
 pncli sonar measures
   --project <key>   SonarQube project key (or set defaults.sonar.project in
@@ -385,7 +386,7 @@ pncli sonar projects
   --query <text>   Search query
   --page <n>       Page number (1-based) (default: "1")
   --page-size <n>  Results per page (default: "100")
-  --all            Fetch all pages
+  --all            Fetch all pages (consider --output-file for large results)
 
 pncli sonar hotspots
   --project <key>      SonarQube project key (or set defaults.sonar.project in
@@ -395,7 +396,8 @@ pncli sonar hotspots
   --branch <name>      Branch name
   --page <n>           Page number (1-based) (default: "1")
   --page-size <n>      Results per page (default: "100")
-  --all                Fetch all pages
+  --all                Fetch all pages (consider --output-file for large
+  results)
 ```
 
 ### Sde
@@ -412,7 +414,8 @@ pncli sde users
   --active <bool>      Filter by active status: true or false
   --page <n>           Page number (1-based) (default: "1")
   --page-size <n>      Results per page (default: "100")
-  --all                Fetch all pages
+  --all                Fetch all pages (consider --output-file for large
+  results)
 
 pncli sde projects
   --name <name>       Filter by project name
@@ -426,7 +429,7 @@ pncli sde projects
   task_counts,permissions
   --page <n>          Page number (1-based) (default: "1")
   --page-size <n>     Results per page (default: "100")
-  --all               Fetch all pages
+  --all               Fetch all pages (consider --output-file for large results)
 
 pncli sde project
   --id <id>           Project ID (or set defaults.sde.project in config)
@@ -453,7 +456,8 @@ pncli sde tasks
   how_tos,last_note,references,regulation_sections
   --page <n>             Page number (1-based) (default: "1")
   --page-size <n>        Results per page (default: "100")
-  --all                  Fetch all pages
+  --all                  Fetch all pages (consider --output-file for large
+  results)
 
 pncli sde task
   --project <id>      Project ID (or set defaults.sde.project in config)
@@ -473,7 +477,8 @@ pncli sde threats
   --component-id <id>  Filter by component ID
   --page <n>           Page number (1-based) (default: "1")
   --page-size <n>      Results per page (default: "100")
-  --all                Fetch all pages
+  --all                Fetch all pages (consider --output-file for large
+  results)
 ```
 
 ### Deps
@@ -528,6 +533,7 @@ pncli config set
 pncli config test
 
 pncli config check
+  --output <format>  Output format: json or table (default: "json")
 ```
 
 ### Ado
@@ -549,38 +555,45 @@ pncli ado pipeline
 ### Jenkins
 
 ```
-pncli jenkins pipeline list
+pncli jenkins pipeline
+```
 
-pncli jenkins pipeline get
-  --name <job>         (required) Job name
+### Artifactory
 
-pncli jenkins pipeline run
-  --name <job>         (required) Job name
-  --parameter <k=v>    Build parameter in key=value format (repeatable)
-  --wait               Wait for the build to complete before returning
-  --timeout <s>        Max wait time in seconds (default: "600")
-  --poll <s>           Poll interval in seconds (default: "10")
+```
+pncli artifactory ping
 
-pncli jenkins pipeline list-runs
-  --name <job>         (required) Job name
-  --top <n>            Maximum number of builds to return (default: "25")
+pncli artifactory repos
+  --type <type>          Filter by type: local, virtual, remote, federated
+  --package-type <type>  Filter by package type: npm, maven, nuget, docker,
+  pypi, etc.
 
-pncli jenkins pipeline get-run
-  --name <job>         (required) Job name
-  --number <n>         (required) Build number
+pncli artifactory artifact-info
 
-pncli jenkins pipeline logs
-  --name <job>         (required) Job name
-  --number <n>         (required) Build number
+pncli artifactory properties-get
+
+pncli artifactory properties-set
+  --recursive  Apply recursively to folder contents (default: false)
+
+pncli artifactory search
+  --repo <name>     Filter by repository key
+  --name <pattern>  Filter by artifact name (supports * and ? wildcards)
+  --path <pattern>  Filter by artifact path (supports * and ? wildcards)
+  --after <date>    Created after this date (ISO 8601, e.g. 2024-01-01)
+  --before <date>   Created before this date (ISO 8601)
+  --limit <n>       Maximum results to return (default: 100) (default: "100")
+  --properties      Include artifact properties in results (default: false)
+
+pncli artifactory builds
+
+pncli artifactory build-runs
+
+pncli artifactory build-info
 ```
 
 ### Udeploy
 
 ```
-pncli udeploy
-  --application <name>  Application name or ID (or set defaults.udeploy.application in config)
-  --environment <name>  Environment name or ID (or set defaults.udeploy.environment in config)
-
 pncli udeploy apps
 
 pncli udeploy environments
@@ -588,39 +601,43 @@ pncli udeploy environments
 pncli udeploy components
 
 pncli udeploy versions
-  --component <name>  Component name or ID [required]
+  --component <name>  Component name or ID
 
 pncli udeploy import-version
-  --component <name>  Component name or ID [required]
-  --version <name>    Version name [required]
+  --component <name>  Component name or ID
+  --name <name>       Version name
   --no-finish         Skip marking the version as finished importing
 
 pncli udeploy run
-  --process <name>    Application process name or ID [required]
-  --component <name>  Component name (repeatable)
-  --version <name>    Component version (repeatable; positionally paired with --component)
-  --snapshot <name>   Snapshot name or ID (alternative to --component/--version)
-  --only-changed      Deploy only changed components
-  --wait              Poll until the process completes
-  --timeout <ms>      Max wait time in milliseconds (default: 600000)
+  --process <name>            Application process name or ID
+  --component <name>          Component name (repeatable) (default: [])
+  --component-version <name>  Component version (repeatable; positionally paired
+  with --component) (default: [])
+  --snapshot <name>           Snapshot name or ID (alternative to specifying
+  versions)
+  --only-changed              Deploy only changed components (default: false)
+  --wait                      Poll until the process completes (default: false)
+  --timeout <ms>              Max wait time in milliseconds (default: "600000")
 
 pncli udeploy request-status
-  --request-id <id>   Request ID returned by udeploy run [required]
+  --request-id <id>  Request ID returned by udeploy run
 
 pncli udeploy request-info
-  --request-id <id>   Request ID returned by udeploy run [required]
+  --request-id <id>  Request ID returned by udeploy run
 ```
 
 ### Skills
 
 ```
 pncli skills install
-  --agent <agent>  Target agent host: github-copilot | claude-code (default: "github-copilot")
+  --agent <agent>  Target agent host: github-copilot | claude-code (default:
+  "github-copilot")
   --scope <scope>  Installation scope: project | user (default: "project")
   --target <dir>   Override install directory (ignores --agent and --scope)
 
 pncli skills list
-  --agent <agent>  Target agent host: github-copilot | claude-code (default: "github-copilot")
+  --agent <agent>  Target agent host: github-copilot | claude-code (default:
+  "github-copilot")
   --scope <scope>  Installation scope: project | user (default: "project")
   --target <dir>   Override skills directory to scan
 ```

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -626,6 +626,25 @@ pncli udeploy request-info
   --request-id <id>  Request ID returned by udeploy run
 ```
 
+### Checkmarx
+
+```
+pncli checkmarx project list
+
+pncli checkmarx project get
+  --id <id>  Project ID (required)
+
+pncli checkmarx scan list
+  --project <id>  Filter by project ID
+  --last <n>      Return only the last N scans per project
+
+pncli checkmarx scan get
+  --id <id>  Scan ID (required)
+
+pncli checkmarx scan stats
+  --id <id>  Scan ID (required)
+```
+
 ### Skills
 
 ```

--- a/site/src/components/FeatureForm.astro
+++ b/site/src/components/FeatureForm.astro
@@ -103,8 +103,12 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY ?? '0x4AAAAAA
       <option>Bitbucket</option>
       <option>Confluence</option>
       <option>SonarQube</option>
+      <option>Checkmarx</option>
       <option>SDElements</option>
       <option>Azure DevOps</option>
+      <option>Jenkins</option>
+      <option>Artifactory</option>
+      <option>IBM UrbanCode Deploy</option>
       <option>Other</option>
     </select>
   </div>

--- a/site/src/components/ServiceGrid.astro
+++ b/site/src/components/ServiceGrid.astro
@@ -8,6 +8,7 @@ const services = [
   { name: 'Bitbucket',    description: 'Pull requests, repositories',    active: true  },
   { name: 'Confluence',   description: 'Pages, spaces, content',         active: true  },
   { name: 'SonarQube',    description: 'Code quality & security',        active: true  },
+  { name: 'Checkmarx',    description: 'Vulnerability scanning (SAST)',  active: true  },
   { name: 'SDElements',   description: 'Security requirements',          active: true  },
   { name: 'Azure DevOps', description: 'Work items, pipelines',          active: true  },
   { name: 'IBM UDeploy',  description: 'Component versions, deploys',    active: true  },

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -26,7 +26,7 @@ const skills = defineCollection({
     title:       z.string(),
     description: z.string(),
     providers:   z.enum(['both', 'bitbucket', 'ado', 'none']).optional(),
-    category:    z.enum(['setup', 'pr-workflow', 'security', 'planning', 'other']).optional(),
+    category:    z.enum(['setup', 'pr-workflow', 'security', 'planning', 'code-quality', 'other']).optional(),
     services:      z.string().optional(),
     userInvocable: z.boolean().optional(),
     generatedAt:   z.string().optional(),

--- a/site/src/lib/skill-categories.ts
+++ b/site/src/lib/skill-categories.ts
@@ -27,9 +27,15 @@ export const categories: Record<string, { label: string; order: string[] }> = {
       'plan',
     ],
   },
+  'code-quality': {
+    label: 'Code Quality',
+    order: [
+      'license-audit-to-tickets',
+    ],
+  },
 };
 
-export const categoryOrder = ['setup', 'pr-workflow', 'security', 'planning'];
+export const categoryOrder = ['setup', 'pr-workflow', 'security', 'planning', 'code-quality'];
 
 export function getSkillsForCategory(
   entries: CollectionEntry<'skills'>[],

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -54,8 +54,7 @@ const fmt = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', y
             <div class="rounded-xl border border-violet/25 bg-violet/5 p-5">
               <p class="font-display font-semibold text-ink text-base mb-1">Works with your stack.</p>
               <p class="text-ink/55 text-sm leading-relaxed">
-                Jira Data Center, Bitbucket Server, Confluence, SonarQube, SDElements,
-                Azure DevOps, and Jenkins. All from the terminal.
+                Your full Data Center stack — see below.
               </p>
             </div>
           </div>

--- a/skills/local-setup/SKILL.md
+++ b/skills/local-setup/SKILL.md
@@ -89,6 +89,16 @@ pncli config set sonar.token <token>
 pncli config set sde.connection <token@hostname>
 ```
 
+**Checkmarx** — "Do you use Checkmarx CxSAST for vulnerability scanning?"
+
+```
+pncli config set checkmarx.baseUrl <url>
+pncli config set checkmarx.username <username>
+pncli config set checkmarx.password <password>
+```
+
+The base URL is your CxSAST server root, e.g. `https://cx.company.com`. pncli handles the OAuth2 token exchange using your username and password — no other tools required.
+
 **IBM UrbanCode Deploy** — "Do you use IBM UrbanCode Deploy for component imports or deployment processes?"
 
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { registerAdoCommands } from './services/ado/commands/index.js';
 import { registerJenkinsCommands } from './services/jenkins/commands.js';
 import { registerArtifactoryCommands } from './services/artifactory/commands.js';
 import { registerUdeployCommands } from './services/udeploy/commands.js';
+import { registerCheckmarxCommands } from './services/checkmarx/commands.js';
 import { registerSkillsCommands } from './services/skills/commands.js';
 
 const require = createRequire(import.meta.url);
@@ -70,6 +71,7 @@ registerAdoCommands(program);
 registerJenkinsCommands(program);
 registerArtifactoryCommands(program);
 registerUdeployCommands(program);
+registerCheckmarxCommands(program);
 registerSkillsCommands(program);
 
 program.addHelpText('after', `
@@ -85,6 +87,7 @@ Services:
   jenkins      Jenkins Data Center (jobs, builds, logs)
   artifactory  Artifactory (repos, artifact search, build info, properties)
   udeploy      IBM UrbanCode Deploy (component versions, deployment processes)
+  checkmarx    Checkmarx CxSAST (projects, scans, scan statistics)
   config       Manage pncli configuration
   skills       Download and manage Claude Code skills
 `);

--- a/src/lib/checkmarxFetch.test.ts
+++ b/src/lib/checkmarxFetch.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildCheckmarxFetcher } from './checkmarxFetch.js';
+import type { ResolvedConfig } from '../types/config.js';
+
+function makeConfig(overrides: Partial<ResolvedConfig['checkmarx']> = {}): ResolvedConfig {
+  return {
+    user: { email: undefined, userId: undefined },
+    jira: { baseUrl: undefined, apiToken: undefined, customFields: [] },
+    bitbucket: { baseUrl: undefined, pat: undefined },
+    confluence: { baseUrl: undefined, apiToken: undefined, apiTokenExplicit: false },
+    artifactory: {},
+    sonar: { baseUrl: undefined, token: undefined },
+    sde: { baseUrl: undefined, token: undefined },
+    ado: { baseUrl: undefined, pat: undefined, fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
+    jenkins: { baseUrl: undefined, username: undefined, apiToken: undefined },
+    udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
+    checkmarx: {
+      baseUrl: 'https://cx.example.com',
+      username: 'admin',
+      password: 'secret',
+      ...overrides
+    },
+    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
+  };
+}
+
+function makeTokenResponse(expiresIn = 3600) {
+  return {
+    access_token: 'test-bearer-token',
+    expires_in: expiresIn,
+    token_type: 'Bearer'
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('buildCheckmarxFetcher', () => {
+  it('throws if baseUrl is missing', () => {
+    expect(() => buildCheckmarxFetcher(makeConfig({ baseUrl: undefined }))).toThrow('baseUrl not configured');
+  });
+
+  it('throws if username is missing', () => {
+    expect(() => buildCheckmarxFetcher(makeConfig({ username: undefined }))).toThrow('username not configured');
+  });
+
+  it('throws if password is missing', () => {
+    expect(() => buildCheckmarxFetcher(makeConfig({ password: undefined }))).toThrow('password not configured');
+  });
+
+  it('exchanges credentials for a token on first call', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeTokenResponse()), { status: 200 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const fetcher = buildCheckmarxFetcher(makeConfig());
+    await fetcher('https://cx.example.com/cxrestapi/projects');
+
+    // First call is token exchange
+    const tokenCall = mockFetch.mock.calls[0];
+    expect(tokenCall[0]).toBe('https://cx.example.com/cxrestapi/auth/identity/connect/token');
+    expect(tokenCall[1]?.method).toBe('POST');
+    const body = tokenCall[1]?.body as string;
+    expect(body).toContain('grant_type=password');
+    expect(body).toContain('client_id=resource_owner_client');
+    expect(body).toContain('scope=sast_api');
+    expect(body).toContain('username=admin');
+    expect(body).toContain('password=secret');
+  });
+
+  it('injects Authorization: Bearer header into the actual request', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeTokenResponse()), { status: 200 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const fetcher = buildCheckmarxFetcher(makeConfig());
+    await fetcher('https://cx.example.com/cxrestapi/projects');
+
+    const apiCall = mockFetch.mock.calls[1];
+    const headers = apiCall[1]?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer test-bearer-token');
+  });
+
+  it('reuses cached token within expiry window', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeTokenResponse(3600)), { status: 200 }))
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const fetcher = buildCheckmarxFetcher(makeConfig());
+    await fetcher('https://cx.example.com/cxrestapi/projects');
+    await fetcher('https://cx.example.com/cxrestapi/projects');
+
+    // Token endpoint called only once across both fetches
+    const tokenCalls = mockFetch.mock.calls.filter(c => String(c[0]).includes('connect/token'));
+    expect(tokenCalls).toHaveLength(1);
+  });
+
+  it('refreshes token when within 60s of expiry', async () => {
+    // First token: expires in 30s (below the 60s refresh threshold)
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeTokenResponse(30)), { status: 200 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeTokenResponse(3600)), { status: 200 }))
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const fetcher = buildCheckmarxFetcher(makeConfig());
+    await fetcher('https://cx.example.com/cxrestapi/projects');
+    // Second call should re-exchange because token expires within 60s
+    await fetcher('https://cx.example.com/cxrestapi/projects');
+
+    const tokenCalls = mockFetch.mock.calls.filter(c => String(c[0]).includes('connect/token'));
+    expect(tokenCalls).toHaveLength(2);
+  });
+
+  it('surfaces a useful error when token endpoint returns 4xx', async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce(
+      new Response('{"message":"Invalid username or password"}', { status: 400 })
+    );
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const fetcher = buildCheckmarxFetcher(makeConfig());
+    await expect(fetcher('https://cx.example.com/cxrestapi/projects')).rejects.toThrow('400');
+  });
+
+  it('does not cache a token after a failed token exchange', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeTokenResponse()), { status: 200 }))
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const fetcher = buildCheckmarxFetcher(makeConfig());
+    await expect(fetcher('https://cx.example.com/cxrestapi/projects')).rejects.toThrow();
+    // Second call should retry token exchange (not use a cached bad token)
+    await fetcher('https://cx.example.com/cxrestapi/projects');
+
+    const tokenCalls = mockFetch.mock.calls.filter(c => String(c[0]).includes('connect/token'));
+    expect(tokenCalls).toHaveLength(2);
+  });
+});

--- a/src/lib/checkmarxFetch.ts
+++ b/src/lib/checkmarxFetch.ts
@@ -1,0 +1,82 @@
+import type { ResolvedConfig } from '../types/config.js';
+import type { CheckmarxTokenResponse } from '../types/checkmarx.js';
+import { PncliError } from './errors.js';
+
+const CX_CLIENT_ID = 'resource_owner_client';
+const CX_CLIENT_SECRET = '014DF517-39D1-4453-B7B3-9930C563627C';
+const CX_SCOPE = 'sast_api offline_access';
+
+interface TokenCache {
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Returns a fetch-compatible function for Checkmarx CxSAST 9.x requests,
+ * with OAuth2 password-grant token exchange and bearer auth injected into every call.
+ * The token is cached for the lifetime of the returned fetcher and refreshed
+ * when within 60s of expiry.
+ */
+export function buildCheckmarxFetcher(config: ResolvedConfig): typeof fetch {
+  const { baseUrl, username, password } = config.checkmarx;
+
+  if (!baseUrl) throw new PncliError('Checkmarx baseUrl not configured. Run: pncli config init', 1);
+  if (!username) throw new PncliError('Checkmarx username not configured. Run: pncli config init', 1);
+  if (!password) throw new PncliError('Checkmarx password not configured. Run: pncli config init', 1);
+
+  // Capture as definite strings for use inside the closure (TypeScript can't narrow across closures)
+  const resolvedUsername: string = username;
+  const resolvedPassword: string = password;
+  const tokenUrl = `${baseUrl.replace(/\/$/, '')}/cxrestapi/auth/identity/connect/token`;
+  let cache: TokenCache | null = null;
+
+  async function getToken(): Promise<string> {
+    const now = Date.now();
+    if (cache && cache.expiresAt - now > 60_000) {
+      return cache.value;
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'password',
+      client_id: CX_CLIENT_ID,
+      client_secret: CX_CLIENT_SECRET,
+      scope: CX_SCOPE,
+      username: resolvedUsername,
+      password: resolvedPassword
+    });
+
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString()
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new PncliError(
+        `Checkmarx token exchange failed (${response.status}): ${text || response.statusText}`,
+        response.status
+      );
+    }
+
+    const data = await response.json() as CheckmarxTokenResponse;
+    cache = {
+      value: data.access_token,
+      expiresAt: now + data.expires_in * 1000
+    };
+    return cache.value;
+  }
+
+  return async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> => {
+    const token = await getToken();
+    return fetch(url, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    });
+  };
+}

--- a/src/lib/checkmarxFetch.ts
+++ b/src/lib/checkmarxFetch.ts
@@ -60,6 +60,9 @@ export function buildCheckmarxFetcher(config: ResolvedConfig): typeof fetch {
     }
 
     const data = await response.json() as CheckmarxTokenResponse;
+    if (!data.access_token) {
+      throw new PncliError('Checkmarx token endpoint returned no access_token', response.status);
+    }
     cache = {
       value: data.access_token,
       expiresAt: now + data.expires_in * 1000
@@ -67,15 +70,15 @@ export function buildCheckmarxFetcher(config: ResolvedConfig): typeof fetch {
     return cache.value;
   }
 
+  // Intentionally synchronous (unlike buildAdoFetcher which is async): the token exchange
+  // happens lazily inside getToken() on the first actual API call, not during construction.
   return async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> => {
     const token = await getToken();
     return fetch(url, {
       ...init,
       headers: {
         ...(init?.headers as Record<string, string> | undefined),
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
+        'Authorization': `Bearer ${token}`
       }
     });
   };

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -14,6 +14,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     ado: { baseUrl: 'https://ado.example.com', pat: 'secret-ado', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'secret-jenkins' },
     udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
+    checkmarx: { baseUrl: undefined, username: undefined, password: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };
@@ -87,5 +88,17 @@ describe('maskConfig', () => {
     const config = baseConfig({ udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined } });
     const masked = maskConfig(config) as ResolvedConfig;
     expect((masked.udeploy as { password?: string }).password).toBeUndefined();
+  });
+
+  it('masks checkmarx password when present', () => {
+    const config = baseConfig({ checkmarx: { baseUrl: 'https://cx.example.com', username: 'admin', password: 'secret' } });
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect((masked.checkmarx as { password?: string }).password).toBe('***');
+  });
+
+  it('leaves checkmarx password undefined when not set', () => {
+    const config = baseConfig({ checkmarx: { baseUrl: undefined, username: undefined, password: undefined } });
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect((masked.checkmarx as { password?: string }).password).toBeUndefined();
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -31,6 +31,9 @@ const ENV_KEYS = {
   UDEPLOY_PAT: 'PNCLI_UDEPLOY_PAT',
   UDEPLOY_USERNAME: 'PNCLI_UDEPLOY_USERNAME',
   UDEPLOY_PASSWORD: 'PNCLI_UDEPLOY_PASSWORD',
+  CHECKMARX_BASE_URL: 'PNCLI_CHECKMARX_BASE_URL',
+  CHECKMARX_USERNAME: 'PNCLI_CHECKMARX_USERNAME',
+  CHECKMARX_PASSWORD: 'PNCLI_CHECKMARX_PASSWORD',
   CONFIG_PATH: 'PNCLI_CONFIG_PATH'
 } as const;
 
@@ -163,6 +166,11 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
       username: process.env[ENV_KEYS.UDEPLOY_USERNAME] ?? globalConfig.udeploy?.username,
       password: process.env[ENV_KEYS.UDEPLOY_PASSWORD] ?? globalConfig.udeploy?.password,
     },
+    checkmarx: {
+      baseUrl: process.env[ENV_KEYS.CHECKMARX_BASE_URL] ?? globalConfig.checkmarx?.baseUrl,
+      username: process.env[ENV_KEYS.CHECKMARX_USERNAME] ?? globalConfig.checkmarx?.username,
+      password: process.env[ENV_KEYS.CHECKMARX_PASSWORD] ?? globalConfig.checkmarx?.password,
+    },
     defaults: mergedDefaults
   };
 }
@@ -262,6 +270,10 @@ export function maskConfig(config: ResolvedConfig): unknown {
       ...config.udeploy,
       pat: config.udeploy.pat ? '***' : undefined,
       password: config.udeploy.password ? '***' : undefined
+    },
+    checkmarx: {
+      ...config.checkmarx,
+      password: config.checkmarx.password ? '***' : undefined
     }
   };
 }

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -14,6 +14,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     ado: { baseUrl: 'https://ado.example.com', pat: 'tok', fieldAliases: {}, discoveredFields: [], discoveredTypes: [] },
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'tok' },
     udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
+    checkmarx: { baseUrl: undefined, username: undefined, password: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -4,6 +4,7 @@ import { PncliError } from './errors.js';
 import { ExitCode } from './exitCodes.js';
 import { log } from './output.js';
 import { buildAdoFetcher } from './adoFetch.js';
+import { buildCheckmarxFetcher } from './checkmarxFetch.js';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
@@ -123,6 +124,7 @@ export class HttpClient {
   private config: ResolvedConfig;
   private dryRun: boolean;
   private adoFetcher: typeof fetch | null = null;
+  private checkmarxFetcher: typeof fetch | null = null;
 
   constructor(config: ResolvedConfig, dryRun = false) {
     this.config = config;
@@ -740,6 +742,40 @@ export class HttpClient {
     }
 
     return results;
+  }
+
+  private getCheckmarxFetcher(): typeof fetch {
+    if (!this.checkmarxFetcher) {
+      this.checkmarxFetcher = buildCheckmarxFetcher(this.config);
+    }
+    return this.checkmarxFetcher;
+  }
+
+  async checkmarx<T>(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<T> {
+    const baseUrl = this.config.checkmarx.baseUrl;
+    if (!baseUrl) throw new PncliError('Checkmarx baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+
+    if (this.dryRun) {
+      const msg = `DRY RUN: ${opts.method ?? 'GET'} ${url}\n`
+        + (opts.body ? `Body: ${JSON.stringify(opts.body, null, 2)}\n` : '');
+      fs.writeSync(process.stderr.fd, msg);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    const fetcher = this.getCheckmarxFetcher();
+    const init: RequestInit = {
+      method: opts.method ?? 'GET',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json', ...opts.headers },
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
+    };
+
+    return request<T>(url, init, opts.timeoutMs ?? 30000, fetcher);
   }
 }
 

--- a/src/services/checkmarx/client.ts
+++ b/src/services/checkmarx/client.ts
@@ -1,0 +1,31 @@
+import type { HttpClient } from '../../lib/http.js';
+import type { CheckmarxProject, CheckmarxScan, CheckmarxResultsStats } from '../../types/checkmarx.js';
+
+export class CheckmarxClient {
+  constructor(private http: HttpClient) {}
+
+  async listProjects(): Promise<CheckmarxProject[]> {
+    return this.http.checkmarx<CheckmarxProject[]>('/cxrestapi/projects');
+  }
+
+  async getProject(id: number): Promise<CheckmarxProject> {
+    return this.http.checkmarx<CheckmarxProject>(`/cxrestapi/projects/${id}`);
+  }
+
+  async listScans(opts: { projectId?: number; last?: number } = {}): Promise<CheckmarxScan[]> {
+    return this.http.checkmarx<CheckmarxScan[]>('/cxrestapi/sast/scans', {
+      params: {
+        projectId: opts.projectId,
+        last: opts.last
+      }
+    });
+  }
+
+  async getScan(id: number): Promise<CheckmarxScan> {
+    return this.http.checkmarx<CheckmarxScan>(`/cxrestapi/sast/scans/${id}`);
+  }
+
+  async getScanResultsStatistics(scanId: number): Promise<CheckmarxResultsStats> {
+    return this.http.checkmarx<CheckmarxResultsStats>(`/cxrestapi/sast/scans/${scanId}/resultsStatistics`);
+  }
+}

--- a/src/services/checkmarx/commands.ts
+++ b/src/services/checkmarx/commands.ts
@@ -1,0 +1,90 @@
+import { Command } from 'commander';
+import { loadConfig } from '../../lib/config.js';
+import { createHttpClient } from '../../lib/http.js';
+import { CheckmarxClient } from './client.js';
+import { success, fail } from '../../lib/output.js';
+import { PncliError } from '../../lib/errors.js';
+
+function getClient(program: Command): CheckmarxClient {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config as string | undefined });
+  if (!config.checkmarx.baseUrl) throw new PncliError('Checkmarx not configured. Run: pncli config init');
+  const http = createHttpClient(config, Boolean(opts.dryRun));
+  return new CheckmarxClient(http);
+}
+
+export function registerCheckmarxCommands(program: Command): void {
+  const cx = program.command('checkmarx').description('Checkmarx CxSAST operations');
+  const project = cx.command('project').description('Project operations');
+  const scan = cx.command('scan').description('Scan operations');
+
+  project
+    .command('list')
+    .description('List all projects')
+    .action(async () => {
+      const start = Date.now();
+      try {
+        const data = await getClient(program).listProjects();
+        success(data, 'checkmarx', 'project-list', start);
+      } catch (err) { fail(err, 'checkmarx', 'project-list', start); }
+    });
+
+  project
+    .command('get')
+    .description('Get a project by ID')
+    .requiredOption('--id <id>', 'Project ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const id = parseInt(opts.id, 10);
+        if (isNaN(id)) throw new PncliError(`Invalid --id "${opts.id}". Expected an integer.`, 1);
+        const data = await getClient(program).getProject(id);
+        success(data, 'checkmarx', 'project-get', start);
+      } catch (err) { fail(err, 'checkmarx', 'project-get', start); }
+    });
+
+  scan
+    .command('list')
+    .description('List scans')
+    .option('--project <id>', 'Filter by project ID')
+    .option('--last <n>', 'Return only the last N scans per project')
+    .action(async (opts: { project?: string; last?: string }) => {
+      const start = Date.now();
+      try {
+        const projectId = opts.project ? parseInt(opts.project, 10) : undefined;
+        const last = opts.last ? parseInt(opts.last, 10) : undefined;
+        if (opts.project && isNaN(projectId!)) throw new PncliError(`Invalid --project "${opts.project}". Expected an integer.`, 1);
+        if (opts.last && isNaN(last!)) throw new PncliError(`Invalid --last "${opts.last}". Expected an integer.`, 1);
+        const data = await getClient(program).listScans({ projectId, last });
+        success(data, 'checkmarx', 'scan-list', start);
+      } catch (err) { fail(err, 'checkmarx', 'scan-list', start); }
+    });
+
+  scan
+    .command('get')
+    .description('Get a scan by ID')
+    .requiredOption('--id <id>', 'Scan ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const id = parseInt(opts.id, 10);
+        if (isNaN(id)) throw new PncliError(`Invalid --id "${opts.id}". Expected an integer.`, 1);
+        const data = await getClient(program).getScan(id);
+        success(data, 'checkmarx', 'scan-get', start);
+      } catch (err) { fail(err, 'checkmarx', 'scan-get', start); }
+    });
+
+  scan
+    .command('stats')
+    .description('Get results statistics for a scan')
+    .requiredOption('--id <id>', 'Scan ID')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const id = parseInt(opts.id, 10);
+        if (isNaN(id)) throw new PncliError(`Invalid --id "${opts.id}". Expected an integer.`, 1);
+        const data = await getClient(program).getScanResultsStatistics(id);
+        success(data, 'checkmarx', 'scan-stats', start);
+      } catch (err) { fail(err, 'checkmarx', 'scan-stats', start); }
+    });
+}

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -196,6 +196,17 @@ export function registerConfigCommands(program: Command): void {
           results.udeploy = { ok: null, message: 'not configured' };
         }
 
+        if (cfg.checkmarx.baseUrl && cfg.checkmarx.username && cfg.checkmarx.password) {
+          try {
+            await http.checkmarx<unknown>('/cxrestapi/projects');
+            results.checkmarx = { ok: true, message: 'connected' };
+          } catch (err) {
+            results.checkmarx = { ok: false, message: err instanceof Error ? err.message : String(err) };
+          }
+        } else {
+          results.checkmarx = { ok: null, message: 'not configured' };
+        }
+
         success(results, 'config', 'test', start);
       } catch (err) {
         fail(err, 'config', 'test', start);
@@ -360,6 +371,20 @@ export function registerConfigCommands(program: Command): void {
           results.artifactory = { status: 'valid', message: 'ok' };
         }
 
+        // Checkmarx
+        if (!cfg.checkmarx.username || !cfg.checkmarx.password) {
+          results.checkmarx = { status: 'blank', message: 'not configured' };
+        } else if (!cfg.checkmarx.baseUrl) {
+          results.checkmarx = { status: 'error', message: 'baseUrl not configured' };
+        } else {
+          try {
+            await http.checkmarx<unknown>('/cxrestapi/projects', { timeoutMs: 10_000 });
+            results.checkmarx = { status: 'valid', message: 'ok' };
+          } catch (err) {
+            results.checkmarx = categorize(err);
+          }
+        }
+
         // Exit code: prefer AUTH_ERROR if any invalid, else NETWORK_ERROR if any errors
         const statuses = Object.values(results).map(r => r.status);
         if (statuses.includes('invalid')) process.exitCode = ExitCode.AUTH_ERROR;
@@ -367,7 +392,7 @@ export function registerConfigCommands(program: Command): void {
 
         if (cmdOpts.output === 'table') {
           // Human-readable table to stdout
-          const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory'] as const;
+          const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx'] as const;
           const labelWidth = 14;
           const statusWidth = 9;
           for (const svc of services) {
@@ -385,7 +410,7 @@ export function registerConfigCommands(program: Command): void {
         } else {
           // Pretty table on stderr when --pretty is set (stdout stays JSON)
           if (opts.pretty) {
-            const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory'] as const;
+            const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx'] as const;
             const labelWidth = 14;
             const statusWidth = 9;
             for (const svc of services) {
@@ -729,6 +754,53 @@ async function initGlobalConfig(start: number): Promise<void> {
     }
   }
 
+  process.stderr.write('\n── Checkmarx ─────────────────────────────────────\n');
+  const useCheckmarx = await confirm({
+    message: 'Configure Checkmarx CxSAST for vulnerability scanning?',
+    default: false
+  });
+
+  let checkmarxBaseUrl = '';
+  let checkmarxUsername = '';
+  let checkmarxPassword = '';
+
+  if (useCheckmarx) {
+    checkmarxBaseUrl = await input({
+      message: 'Checkmarx base URL (e.g. https://cx.company.com):',
+      default: ''
+    });
+
+    checkmarxUsername = await input({
+      message: 'Checkmarx username:',
+      default: ''
+    });
+
+    checkmarxPassword = await password({
+      message: 'Checkmarx password:',
+      validate: (v) => v.length > 0 || 'Password cannot be blank'
+    });
+
+    if (checkmarxBaseUrl && checkmarxUsername && checkmarxPassword) {
+      process.stderr.write('\n  Verifying connection...\n');
+      try {
+        const tempConfig = {
+          ...loadConfig(),
+          checkmarx: {
+            baseUrl: checkmarxBaseUrl,
+            username: checkmarxUsername,
+            password: checkmarxPassword
+          }
+        };
+        const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
+        await tempHttp.checkmarx<unknown>('/cxrestapi/projects');
+        process.stderr.write('  Connected.\n');
+      } catch (err) {
+        warn(`Could not connect to Checkmarx: ${err instanceof Error ? err.message : String(err)}`);
+        warn('Config will be saved anyway. Check your URL and credentials and re-run pncli config init or pncli config test.');
+      }
+    }
+  }
+
   process.stderr.write('\n── Defaults ──────────────────────────────────────\n');
   const jiraProject = await input({
     message: 'Default Jira project key (optional):',
@@ -818,6 +890,13 @@ async function initGlobalConfig(start: number): Promise<void> {
         ...(udeployPat ? { pat: udeployPat } : {}),
         ...(udeployUsername ? { username: udeployUsername } : {}),
         ...(udeployPassword ? { password: udeployPassword } : {})
+      }
+    } : {}),
+    ...(useCheckmarx && checkmarxBaseUrl ? {
+      checkmarx: {
+        baseUrl: checkmarxBaseUrl,
+        username: checkmarxUsername || undefined,
+        password: checkmarxPassword || undefined
       }
     } : {}),
     defaults: {

--- a/src/types/checkmarx.ts
+++ b/src/types/checkmarx.ts
@@ -1,0 +1,58 @@
+export interface CheckmarxTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+export interface CheckmarxProject {
+  id: number;
+  teamId: string;
+  name: string;
+  isPublic: boolean;
+  description: string;
+  createdDate: string;
+  projectOwner: string;
+}
+
+export interface CheckmarxScanStatus {
+  id: number;
+  name: string;
+  details: string | null;
+}
+
+export interface CheckmarxScanStage {
+  value: string;
+  stateValue: number;
+  details: string | null;
+}
+
+export interface CheckmarxScan {
+  id: number;
+  status: CheckmarxScanStatus;
+  scanState: CheckmarxScanStage;
+  owner: string;
+  origin: string;
+  initiatorName: string;
+  project: { id: number; value: string };
+  team: { id: string; value: string };
+  engineServer: { id: number; value: string };
+  engineId: number;
+  isPublic: boolean;
+  isIncremental: boolean;
+  processCanceled: boolean;
+  comment: string;
+  dateAndTime: {
+    startedOn: string;
+    finishedOn: string;
+    engineStartedOn: string;
+    engineFinishedOn: string;
+  };
+}
+
+export interface CheckmarxResultsStats {
+  highSeverity: number;
+  mediumSeverity: number;
+  lowSeverity: number;
+  infoSeverity: number;
+  statisticsCalculationDate: string;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -92,6 +92,12 @@ export interface UdeployConfig {
   password?: string;
 }
 
+export interface CheckmarxConfig {
+  baseUrl?: string;
+  username?: string;
+  password?: string;
+}
+
 export interface UdeployDefaults {
   application?: string;
   environment?: string;
@@ -122,6 +128,7 @@ export interface GlobalConfig {
   ado?: AdoConfig;
   jenkins?: JenkinsConfig;
   udeploy?: UdeployConfig;
+  checkmarx?: CheckmarxConfig;
   defaults?: Defaults;
 }
 
@@ -174,6 +181,11 @@ export interface ResolvedConfig {
   udeploy: {
     baseUrl: string | undefined;
     pat: string | undefined;
+    username: string | undefined;
+    password: string | undefined;
+  };
+  checkmarx: {
+    baseUrl: string | undefined;
     username: string | undefined;
     password: string | undefined;
   };


### PR DESCRIPTION
## Summary

- Adds Checkmarx CxSAST 9.x integration: projects, scans, and scan statistics
- pncli exchanges username/password for a bearer token natively via OAuth2 password grant — no external CLI (az, gcloud, etc.) required at runtime
- Codifies two new project rules in `CLAUDE.md` and the automated triage workflow:
  - **Self-Containment Rule**: integrations must not require other CLIs at runtime; pncli must handle any token exchange natively
  - **Testing Rule**: unit tests stub `fetch`; live connectivity is `pncli config test`'s job
- Fixes stale docs: README services table now includes designed-for version and auth method per integration; env var table backfilled (ADO, Artifactory, Checkmarx); site ServiceGrid, feedback form dropdown, and getting-started prose refreshed to match the current service list
- Fixes pre-existing site schema error (`license-audit-to-tickets` category `"code-quality"` was not in the Zod enum)

## Commands added / updated

- `pncli checkmarx project list` — list all projects
- `pncli checkmarx project get --id <id>` — get a project by ID
- `pncli checkmarx scan list [--project <id>] [--last <n>]` — list scans, optionally filtered by project or limited to last N
- `pncli checkmarx scan get --id <id>` — get a scan by ID
- `pncli checkmarx scan stats --id <id>` — get vulnerability count statistics for a scan (high/medium/low/info)

## Pre-PR gate

- ✅ Build: passed
- ✅ Typecheck: 0 errors (pre-existing vitest module resolution errors on `tsc --noEmit` unchanged from main)
- ✅ Lint: clean
- ✅ Code review: approved after fixing duplicate headers in fetcher, adding `access_token` presence check, and adding sync/async design comment
- ✅ Tests: 80 passed (9 new tests in `checkmarxFetch.test.ts` covering token exchange, bearer injection, cache reuse/refresh, 4xx handling, bad-token non-caching, and password masking)
- ✅ Docs: `copilot-instructions.md` updated with Checkmarx command reference; `README.md`, site components, and getting-started refreshed

## Screenshots

> The browser extension was not available during this run. Site changes verified via curl:
> - `/pncli/` — `Checkmarx` present in ServiceGrid (confirmed)
> - `/pncli/feedback/` — Checkmarx, Jenkins, Artifactory, IBM UrbanCode Deploy now in service dropdown (confirmed)
> - `/pncli/getting-started/` — full service list including Checkmarx in "What is pncli?" (confirmed)

Closes #116