### PR TITLE
feat(site): integration testing-maturity badges + homepage reframe + triage workflow bump

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -149,7 +149,7 @@ jobs:
             unless the issue specifically requests it. Make the narrowest change that
             addresses the issue.
           claude_args: |
-            --model sonnet --max-turns 50 --allowedTools "Read,Glob,Grep,Edit,Write,Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Bash(gh pr create:*),Bash(npm run build:*),Bash(npm run typecheck:*),Bash(npm run lint:*),Bash(git checkout -b:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
+            --model sonnet --max-turns 300 --allowedTools "Read,Glob,Grep,Edit,Write,Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Bash(gh pr create:*),Bash(npm run build:*),Bash(npm run typecheck:*),Bash(npm run lint:*),Bash(git checkout -b:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
 
       - name: Write job summary
         if: always()

--- a/site/src/components/ServiceGrid.astro
+++ b/site/src/components/ServiceGrid.astro
@@ -1,20 +1,8 @@
 ---
 import { Image } from 'astro:assets';
 import tools from '../assets/tools.png';
-
-const services = [
-  { name: 'Git',          description: 'Local repository operations',   active: true  },
-  { name: 'Jira',         description: 'Issues, sprints, projects',      active: true  },
-  { name: 'Bitbucket',    description: 'Pull requests, repositories',    active: true  },
-  { name: 'Confluence',   description: 'Pages, spaces, content',         active: true  },
-  { name: 'SonarQube',    description: 'Code quality & security',        active: true  },
-  { name: 'Checkmarx',    description: 'Vulnerability scanning (SAST)',  active: true  },
-  { name: 'SDElements',   description: 'Security requirements',          active: true  },
-  { name: 'Azure DevOps', description: 'Work items, pipelines',          active: true  },
-  { name: 'IBM UDeploy',  description: 'Component versions, deploys',    active: true  },
-  { name: 'Artifactory',  description: 'Artifact repository',            active: true  },
-  { name: 'Jenkins',      description: 'CI/CD pipelines',               active: true  },
-];
+import TestingMeter from './TestingMeter.astro';
+import { integrations } from '../lib/integrations';
 ---
 
 <section class="relative w-full py-20 px-6 overflow-hidden bg-cream border-t border-ink/5">
