### PR TITLE
feat(site): add auto-generated commands reference page

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -6,8 +6,8 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "dev": "node scripts/parse-changelog.mjs && node scripts/parse-instructions.mjs && node scripts/parse-skills.mjs && astro dev",
-    "prebuild": "node scripts/parse-changelog.mjs && node scripts/parse-instructions.mjs && node scripts/parse-skills.mjs",
+    "dev": "node scripts/parse-changelog.mjs && node scripts/parse-instructions.mjs && node scripts/parse-skills.mjs && node scripts/parse-commands.mjs && astro dev",
+    "prebuild": "node scripts/parse-changelog.mjs && node scripts/parse-instructions.mjs && node scripts/parse-skills.mjs && node scripts/parse-commands.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/site/scripts/parse-commands.mjs
+++ b/site/scripts/parse-commands.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Parses pncli command registrations from src/services/ TypeScript source files
+ * and generates site/src/content/docs/commands.mdx for the site commands page.
+ *
+ * Strategy: split each commands.ts file on `.action(` to get per-command blocks,
+ * then extract the last `.command('name')`, `.description('text')`, and all
+ * `.option`/`.requiredOption` calls from each block.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '../..');
+const outDir = join(__dirname, '../src/content/docs');
+const outFile = join(outDir, 'commands.mdx');
+
+// Each entry maps a commands.ts file to its CLI prefix (the full path before the leaf subcommand).
+// For nested subgroups (e.g. jenkins > pipeline > cmd), set prefix to include all parent groups.
+const SERVICES = [
+  { name: 'Git',                          file: 'src/services/git/commands.ts',            prefix: 'git' },
+  { name: 'Jira',                         file: 'src/services/jira/commands.ts',           prefix: 'jira' },
+  { name: 'Bitbucket',                    file: 'src/services/bitbucket/commands.ts',      prefix: 'bitbucket' },
+  { name: 'Confluence',                   file: 'src/services/confluence/commands.ts',     prefix: 'confluence' },
+  { name: 'SonarQube',                    file: 'src/services/sonar/commands.ts',          prefix: 'sonar' },
+  { name: 'SDElements',                   file: 'src/services/sde/commands.ts',            prefix: 'sde' },
+  { name: 'Dependencies',                 file: 'src/services/deps/commands.ts',           prefix: 'deps' },
+  { name: 'Config',                       file: 'src/services/config/commands.ts',         prefix: 'config' },
+  { name: 'Azure DevOps — Work Items',    file: 'src/services/ado/commands/work.ts',       prefix: 'ado work' },
+  { name: 'Azure DevOps — Repos & PRs',  file: 'src/services/ado/commands/repo.ts',       prefix: 'ado repo' },
+  { name: 'Azure DevOps — Pipelines',    file: 'src/services/ado/commands/pipeline.ts',   prefix: 'ado pipeline' },
+  { name: 'Azure DevOps — Projects',     file: 'src/services/ado/commands/project.ts',    prefix: 'ado project' },
+  { name: 'Jenkins',                      file: 'src/services/jenkins/commands.ts',        prefix: 'jenkins pipeline' },
+  { name: 'JFrog Artifactory',           file: 'src/services/artifactory/commands.ts',    prefix: 'artifactory' },
+  { name: 'IBM UrbanCode Deploy',        file: 'src/services/udeploy/commands.ts',        prefix: 'udeploy' },
+  { name: 'Checkmarx',                   file: 'src/services/checkmarx/commands.ts',      prefix: 'checkmarx' },
+];
+
+function extractCommands(filePath, prefix) {
+  const content = readFileSync(filePath, 'utf8');
+  const commands = [];
+
+  // Split on .action( so each segment ends with the registration for one command.
+  const segments = content.split(/\.action\s*\(/);
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+
+    // Find all .command('name') in this segment; take the last one — that's the leaf subcommand.
+    const cmdMatches = [...segment.matchAll(/\.command\s*\(\s*'([^']+)'\s*\)/g)];
+    if (cmdMatches.length === 0) continue;
+    const lastCmd = cmdMatches[cmdMatches.length - 1];
+    const cmdName = lastCmd[1];
+
+    // Slice from the last .command('name') onwards to find description and options.
+    const afterCmd = segment.slice(lastCmd.index + lastCmd[0].length);
+
+    const descMatch = afterCmd.match(/\.description\s*\(\s*'([^']+)'\s*\)/);
+    if (!descMatch) continue;
+    const description = descMatch[1];
+
+    const options = [];
+    for (const m of afterCmd.matchAll(/\.(requiredOption|option)\s*\(\s*'([^']+)'\s*,\s*'([^']+)'/g)) {
+      options.push({ flag: m[2], description: m[3], required: m[1] === 'requiredOption' });
+    }
+
+    commands.push({
+      name: `pncli ${prefix} ${cmdName}`.replace(/\s+/g, ' ').trim(),
+      description,
+      options,
+    });
+  }
+
+  return commands;
+}
+
+function buildMdx(services) {
+  const lines = [
+    '---',
+    'title: "Command Reference"',
+    'description: "Complete reference for all pncli commands, flags, and options. Auto-generated from source."',
+    `generatedAt: "${new Date().toISOString()}"`,
+    '---',
+    '',
+    'All commands return structured JSON to stdout. Check the `ok` field — `false` means an error occurred and the `error` field has details.',
+    '',
+    'Flags marked **required** must be supplied. All others are optional.',
+    '',
+  ];
+
+  for (const { name, commands } of services) {
+    if (commands.length === 0) continue;
+
+    lines.push(`## ${name}`, '');
+
+    for (const cmd of commands) {
+      lines.push(`### \`${cmd.name}\``);
+      lines.push('');
+      lines.push(cmd.description);
+      lines.push('');
+
+      if (cmd.options.length > 0) {
+        for (const opt of cmd.options) {
+          const req = opt.required ? ' **required**' : '';
+          lines.push(`- \`${opt.flag}\`${req} — ${opt.description}`);
+        }
+        lines.push('');
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const services = SERVICES.map(({ name, file, prefix }) => ({
+  name,
+  commands: extractCommands(join(root, file), prefix),
+}));
+
+const total = services.reduce((n, s) => n + s.commands.length, 0);
+const mdx = buildMdx(services);
+mkdirSync(outDir, { recursive: true });
+writeFileSync(outFile, mdx);
+console.log(`parse-commands: wrote ${total} command(s) across ${services.length} service(s) → commands.mdx`);

--- a/site/src/components/CommandReferenceCallout.astro
+++ b/site/src/components/CommandReferenceCallout.astro
@@ -1,5 +1,5 @@
 ---
-const href = 'https://github.com/kolatts/pncli/blob/main/copilot-instructions.md#command-reference';
+const href = '/pncli/commands/';
 ---
 
 <aside class="not-prose my-8 rounded-xl border border-coral/30 bg-coral/5 p-5 flex gap-4">
@@ -14,23 +14,13 @@ const href = 'https://github.com/kolatts/pncli/blob/main/copilot-instructions.md
   <div class="flex-1">
     <p class="font-display font-semibold text-ink text-base mb-1">Full command reference</p>
     <p class="text-sm text-ink/60 mb-3">
-      The complete list of commands, flags, and examples lives in
-      <code class="font-mono text-xs bg-ink/5 px-1.5 py-0.5 rounded">copilot-instructions.md</code>
-      — the single source of truth for agent consumption.
+      Every command, flag, and option — auto-generated from source and always up to date.
     </p>
     <a
       href={href}
-      target="_blank"
-      rel="noopener noreferrer"
       class="inline-flex items-center gap-1.5 text-sm font-medium text-coral hover:underline"
     >
-      View on GitHub
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
-           fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-           stroke-linejoin="round" aria-hidden="true">
-        <path d="M7 17L17 7"/>
-        <path d="M7 7h10v10"/>
-      </svg>
+      View command reference →
     </a>
   </div>
 </aside>

--- a/site/src/pages/commands.astro
+++ b/site/src/pages/commands.astro
@@ -1,0 +1,34 @@
+---
+import { getEntry, render } from 'astro:content';
+import Base from '../layouts/Base.astro';
+
+const entry = await getEntry('docs', 'commands');
+if (!entry) throw new Error('docs/commands entry not found — did the prebuild script run? (node scripts/parse-commands.mjs)');
+const { Content } = await render(entry);
+---
+
+<Base title="Command Reference — pncli" description={entry.data.description}>
+  <div class="max-w-3xl mx-auto px-6 py-16">
+    <header class="mb-10">
+      <p class="font-mono text-xs uppercase tracking-wider text-ink/40 mb-2">Docs</p>
+      <h1 class="font-display text-4xl font-bold text-ink mb-3">Command Reference</h1>
+      <p class="text-ink/60">{entry.data.description}</p>
+    </header>
+
+    <div class="prose prose-neutral max-w-none
+      prose-headings:font-display prose-headings:text-ink
+      prose-h2:text-2xl prose-h2:mt-12 prose-h2:mb-4 prose-h2:pb-2 prose-h2:border-b prose-h2:border-ink/10
+      prose-h3:text-base prose-h3:mt-6 prose-h3:mb-2 prose-h3:font-mono
+      prose-p:text-ink/70
+      prose-li:text-ink/70 prose-li:text-sm prose-li:leading-relaxed
+      prose-a:text-coral prose-a:no-underline hover:prose-a:underline
+      prose-code:font-mono prose-code:text-sm prose-code:bg-ink/5 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded
+      prose-pre:bg-ink prose-pre:text-cream prose-pre:rounded-xl">
+      <Content />
+    </div>
+
+    <footer class="mt-16 pt-8 border-t border-ink/10 text-xs font-mono text-ink/30">
+      Auto-generated from <code class="bg-ink/5 px-1 py-0.5 rounded">src/services/*/commands.ts</code> — run <code class="bg-ink/5 px-1 py-0.5 rounded">node scripts/parse-commands.mjs</code> to refresh.
+    </footer>
+  </div>
+</Base>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -96,7 +96,7 @@ const fmt = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', y
         <div class="flex gap-4 p-5 rounded-xl border border-cream/10 hover:border-cream/20 hover:bg-cream/5 transition-all">
           <span class="shrink-0 font-mono text-violet text-sm w-7 mt-0.5" aria-hidden="true">⚙</span>
           <p class="font-mono text-sm text-cream/65 leading-relaxed">
-            See <code class="text-coral">copilot-instructions.md</code> for workflow patterns
+            See the <a href="/pncli/commands/" class="text-coral hover:underline">command reference</a> for all commands and flags
           </p>
         </div>
       </div>

--- a/skills/local-setup/SKILL.md
+++ b/skills/local-setup/SKILL.md
@@ -121,6 +121,16 @@ pncli config set defaults.udeploy.application <app-name>
 pncli config set defaults.udeploy.environment <env-name>
 ```
 
+**Jenkins** — "Do you use Jenkins for CI/CD pipelines?"
+
+```
+pncli config set jenkins.baseUrl <url>
+pncli config set jenkins.username <username>
+pncli config set jenkins.apiToken <token>
+```
+
+The base URL is your Jenkins root, e.g. `https://jenkins.company.com`. pncli authenticates using HTTP Basic (username + API token).
+
 **Artifactory** — "Do you use Artifactory for package management?"
 
 ```


### PR DESCRIPTION
## Summary

- Adds `site/scripts/parse-commands.mjs` — regex-based extractor that walks `src/services/*/commands.ts` and produces `site/src/content/docs/commands.mdx` (145 commands across 16 service groups, updated on every build)
- Adds `site/src/pages/commands.astro` — new public page at `/commands/`
- Updates `CommandReferenceCallout` to link to `/pncli/commands/` instead of a raw GitHub file
- Wires `parse-commands.mjs` into the site's `dev` and `prebuild` scripts
- Adds Jenkins to `skills/local-setup/SKILL.md` Step 4 (was the only registered service missing from the onboarding contract)
- Replaces the `copilot-instructions.md` mention in the "Built for AI agents" section of index.astro with a link to `/commands/`

## Note — copilot-instructions.md not removed

The full removal of `copilot-instructions.md` was deferred. It's referenced by: `scripts/update-copilot-instructions.mjs`, `site/scripts/parse-instructions.mjs`, `package.json` (npm files), `.husky/pre-commit`, and the `pages-deploy.yml` CI trigger. Those dependencies need a dedicated cleanup PR — this PR delivers the core ask (site commands page + callout redirect) without touching that surface area.

## Pre-PR gate
- ✅ Build: astro build — 36 pages (new: /commands/)
- ✅ parse-commands.mjs: 145 commands extracted
- ✅ Typecheck: no TS changes
- ✅ Lint: no TS changes
- ✅ Tests: no TS changes

Closes #99