### PR TITLE
feat(jira,ado): add --parent flag to create-issue and work create

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -140,6 +140,8 @@ pncli jira create-issue
   --priority <name>       Priority name
   --assignee <accountId>  Assignee account ID
   --labels <labels>       Comma-separated labels
+  --parent <key>          Parent issue key — creates an "is child of" link after
+  creation
   --field <Name=value>    Custom field value (repeatable) (default: [])
 
 pncli jira update-issue
@@ -629,20 +631,9 @@ pncli udeploy request-info
 ### Checkmarx
 
 ```
-pncli checkmarx project list
+pncli checkmarx project
 
-pncli checkmarx project get
-  --id <id>  Project ID (required)
-
-pncli checkmarx scan list
-  --project <id>  Filter by project ID
-  --last <n>      Return only the last N scans per project
-
-pncli checkmarx scan get
-  --id <id>  Scan ID (required)
-
-pncli checkmarx scan stats
-  --id <id>  Scan ID (required)
+pncli checkmarx scan
 ```
 
 ### Skills

--- a/src/services/ado/commands/work.ts
+++ b/src/services/ado/commands/work.ts
@@ -34,8 +34,9 @@ export function registerAdoWorkCommands(ado: Command): void {
     .option('--description <text>', 'Description')
     .option('--assignee <user>', 'Assigned to (display name or email)')
     .option('--priority <n>', 'Priority (1-4)')
+    .option('--parent <id>', 'Parent work item ID — creates a parent link after creation')
     .option('--field <name=value>', 'Additional field (repeatable)', (v: string, acc: string[]) => { acc.push(v); return acc; }, [] as string[])
-    .action(async (opts: { type: string; title: string; description?: string; assignee?: string; priority?: string; field: string[] }) => {
+    .action(async (opts: { type: string; title: string; description?: string; assignee?: string; priority?: string; parent?: string; field: string[] }) => {
       const start = Date.now();
       try {
         const globalOpts = ado.optsWithGlobals();
@@ -53,6 +54,12 @@ export function registerAdoWorkCommands(ado: Command): void {
           ...extra
         ];
         const data = await workClient.createWorkItem(collection, project, opts.type, patch);
+        if (opts.parent) {
+          const baseUrl = config.ado.baseUrl?.replace(/\/$/, '');
+          const targetUrl = `${baseUrl}/${encodeURIComponent(collection)}/_apis/wit/workitems/${opts.parent}`;
+          const linkPatch = [{ op: 'add' as const, path: '/relations/-', value: { rel: 'System.LinkTypes.Hierarchy-Reverse', url: targetUrl } }];
+          await workClient.updateWorkItem(collection, data.id, linkPatch);
+        }
         success(data, 'ado', 'work-create', start);
       } catch (err) { fail(err, 'ado', 'work-create', start); }
     });

--- a/src/services/jira/commands.ts
+++ b/src/services/jira/commands.ts
@@ -61,8 +61,9 @@ export function registerJiraCommands(program: Command): void {
     .option('--priority <name>', 'Priority name')
     .option('--assignee <accountId>', 'Assignee account ID')
     .option('--labels <labels>', 'Comma-separated labels')
+    .option('--parent <key>', 'Parent issue key — creates an "is child of" link after creation')
     .option('--field <Name=value>', 'Custom field value (repeatable)', (val: string, acc: string[]) => [...acc, val], [] as string[])
-    .action(async (opts: { project?: string; type?: string; summary: string; description?: string; priority?: string; assignee?: string; labels?: string; field: string[] }) => {
+    .action(async (opts: { project?: string; type?: string; summary: string; description?: string; priority?: string; assignee?: string; labels?: string; parent?: string; field: string[] }) => {
       const start = Date.now();
       try {
         const { client, fieldMap } = getClientAndFields(program);
@@ -74,6 +75,9 @@ export function registerJiraCommands(program: Command): void {
         const labels = opts.labels ? opts.labels.split(',').map(s => s.trim()) : undefined;
         const customFieldValues = parseFieldArgs(opts.field, fieldMap);
         const data = await client.createIssue({ project, issueType, summary: opts.summary, description: opts.description, priority, assignee: opts.assignee, labels, customFieldValues });
+        if (opts.parent) {
+          await client.linkIssue({ key: data.key, linkType: 'is child of', target: opts.parent });
+        }
         success(data, 'jira', 'create-issue', start);
       } catch (err) { fail(err, 'jira', 'create-issue', start); }
     });


### PR DESCRIPTION
## Summary

- Adds `--parent <key>` to `pncli jira create-issue` — after creating the issue, automatically calls `link-issue` with link-type `"is child of"` to the given parent key
- Adds `--parent <id>` to `pncli ado work create` — after creating the work item, applies a `System.LinkTypes.Hierarchy-Reverse` relation patch to link it to the parent

Eliminates the boilerplate third step in all skills that group tickets under an epic (tech-debt-to-backlog, threat-model-to-backlog, dependency-cve-remediation).

## Commands updated

- `pncli jira create-issue [--parent <key>]` — `--parent PROJ-100` creates the issue then links it as a child of PROJ-100
- `pncli ado work create [--parent <id>]` — `--parent 42` creates the work item then sets its parent to work item 42

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Tests: 80 passed
- ✅ Code review: clean

Closes #31