@@ -33,11 +21,12 @@ const services = [
       <h2 class="font-display text-4xl md:text-5xl font-bold text-ink">
         Every tool your org<br class="hidden sm:block" /> throws at you.
       </h2>
-      <p class="mt-3 text-ink/50 text-lg">Data Center editions, specifically. The ones your company hasn't gotten around to migrating off yet.</p>
+      <p class="mt-3 text-ink/50 text-lg">Give GitHub Copilot, Claude Code, and Codex a unified API into the Data Center editions your org hasn't migrated yet.</p>
+      <p class="mt-2 text-ink/30 text-sm font-mono">Testing maturity shown per integration — <code>untested</code> means shipped but not validated against a live instance.</p>
     </div>
 
     <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-      {services.map(service => (
+      {integrations.map(service => (
         <div
           class={`rounded-xl px-5 py-4 border transition-all ${
             service.active
@@ -55,7 +44,7 @@ const services = [
               </p>
             </div>
             {service.active ? (
-              <span class="shrink-0 mt-1.5 w-2 h-2 rounded-full bg-coral/80"></span>
+              <TestingMeter level={service.testing} />
             ) : (
               <span class="shrink-0 text-xs font-mono text-ink/30 bg-ink/5 px-2 py-0.5 rounded-full whitespace-nowrap">
                 soon

--- a/site/src/components/TestingMeter.astro
+++ b/site/src/components/TestingMeter.astro
@@ -1,0 +1,36 @@
+---
+import type { TestingLevel } from '../lib/integrations';
+
+interface Props {
+  level: TestingLevel;
+}
+
+const { level } = Astro.props;
+
+const filledCount = { untested: 1, basic: 2, beta: 3, live: 4 }[level];
+
+const filledClass = {
+  untested: 'bg-ink/20',
+  basic:    'bg-violet/70',
+  beta:     'bg-coral/70',
+  live:     'bg-coral',
+}[level];
+
+const labelClass = {
+  untested: 'text-ink/30',
+  basic:    'text-violet/70',
+  beta:     'text-coral/70',
+  live:     'text-coral',
+}[level];
+
+const bars = [1, 2, 3, 4].map(i => i <= filledCount);
+---
+
+<span class="flex items-center gap-1.5 shrink-0 mt-1.5">
+  <span class="flex items-end gap-0.5">
+    {bars.map(isFilled => (
+      <span class={`w-1.5 h-3 rounded-sm ${isFilled ? filledClass : 'bg-ink/10'}`}></span>
+    ))}
+  </span>
+  <span class={`text-xs font-mono ${labelClass}`}>{level}</span>
+</span>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const {
   title = 'pncli — The Paperwork Nightmare CLI',
-  description = 'One command does what three meetings couldn\'t. Structured CLI access to Jira, Bitbucket, Confluence, SonarQube, and more.',
+  description = 'Bridge GitHub Copilot, Claude Code, and Codex to your Data Center SDLC stack. Structured JSON access to Jira, Bitbucket, Confluence, SonarQube, and more.',
 } = Astro.props;
 ---
 
@@ -27,8 +27,7 @@ const {
     <script is:inline>
       (function () {
         var stored = localStorage.getItem('pncli-theme');
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.dataset.theme = stored ?? (prefersDark ? 'dark' : 'light');
+        document.documentElement.dataset.theme = stored ?? 'light';
       })();
     </script>
   </head>

--- a/site/src/lib/integrations.ts
+++ b/site/src/lib/integrations.ts
@@ -1,0 +1,24 @@
+export type TestingLevel = 'untested' | 'basic' | 'beta' | 'live';
+
+export interface Integration {
+  name: string;
+  description: string;
+  active: boolean;
+  testing: TestingLevel;
+}
+
+export const integrations: Integration[] = [
+  { name: 'Git',          description: 'Local repository operations',   active: true,  testing: 'live'     },
+  { name: 'Jira',         description: 'Issues, sprints, projects',     active: true,  testing: 'basic'    },
+  { name: 'Bitbucket',    description: 'Pull requests, repositories',   active: true,  testing: 'basic'    },
+  { name: 'Confluence',   description: 'Pages, spaces, content',        active: true,  testing: 'basic'    },
+  { name: 'SonarQube',    description: 'Code quality & security',       active: true,  testing: 'basic'    },
+  { name: 'Checkmarx',    description: 'Vulnerability scanning (SAST)', active: true,  testing: 'untested' },
+  { name: 'SDElements',   description: 'Security requirements',         active: true,  testing: 'basic'    },
+  { name: 'Azure DevOps', description: 'Work items, pipelines',         active: true,  testing: 'basic'    },
+  { name: 'IBM UDeploy',  description: 'Component versions, deploys',   active: true,  testing: 'basic'    },
+  { name: 'Artifactory',  description: 'Artifact repository',           active: true,  testing: 'basic'    },
+  { name: 'Jenkins',      description: 'CI/CD pipelines',               active: true,  testing: 'basic'    },
+  { name: 'Contrast IAST', description: 'Runtime application security', active: true,  testing: 'untested' },
+  { name: 'ServiceNow',   description: 'IT service management',         active: true,  testing: 'untested' },
+];

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -39,22 +39,22 @@ const fmt = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', y
           </h2>
           <div class="flex flex-col gap-3">
             <div class="rounded-xl border border-ink/10 bg-ink text-cream p-5">
-              <p class="font-display font-semibold text-base mb-1">Three meetings to get one PR merged.</p>
+              <p class="font-display font-semibold text-base mb-1">Your coding agents can't reach your stack.</p>
               <p class="text-cream/55 text-sm leading-relaxed">
-                Your org blocked MCP. Your agents still need to review PRs, create issues,
-                and manage code reviews.
+                GitHub Copilot, Claude Code, and Codex need to create Jira tickets, review PRs,
+                and run security scans — but your Data Center tools have no native agent integration.
               </p>
             </div>
             <div class="rounded-xl border border-coral/25 bg-coral/5 p-5">
-              <p class="font-display font-semibold text-ink text-base mb-1">One command instead.</p>
+              <p class="font-display font-semibold text-ink text-base mb-1">pncli bridges the gap.</p>
               <p class="text-ink/55 text-sm leading-relaxed">
-                pncli is the shim layer — one npm install and you're cutting through red tape.
+                One CLI with a structured JSON API your agents can call directly. No MCP required, no custom integrations to maintain.
               </p>
             </div>
             <div class="rounded-xl border border-violet/25 bg-violet/5 p-5">
-              <p class="font-display font-semibold text-ink text-base mb-1">Works with your stack.</p>
+              <p class="font-display font-semibold text-ink text-base mb-1">Every Data Center tool, covered.</p>
               <p class="text-ink/55 text-sm leading-relaxed">
-                Your full Data Center stack — see below.
+                Jira, Bitbucket, Confluence, SonarQube, and more — the on-prem editions your org hasn't migrated yet.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Adds a 4-bar testing-maturity meter badge (untested → basic → beta → live) to each service card on the homepage, giving users an honest read on how well each integration has been validated
- Extracts the service list to `site/src/lib/integrations.ts` (typed, single source of truth); adds Contrast IAST and ServiceNow as upcoming `untested` entries
- Reframes "Why pncli" section copy: positions pncli as the bridge between AI coding agents (GitHub Copilot, Claude Code, Codex) and Data Center enterprise tooling, replacing the "three meetings" framing
- Defaults the site to light mode regardless of OS preference
- Updates meta description to reflect the agent-connector positioning
- Bumps `claude-triage` workflow from `--max-turns 50` → `--max-turns 300` so the agent can complete full service integration implementations without hitting the cap

## Pre-PR gate
- ✅ Build: passed (CLI tsup + Astro static — 35 pages)
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Tests: passing
- ✅ Docs: no stale docs (site content updated in this PR)

> **Note — screenshots:** The browser extension was not connected during this run. The site dev server ran cleanly at `http://localhost:4323/pncli/` and `astro build` completed without errors. Please verify the testing badges visually before merging.