### PR TITLE
feat(servicenow,contrast): add ServiceNow change management and Contrast IAST integrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-pncli (The Paperwork Nightmare CLI) is a structured JSON CLI that gives AI coding agents and humans unified access to Jira, Bitbucket, Confluence, SonarQube, SDElements, Azure DevOps Server, Jenkins, JFrog Artifactory, IBM UrbanCode Deploy, and Checkmarx. Built with TypeScript, Commander.js, and published as `@kolatts/pncli`.
+pncli (The Paperwork Nightmare CLI) is a structured JSON CLI that gives AI coding agents and humans unified access to Jira, Bitbucket, Confluence, SonarQube, SDElements, Azure DevOps Server, Jenkins, JFrog Artifactory, IBM UrbanCode Deploy, Checkmarx, ServiceNow, and Contrast Security IAST. Built with TypeScript, Commander.js, and published as `@kolatts/pncli`.
 
 ## Key Directories
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -629,20 +629,23 @@ pncli udeploy request-info
 ### Checkmarx
 
 ```
-pncli checkmarx project list
+pncli checkmarx project
 
-pncli checkmarx project get
-  --id <id>  Project ID (required)
+pncli checkmarx scan
+```
 
-pncli checkmarx scan list
-  --project <id>  Filter by project ID
-  --last <n>      Return only the last N scans per project
+### Servicenow
 
-pncli checkmarx scan get
-  --id <id>  Scan ID (required)
+```
+pncli servicenow change
+```
 
-pncli checkmarx scan stats
-  --id <id>  Scan ID (required)
+### Contrast
+
+```
+pncli contrast apps
+
+pncli contrast findings
 ```
 
 ### Skills

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -543,19 +543,213 @@ pncli ado whoami
 
 pncli ado connection-data
 
-pncli ado project
+pncli ado project list-collections
 
-pncli ado work
+pncli ado project list
 
-pncli ado repo
+pncli ado project get
+  --name <project>  Project name
 
-pncli ado pipeline
+pncli ado work get
+  --id <n>    Work item ID
+
+pncli ado work create
+  --type <type>         Work item type (e.g. Bug, Task, User Story)
+  --title <title>       Work item title
+  --description <text>  Description
+  --assignee <user>     Assigned to (display name or email)
+  --priority <n>        Priority (1-4)
+  --field <name=value>  Additional field (repeatable) (default: [])
+
+pncli ado work update
+  --id <n>              Work item ID
+  --field <name=value>  Field to update (repeatable) (default: [])
+
+pncli ado work transition
+  --id <n>         Work item ID
+  --state <state>  New state (e.g. Active, Resolved, Closed)
+
+pncli ado work assign
+  --id <n>     Work item ID
+  --to <user>  User display name or email
+
+pncli ado work link
+  --id <a>      Source work item ID
+  --to <b>      Target work item ID
+  --type <rel>  Link type (related|parent|child|duplicate|duplicate-of)
+  (default: "related")
+
+pncli ado work search
+  --wiql <query>  WIQL query string
+
+pncli ado work list-comments
+  --id <n>    Work item ID
+
+pncli ado work add-comment
+  --id <n>       Work item ID
+  --body <text>  Comment text
+
+pncli ado work types
+  --discover  Fetch from server (always true for this command)
+  --save      Save discovered types to ~/.pncli/config.json
+
+pncli ado work list-states
+  --type <type>  Work item type name (e.g. Bug)
+
+pncli ado work fields
+  --type <type>  Scope to fields for a specific work item type (e.g. Bug)
+  --custom-only  Exclude System.* and Microsoft.VSTS.* fields
+  --discover     Fetch from server (always true for this command)
+  --save         Save discovered fields and aliases to ~/.pncli/config.json
+
+pncli ado repo list
+
+pncli ado repo get
+
+pncli ado repo list-prs
+  --state <state>     PR state: active|abandoned|completed|all (default:
+  "active")
+  --creator <alias>   Filter by creator
+  --reviewer <alias>  Filter by reviewer
+
+pncli ado repo get-pr
+  --id <n>    Pull request ID
+
+pncli ado repo create-pr
+  --title <title>       PR title
+  --source <branch>     Source branch
+  --target <branch>     Target branch (default: main) (default: "main")
+  --description <text>  PR description
+  --reviewers <ids>     Comma-separated reviewer IDs or display names
+
+pncli ado repo update-pr
+  --id <n>              Pull request ID
+  --title <title>       New title
+  --description <text>  New description
+  --reviewers <ids>     Comma-separated reviewer IDs
+
+pncli ado repo merge-pr
+  --id <n>         Pull request ID
+  --strategy <s>   Merge strategy: noFastForward|squash|rebase|rebaseMerge
+  (default: "noFastForward")
+  --delete-source  Delete source branch after merge
+
+pncli ado repo abandon-pr
+  --id <n>    Pull request ID
+
+pncli ado repo list-comments
+  --pr <n>        Pull request ID
+  --inline-only   Return only inline file comments
+  --general-only  Return only general PR comments
+
+pncli ado repo add-comment
+  --pr <n>       Pull request ID
+  --body <text>  Comment text
+
+pncli ado repo add-inline-comment
+  --pr <n>            Pull request ID
+  --file <path>       File path
+  --line <n>          Line number
+  --body <text>       Comment text
+  --line-type <side>  Line side: left|right (default: right) (default: "right")
+
+pncli ado repo reply-comment
+  --pr <n>          Pull request ID
+  --thread-id <id>  Thread ID
+  --body <text>     Reply text
+
+pncli ado repo resolve-comment
+  --pr <n>          Pull request ID
+  --thread-id <id>  Thread ID
+
+pncli ado repo delete-comment
+  --pr <n>           Pull request ID
+  --thread-id <id>   Thread ID
+  --comment-id <id>  Comment ID
+
+pncli ado repo list-files
+  --pr <n>    Pull request ID
+
+pncli ado repo diff
+  --pr <n>    Pull request ID
+  --path <p>  Filter diff to a specific file path
+
+pncli ado repo get-build-status
+  --commit <sha>  Commit SHA
+
+pncli ado repo list-reviewers
+  --pr <n>    Pull request ID
+
+pncli ado repo approve
+  --pr <n>    Pull request ID
+
+pncli ado repo unapprove
+  --pr <n>    Pull request ID
+
+pncli ado repo wait-for-author
+  --pr <n>    Pull request ID
+
+pncli ado repo list-builds
+  --pr <n>    Pull request ID
+
+pncli ado pipeline list
+
+pncli ado pipeline get
+  --id <n>    Pipeline definition ID
+
+pncli ado pipeline run
+  --id <n>           Pipeline definition ID
+  --branch <ref>     Source branch (e.g. refs/heads/main or main)
+  --parameter <k=v>  Build parameter (repeatable) (default: [])
+  --wait             Wait for the run to complete before returning
+  --timeout <s>      Max wait time in seconds (default 600) (default: "600")
+  --poll <s>         Poll interval in seconds (default 10) (default: "10")
+
+pncli ado pipeline list-runs
+  --definition <id>  Filter by definition ID
+  --branch <ref>     Filter by branch name
+  --status <filter>  Filter by status (inProgress|completed|cancelling|...)
+  --top <n>          Maximum results (default: "50")
+
+pncli ado pipeline get-run
+  --id <n>    Build ID
+
+pncli ado pipeline cancel-run
+  --id <n>    Build ID
+
+pncli ado pipeline logs
+  --id <n>      Build ID
+  --log-id <n>  Specific log ID (omit to list all logs)
 ```
 
 ### Jenkins
 
 ```
-pncli jenkins pipeline
+pncli jenkins pipeline list
+
+pncli jenkins pipeline get
+  --name <job>  Job name
+
+pncli jenkins pipeline run
+  --name <job>       Job name
+  --parameter <k=v>  Build parameter (repeatable) (default: [])
+  --wait             Wait for the build to complete before returning
+  --timeout <s>      Max wait time in seconds per phase (queue-wait and
+  build-wait each get this budget; default 600) (default:
+  "600")
+  --poll <s>         Poll interval in seconds (default 10) (default: "10")
+
+pncli jenkins pipeline list-runs
+  --name <job>  Job name
+  --top <n>     Maximum number of builds to return (default 25) (default: "25")
+
+pncli jenkins pipeline get-run
+  --name <job>  Job name
+  --number <n>  Build number
+
+pncli jenkins pipeline logs
+  --name <job>  Job name
+  --number <n>  Build number
 ```
 
 ### Artifactory
@@ -629,23 +823,80 @@ pncli udeploy request-info
 ### Checkmarx
 
 ```
-pncli checkmarx project
+pncli checkmarx project list
 
-pncli checkmarx scan
+pncli checkmarx project get
+  --id <id>   Project ID
+
+pncli checkmarx scan list
+  --project <id>  Filter by project ID
+  --last <n>      Return only the last N scans per project
+
+pncli checkmarx scan get
+  --id <id>   Scan ID
+
+pncli checkmarx scan stats
+  --id <id>   Scan ID
 ```
 
 ### Servicenow
 
 ```
-pncli servicenow change
+pncli servicenow change list
+  --state <state>       Filter by state (e.g. -1=Pending, 1=Open, 2=Work in
+  Progress, 3=Closed Complete)
+  --assigned-to <user>  Filter by assigned user sys_id or display name
+  --limit <n>           Maximum number of results (default: "25")
+  --fields <fields>     Comma-separated field names to return
+
+pncli servicenow change get
+  --id <id>   Change request sys_id or number (e.g. CHG0001234)
+
+pncli servicenow change create
+  --short-description <text>  Short description (title)
+  --description <text>        Full description
+  --type <type>               Change type: normal, standard, or emergency
+  (default: "normal")
+  --priority <n>              Priority: 1=Critical, 2=High, 3=Moderate, 4=Low
+  --assigned-to <user>        Assigned user sys_id
+  --assignment-group <group>  Assignment group sys_id
+  --start-date <datetime>     Planned start date (yyyy-MM-dd HH:mm:ss)
+  --end-date <datetime>       Planned end date (yyyy-MM-dd HH:mm:ss)
+
+pncli servicenow change update
+  --id <sys_id>               Change request sys_id
+  --short-description <text>  New short description
+  --description <text>        New description
+  --state <state>             New state value
+  --priority <n>              New priority
+  --assigned-to <user>        New assigned user sys_id
+  --start-date <datetime>     New planned start date
+  --end-date <datetime>       New planned end date
+
+pncli servicenow change close
+  --id <sys_id>         Change request sys_id
+  --close-notes <text>  Closure notes
+  --close-code <code>   Close code (e.g. successful, unsuccessful)
 ```
 
 ### Contrast
 
 ```
-pncli contrast apps
+pncli contrast apps list
+  --limit <n>   Maximum number of results (default: "25")
+  --offset <n>  Pagination offset (default: "0")
 
-pncli contrast findings
+pncli contrast findings list
+  --app <app-id>      Application ID (UUID)
+  --severity <level>  Filter by severity: CRITICAL, HIGH, MEDIUM, LOW, NOTE
+  --status <status>   Filter by status: REPORTED, CONFIRMED, SUSPICIOUS,
+  NOT_A_PROBLEM, REMEDIATED, FIXED
+  --limit <n>         Maximum number of results (default: "25")
+  --offset <n>        Pagination offset (default: "0")
+
+pncli contrast findings get
+  --app <app-id>      Application ID (UUID)
+  --trace <trace-id>  Trace/finding UUID
 ```
 
 ### Skills

--- a/scripts/update-copilot-instructions.mjs
+++ b/scripts/update-copilot-instructions.mjs
@@ -71,6 +71,35 @@ function formatHelp(helpText) {
     .join('\n');
 }
 
+/** Extract options block from a help string, excluding -h/--help */
+function extractOptions(helpText) {
+  const subLines = helpText.split('\n');
+  const optStart = subLines.findIndex(l => l.trimEnd() === 'Options:');
+  const opts = [];
+  if (optStart !== -1) {
+    for (let i = optStart + 1; i < subLines.length; i++) {
+      const l = subLines[i];
+      if (l.length > 0 && !l.startsWith(' ') && !l.startsWith('\t')) break;
+      const trimmed = l.trim();
+      if (trimmed && !trimmed.startsWith('-h,') && !trimmed.startsWith('--help')) {
+        opts.push(trimmed);
+      }
+    }
+  }
+  return opts;
+}
+
+/** Emit a single leaf command entry into the lines array */
+function emitLeaf(lines, fullPrefix, helpText) {
+  lines.push(`pncli ${fullPrefix}`);
+  const description = helpText.split('\n')[1]?.trim() ?? '';
+  if (description) lines.push(`  # ${description}`);
+  for (const opt of extractOptions(helpText)) {
+    lines.push(`  ${opt}`);
+  }
+  lines.push('');
+}
+
 function buildCommandReference() {
   const topHelp = run('');
   const topCommands = parseTopLevelCommands(topHelp);
@@ -91,29 +120,18 @@ function buildCommandReference() {
     } else {
       for (const sub of subcommands) {
         const subHelp = run(`${cmd} ${sub}`);
-        lines.push(`pncli ${cmd} ${sub}`);
-        // Extract usage line and options
-        const usageLine = subHelp.match(/^Usage:\s+(.+)$/m)?.[1] ?? '';
-        const description = subHelp.split('\n')[1]?.trim() ?? '';
-        if (description) lines.push(`  # ${description}`);
-        // Extract options (excluding -h/--help and global flags)
-        const subLines = subHelp.split('\n');
-        const optStart = subLines.findIndex(l => l.trimEnd() === 'Options:');
-        const opts = [];
-        if (optStart !== -1) {
-          for (let i = optStart + 1; i < subLines.length; i++) {
-            const l = subLines[i];
-            if (l.length > 0 && !l.startsWith(' ') && !l.startsWith('\t')) break;
-            const trimmed = l.trim();
-            if (trimmed && !trimmed.startsWith('-h,') && !trimmed.startsWith('--help')) {
-              opts.push(trimmed);
-            }
+        const subSubcommands = parseSubcommands(subHelp);
+
+        if (subSubcommands.length > 0) {
+          // This is a subgroup (e.g. `change`, `pipeline`, `project`) — recurse one more level
+          for (const leaf of subSubcommands) {
+            const leafHelp = run(`${cmd} ${sub} ${leaf}`);
+            emitLeaf(lines, `${cmd} ${sub} ${leaf}`, leafHelp);
           }
+        } else {
+          // This is a leaf command
+          emitLeaf(lines, `${cmd} ${sub}`, subHelp);
         }
-        for (const opt of opts) {
-          lines.push(`  ${opt}`);
-        }
-        lines.push('');
       }
       // Remove trailing empty line before closing ```
       if (lines[lines.length - 1] === '') lines.pop();

--- a/skills/local-setup/SKILL.md
+++ b/skills/local-setup/SKILL.md
@@ -136,6 +136,45 @@ pncli config set artifactory.nugetRepo <virtual-repo-name>
 pncli config set artifactory.mavenRepo <virtual-repo-name>
 ```
 
+**Jenkins** — "Do you use Jenkins for CI/CD pipelines?"
+
+```
+pncli config set jenkins.baseUrl <url>
+pncli config set jenkins.username <username>
+pncli config set jenkins.apiToken <token>
+```
+
+**ServiceNow** — "Do you use ServiceNow for change management?"
+
+```
+pncli config set servicenow.baseUrl <url>
+pncli config set servicenow.username <username>
+```
+
+Ask whether they authenticate with a password or API token:
+
+- If **password**: `pncli config set servicenow.password <password>`
+- If **API token**: `pncli config set servicenow.apiToken <token>`
+
+The base URL is your ServiceNow instance root, e.g. `https://mycompany.service-now.com`.
+
+**Contrast IAST** — "Do you use Contrast Security for interactive application security testing?"
+
+```
+pncli config set contrast.orgUuid <org-uuid>
+pncli config set contrast.username <username>
+pncli config set contrast.apiKey <api-key>
+pncli config set contrast.serviceKey <service-key>
+```
+
+Optionally set the base URL if using an on-premise instance (defaults to `https://app.contrastsecurity.com`):
+
+```
+pncli config set contrast.baseUrl <url>
+```
+
+All four credentials (org UUID, username, API key, service key) are found in your Contrast account under **User Settings → Your Keys**.
+
 **Step 5 — Set repo-level defaults.**
 
 Ask the user for project-specific defaults:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,8 @@ import { registerJenkinsCommands } from './services/jenkins/commands.js';
 import { registerArtifactoryCommands } from './services/artifactory/commands.js';
 import { registerUdeployCommands } from './services/udeploy/commands.js';
 import { registerCheckmarxCommands } from './services/checkmarx/commands.js';
+import { registerServiceNowCommands } from './services/servicenow/commands.js';
+import { registerContrastCommands } from './services/contrast/commands.js';
 import { registerSkillsCommands } from './services/skills/commands.js';
 
 const require = createRequire(import.meta.url);
@@ -72,6 +74,8 @@ registerJenkinsCommands(program);
 registerArtifactoryCommands(program);
 registerUdeployCommands(program);
 registerCheckmarxCommands(program);
+registerServiceNowCommands(program);
+registerContrastCommands(program);
 registerSkillsCommands(program);
 
 program.addHelpText('after', `
@@ -88,6 +92,8 @@ Services:
   artifactory  Artifactory (repos, artifact search, build info, properties)
   udeploy      IBM UrbanCode Deploy (component versions, deployment processes)
   checkmarx    Checkmarx CxSAST (projects, scans, scan statistics)
+  servicenow   ServiceNow (change requests)
+  contrast     Contrast IAST (applications, vulnerability findings)
   config       Manage pncli configuration
   skills       Download and manage Claude Code skills
 `);

--- a/src/lib/checkmarxFetch.test.ts
+++ b/src/lib/checkmarxFetch.test.ts
@@ -20,6 +20,8 @@ function makeConfig(overrides: Partial<ResolvedConfig['checkmarx']> = {}): Resol
       password: 'secret',
       ...overrides
     },
+    servicenow: { baseUrl: undefined, username: undefined, password: undefined, apiToken: undefined },
+    contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
   };
 }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -15,6 +15,8 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'secret-jenkins' },
     udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
     checkmarx: { baseUrl: undefined, username: undefined, password: undefined },
+    servicenow: { baseUrl: undefined, username: undefined, password: undefined, apiToken: undefined },
+    contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };
@@ -100,5 +102,26 @@ describe('maskConfig', () => {
     const config = baseConfig({ checkmarx: { baseUrl: undefined, username: undefined, password: undefined } });
     const masked = maskConfig(config) as ResolvedConfig;
     expect((masked.checkmarx as { password?: string }).password).toBeUndefined();
+  });
+
+  it('masks servicenow password and apiToken when present', () => {
+    const config = baseConfig({ servicenow: { baseUrl: 'https://sn.example.com', username: 'user', password: 'secret', apiToken: 'tok' } });
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect((masked.servicenow as { password?: string }).password).toBe('***');
+    expect((masked.servicenow as { apiToken?: string }).apiToken).toBe('***');
+  });
+
+  it('leaves servicenow credentials undefined when not set', () => {
+    const config = baseConfig({ servicenow: { baseUrl: undefined, username: undefined, password: undefined, apiToken: undefined } });
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect((masked.servicenow as { password?: string }).password).toBeUndefined();
+    expect((masked.servicenow as { apiToken?: string }).apiToken).toBeUndefined();
+  });
+
+  it('masks contrast apiKey and serviceKey when present', () => {
+    const config = baseConfig({ contrast: { baseUrl: undefined, orgUuid: 'org', apiKey: 'key', serviceKey: 'svc', username: 'user' } });
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect((masked.contrast as { apiKey?: string }).apiKey).toBe('***');
+    expect((masked.contrast as { serviceKey?: string }).serviceKey).toBe('***');
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -34,6 +34,15 @@ const ENV_KEYS = {
   CHECKMARX_BASE_URL: 'PNCLI_CHECKMARX_BASE_URL',
   CHECKMARX_USERNAME: 'PNCLI_CHECKMARX_USERNAME',
   CHECKMARX_PASSWORD: 'PNCLI_CHECKMARX_PASSWORD',
+  SERVICENOW_BASE_URL: 'PNCLI_SERVICENOW_BASE_URL',
+  SERVICENOW_USERNAME: 'PNCLI_SERVICENOW_USERNAME',
+  SERVICENOW_PASSWORD: 'PNCLI_SERVICENOW_PASSWORD',
+  SERVICENOW_API_TOKEN: 'PNCLI_SERVICENOW_API_TOKEN',
+  CONTRAST_BASE_URL: 'PNCLI_CONTRAST_BASE_URL',
+  CONTRAST_ORG_UUID: 'PNCLI_CONTRAST_ORG_UUID',
+  CONTRAST_API_KEY: 'PNCLI_CONTRAST_API_KEY',
+  CONTRAST_SERVICE_KEY: 'PNCLI_CONTRAST_SERVICE_KEY',
+  CONTRAST_USERNAME: 'PNCLI_CONTRAST_USERNAME',
   CONFIG_PATH: 'PNCLI_CONFIG_PATH'
 } as const;
 
@@ -171,6 +180,19 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
       username: process.env[ENV_KEYS.CHECKMARX_USERNAME] ?? globalConfig.checkmarx?.username,
       password: process.env[ENV_KEYS.CHECKMARX_PASSWORD] ?? globalConfig.checkmarx?.password,
     },
+    servicenow: {
+      baseUrl: process.env[ENV_KEYS.SERVICENOW_BASE_URL] ?? globalConfig.servicenow?.baseUrl,
+      username: process.env[ENV_KEYS.SERVICENOW_USERNAME] ?? globalConfig.servicenow?.username,
+      password: process.env[ENV_KEYS.SERVICENOW_PASSWORD] ?? globalConfig.servicenow?.password,
+      apiToken: process.env[ENV_KEYS.SERVICENOW_API_TOKEN] ?? globalConfig.servicenow?.apiToken,
+    },
+    contrast: {
+      baseUrl: process.env[ENV_KEYS.CONTRAST_BASE_URL] ?? globalConfig.contrast?.baseUrl,
+      orgUuid: process.env[ENV_KEYS.CONTRAST_ORG_UUID] ?? globalConfig.contrast?.orgUuid,
+      apiKey: process.env[ENV_KEYS.CONTRAST_API_KEY] ?? globalConfig.contrast?.apiKey,
+      serviceKey: process.env[ENV_KEYS.CONTRAST_SERVICE_KEY] ?? globalConfig.contrast?.serviceKey,
+      username: process.env[ENV_KEYS.CONTRAST_USERNAME] ?? globalConfig.contrast?.username,
+    },
     defaults: mergedDefaults
   };
 }
@@ -274,6 +296,16 @@ export function maskConfig(config: ResolvedConfig): unknown {
     checkmarx: {
       ...config.checkmarx,
       password: config.checkmarx.password ? '***' : undefined
+    },
+    servicenow: {
+      ...config.servicenow,
+      password: config.servicenow.password ? '***' : undefined,
+      apiToken: config.servicenow.apiToken ? '***' : undefined
+    },
+    contrast: {
+      ...config.contrast,
+      apiKey: config.contrast.apiKey ? '***' : undefined,
+      serviceKey: config.contrast.serviceKey ? '***' : undefined
     }
   };
 }

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -366,6 +366,24 @@ describe('HttpClient — ServiceNow', () => {
     expect(decoded).toBe('alice:my-token');
   });
 
+  it('prefers apiToken over password when both are set', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      capturedHeaders.push(Object.fromEntries(new Headers(init.headers as Record<string, string>).entries()));
+      return new Response('{"result":[]}', { status: 200 });
+    });
+    try {
+      const config = baseConfig({ servicenow: { baseUrl: 'https://sn.example.com', username: 'alice', password: 'pw', apiToken: 'tok' } });
+      const client = new HttpClient(config);
+      await client.servicenow('/api/now/table/change_request');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const auth = capturedHeaders[0]?.['authorization'] ?? '';
+    const decoded = Buffer.from(auth.replace('Basic ', ''), 'base64').toString();
+    expect(decoded).toBe('alice:tok');
+  });
+
   it('throws PncliError with status 0 on dry-run', async () => {
     const config = baseConfig({ servicenow: { baseUrl: 'https://sn.example.com', username: 'u', password: 'p', apiToken: undefined } });
     const client = new HttpClient(config, true);

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -15,6 +15,8 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     jenkins: { baseUrl: 'https://jenkins.example.com', username: 'user', apiToken: 'tok' },
     udeploy: { baseUrl: undefined, pat: undefined, username: undefined, password: undefined },
     checkmarx: { baseUrl: undefined, username: undefined, password: undefined },
+    servicenow: { baseUrl: undefined, username: undefined, password: undefined, apiToken: undefined },
+    contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };
@@ -312,5 +314,95 @@ describe('HttpClient — confluencePaginate', () => {
     });
     expect(results).toEqual(['x', 'y']);
     expect(starts).toEqual([0, 25]);
+  });
+});
+
+describe('HttpClient — ServiceNow', () => {
+  it('throws on missing baseUrl', async () => {
+    const config = baseConfig({ servicenow: { baseUrl: undefined, username: 'user', password: 'pass', apiToken: undefined } });
+    const client = new HttpClient(config);
+    await expect(client.servicenow('/api/now/table/change_request')).rejects.toMatchObject({ name: 'PncliError' });
+  });
+
+  it('throws on missing credentials', async () => {
+    const config = baseConfig({ servicenow: { baseUrl: 'https://sn.example.com', username: undefined, password: undefined, apiToken: undefined } });
+    const client = new HttpClient(config);
+    await expect(client.servicenow('/api/now/table/change_request')).rejects.toMatchObject({ name: 'PncliError' });
+  });
+
+  it('sends Basic auth with username:password', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      capturedHeaders.push(Object.fromEntries(new Headers(init.headers as Record<string, string>).entries()));
+      return new Response('{"result":[]}', { status: 200 });
+    });
+    try {
+      const config = baseConfig({ servicenow: { baseUrl: 'https://sn.example.com', username: 'alice', password: 'secret', apiToken: undefined } });
+      const client = new HttpClient(config);
+      await client.servicenow('/api/now/table/change_request');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const auth = capturedHeaders[0]?.['authorization'] ?? '';
+    const decoded = Buffer.from(auth.replace('Basic ', ''), 'base64').toString();
+    expect(decoded).toBe('alice:secret');
+  });
+
+  it('sends Basic auth with username:apiToken when token provided', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      capturedHeaders.push(Object.fromEntries(new Headers(init.headers as Record<string, string>).entries()));
+      return new Response('{"result":[]}', { status: 200 });
+    });
+    try {
+      const config = baseConfig({ servicenow: { baseUrl: 'https://sn.example.com', username: 'alice', password: undefined, apiToken: 'my-token' } });
+      const client = new HttpClient(config);
+      await client.servicenow('/api/now/table/change_request');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const auth = capturedHeaders[0]?.['authorization'] ?? '';
+    const decoded = Buffer.from(auth.replace('Basic ', ''), 'base64').toString();
+    expect(decoded).toBe('alice:my-token');
+  });
+
+  it('throws PncliError with status 0 on dry-run', async () => {
+    const config = baseConfig({ servicenow: { baseUrl: 'https://sn.example.com', username: 'u', password: 'p', apiToken: undefined } });
+    const client = new HttpClient(config, true);
+    await expect(client.servicenow('/api/now/table/change_request')).rejects.toMatchObject({ status: 0, message: 'dry-run' });
+  });
+});
+
+describe('HttpClient — Contrast', () => {
+  it('throws on missing credentials', async () => {
+    const config = baseConfig({ contrast: { baseUrl: undefined, orgUuid: 'org', apiKey: undefined, serviceKey: undefined, username: undefined } });
+    const client = new HttpClient(config);
+    await expect(client.contrast('/Contrast/api/ng/org/applications')).rejects.toMatchObject({ name: 'PncliError' });
+  });
+
+  it('sends Authorization, API-Key headers', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      capturedHeaders.push(Object.fromEntries(new Headers(init.headers as Record<string, string>).entries()));
+      return new Response('{}', { status: 200 });
+    });
+    try {
+      const config = baseConfig({ contrast: { baseUrl: 'https://app.contrastsecurity.com', orgUuid: 'org-123', apiKey: 'my-api-key', serviceKey: 'my-svc-key', username: 'user@example.com' } });
+      const client = new HttpClient(config);
+      await client.contrast('/Contrast/api/ng/org-123/applications');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const authorization = capturedHeaders[0]?.['authorization'] ?? '';
+    const apiKey = capturedHeaders[0]?.['api-key'] ?? '';
+    const decoded = Buffer.from(authorization, 'base64').toString();
+    expect(decoded).toBe('user@example.com:my-svc-key');
+    expect(apiKey).toBe('my-api-key');
+  });
+
+  it('throws PncliError with status 0 on dry-run', async () => {
+    const config = baseConfig({ contrast: { baseUrl: undefined, orgUuid: 'org', apiKey: 'k', serviceKey: 's', username: 'u' } });
+    const client = new HttpClient(config, true);
+    await expect(client.contrast('/Contrast/api/ng/org/applications')).rejects.toMatchObject({ status: 0, message: 'dry-run' });
   });
 });

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -751,6 +751,92 @@ export class HttpClient {
     return this.checkmarxFetcher;
   }
 
+  private servicenowHeaders(): Record<string, string> {
+    const { username, password, apiToken } = this.config.servicenow;
+    let encoded: string;
+    if (username && apiToken) {
+      encoded = Buffer.from(`${username}:${apiToken}`).toString('base64');
+    } else if (username && password) {
+      encoded = Buffer.from(`${username}:${password}`).toString('base64');
+    } else {
+      throw new PncliError('ServiceNow credentials not configured. Run: pncli config init');
+    }
+    return {
+      'Authorization': `Basic ${encoded}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'Connection': 'close'
+    };
+  }
+
+  async servicenow<T>(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<T> {
+    const baseUrl = this.config.servicenow.baseUrl;
+    if (!baseUrl) throw new PncliError('ServiceNow baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+    const headers = this.servicenowHeaders();
+    const init: RequestInit = {
+      method: opts.method ?? 'GET',
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
+    };
+
+    if (this.dryRun) {
+      const safeHeaders = { ...headers, Authorization: '[REDACTED]' };
+      const msg = `DRY RUN: ${init.method} ${url}\nHeaders: ${JSON.stringify(safeHeaders, null, 2)}\n`
+        + (opts.body ? `Body: ${JSON.stringify(opts.body, null, 2)}\n` : '');
+      fs.writeSync(process.stderr.fd, msg);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    return request<T>(url, init, opts.timeoutMs ?? 30000);
+  }
+
+  private contrastHeaders(): Record<string, string> {
+    const { apiKey, serviceKey, username } = this.config.contrast;
+    if (!apiKey || !serviceKey || !username) {
+      throw new PncliError('Contrast credentials not configured. Run: pncli config init');
+    }
+    const authorization = Buffer.from(`${username}:${serviceKey}`).toString('base64');
+    return {
+      'Authorization': authorization,
+      'API-Key': apiKey,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'Connection': 'close'
+    };
+  }
+
+  async contrast<T>(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<T> {
+    const baseUrl = this.config.contrast.baseUrl ?? 'https://app.contrastsecurity.com';
+
+    const url = buildUrl(baseUrl, path, opts.params);
+    const headers = this.contrastHeaders();
+    const init: RequestInit = {
+      method: opts.method ?? 'GET',
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
+    };
+
+    if (this.dryRun) {
+      const safeHeaders = { ...headers, Authorization: '[REDACTED]', 'API-Key': '[REDACTED]' };
+      const msg = `DRY RUN: ${init.method} ${url}\nHeaders: ${JSON.stringify(safeHeaders, null, 2)}\n`
+        + (opts.body ? `Body: ${JSON.stringify(opts.body, null, 2)}\n` : '');
+      fs.writeSync(process.stderr.fd, msg);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    return request<T>(url, init, opts.timeoutMs ?? 30000);
+  }
+
   async checkmarx<T>(
     path: string,
     opts: HttpRequestOptions = {}

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -207,6 +207,29 @@ export function registerConfigCommands(program: Command): void {
           results.checkmarx = { ok: null, message: 'not configured' };
         }
 
+        const snConfigured = cfg.servicenow.baseUrl && cfg.servicenow.username && (cfg.servicenow.password || cfg.servicenow.apiToken);
+        if (snConfigured) {
+          try {
+            await http.servicenow<unknown>('/api/now/table/change_request', { params: { sysparm_limit: 1 } });
+            results.servicenow = { ok: true, message: 'connected' };
+          } catch (err) {
+            results.servicenow = { ok: false, message: err instanceof Error ? err.message : String(err) };
+          }
+        } else {
+          results.servicenow = { ok: null, message: 'not configured' };
+        }
+
+        if (cfg.contrast.apiKey && cfg.contrast.serviceKey && cfg.contrast.username && cfg.contrast.orgUuid) {
+          try {
+            await http.contrast<unknown>(`/Contrast/api/ng/${cfg.contrast.orgUuid}/applications`, { params: { limit: 1 } });
+            results.contrast = { ok: true, message: 'connected' };
+          } catch (err) {
+            results.contrast = { ok: false, message: err instanceof Error ? err.message : String(err) };
+          }
+        } else {
+          results.contrast = { ok: null, message: 'not configured' };
+        }
+
         success(results, 'config', 'test', start);
       } catch (err) {
         fail(err, 'config', 'test', start);
@@ -385,6 +408,35 @@ export function registerConfigCommands(program: Command): void {
           }
         }
 
+        // ServiceNow
+        const snCreds = cfg.servicenow.username && (cfg.servicenow.password || cfg.servicenow.apiToken);
+        if (!snCreds) {
+          results.servicenow = { status: 'blank', message: 'not configured' };
+        } else if (!cfg.servicenow.baseUrl) {
+          results.servicenow = { status: 'error', message: 'baseUrl not configured' };
+        } else {
+          try {
+            await http.servicenow<unknown>('/api/now/table/change_request', { params: { sysparm_limit: 1 }, timeoutMs: 10_000 });
+            results.servicenow = { status: 'valid', message: 'ok' };
+          } catch (err) {
+            results.servicenow = categorize(err);
+          }
+        }
+
+        // Contrast IAST
+        if (!cfg.contrast.apiKey || !cfg.contrast.serviceKey || !cfg.contrast.username) {
+          results.contrast = { status: 'blank', message: 'not configured' };
+        } else if (!cfg.contrast.orgUuid) {
+          results.contrast = { status: 'error', message: 'orgUuid not configured' };
+        } else {
+          try {
+            await http.contrast<unknown>(`/Contrast/api/ng/${cfg.contrast.orgUuid}/applications`, { params: { limit: 1 }, timeoutMs: 10_000 });
+            results.contrast = { status: 'valid', message: 'ok' };
+          } catch (err) {
+            results.contrast = categorize(err);
+          }
+        }
+
         // Exit code: prefer AUTH_ERROR if any invalid, else NETWORK_ERROR if any errors
         const statuses = Object.values(results).map(r => r.status);
         if (statuses.includes('invalid')) process.exitCode = ExitCode.AUTH_ERROR;
@@ -392,7 +444,7 @@ export function registerConfigCommands(program: Command): void {
 
         if (cmdOpts.output === 'table') {
           // Human-readable table to stdout
-          const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx'] as const;
+          const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx', 'servicenow', 'contrast'] as const;
           const labelWidth = 14;
           const statusWidth = 9;
           for (const svc of services) {
@@ -410,7 +462,7 @@ export function registerConfigCommands(program: Command): void {
         } else {
           // Pretty table on stderr when --pretty is set (stdout stays JSON)
           if (opts.pretty) {
-            const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx'] as const;
+            const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx', 'servicenow', 'contrast'] as const;
             const labelWidth = 14;
             const statusWidth = 9;
             for (const svc of services) {
@@ -801,6 +853,106 @@ async function initGlobalConfig(start: number): Promise<void> {
     }
   }
 
+  process.stderr.write('\n── ServiceNow ────────────────────────────────────\n');
+  const useServiceNow = await confirm({
+    message: 'Configure ServiceNow for change management?',
+    default: false
+  });
+
+  let servicenowBaseUrl = '';
+  let servicenowUsername = '';
+  let servicenowPassword = '';
+  let servicenowApiToken = '';
+
+  if (useServiceNow) {
+    servicenowBaseUrl = await input({
+      message: 'ServiceNow instance URL (e.g. https://mycompany.service-now.com):',
+      default: ''
+    });
+
+    servicenowUsername = await input({
+      message: 'ServiceNow username:',
+      default: ''
+    });
+
+    const snUseToken = await confirm({
+      message: 'Authenticate with an API token instead of a password?',
+      default: false
+    });
+
+    if (snUseToken) {
+      servicenowApiToken = await password({
+        message: 'ServiceNow API token:'
+      });
+    } else {
+      servicenowPassword = await password({
+        message: 'ServiceNow password:',
+        validate: (v) => v.length > 0 || 'Password cannot be blank'
+      });
+    }
+
+    const snHasCreds = servicenowBaseUrl && servicenowUsername && (servicenowPassword || servicenowApiToken);
+    if (snHasCreds) {
+      process.stderr.write('\n  Verifying connection...\n');
+      try {
+        const tempConfig = {
+          ...loadConfig(),
+          servicenow: {
+            baseUrl: servicenowBaseUrl,
+            username: servicenowUsername,
+            password: servicenowPassword || undefined,
+            apiToken: servicenowApiToken || undefined
+          }
+        };
+        const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
+        await tempHttp.servicenow<unknown>('/api/now/table/change_request', { params: { sysparm_limit: 1 } });
+        process.stderr.write('  Connected.\n');
+      } catch (err) {
+        warn(`Could not connect to ServiceNow: ${err instanceof Error ? err.message : String(err)}`);
+        warn('Config will be saved anyway. Check your URL and credentials and re-run pncli config init or pncli config test.');
+      }
+    }
+  }
+
+  process.stderr.write('\n── Contrast IAST ─────────────────────────────────\n');
+  const useContrast = await confirm({
+    message: 'Configure Contrast Security IAST for vulnerability findings?',
+    default: false
+  });
+
+  let contrastBaseUrl = '';
+  let contrastOrgUuid = '';
+  let contrastUsername = '';
+  let contrastApiKey = '';
+  let contrastServiceKey = '';
+
+  if (useContrast) {
+    process.stderr.write('  Find your credentials in Contrast under User Settings → Your Keys.\n');
+
+    contrastBaseUrl = await input({
+      message: 'Contrast base URL (leave blank for cloud: https://app.contrastsecurity.com):',
+      default: ''
+    });
+
+    contrastOrgUuid = await input({
+      message: 'Organization UUID:',
+      default: ''
+    });
+
+    contrastUsername = await input({
+      message: 'Username (email):',
+      default: ''
+    });
+
+    contrastApiKey = await password({
+      message: 'API key:'
+    });
+
+    contrastServiceKey = await password({
+      message: 'Service key:'
+    });
+  }
+
   process.stderr.write('\n── Defaults ──────────────────────────────────────\n');
   const jiraProject = await input({
     message: 'Default Jira project key (optional):',
@@ -897,6 +1049,23 @@ async function initGlobalConfig(start: number): Promise<void> {
         baseUrl: checkmarxBaseUrl,
         username: checkmarxUsername || undefined,
         password: checkmarxPassword || undefined
+      }
+    } : {}),
+    ...(useServiceNow && servicenowBaseUrl ? {
+      servicenow: {
+        baseUrl: servicenowBaseUrl,
+        username: servicenowUsername || undefined,
+        ...(servicenowApiToken ? { apiToken: servicenowApiToken } : {}),
+        ...(servicenowPassword ? { password: servicenowPassword } : {})
+      }
+    } : {}),
+    ...(useContrast && contrastOrgUuid ? {
+      contrast: {
+        ...(contrastBaseUrl ? { baseUrl: contrastBaseUrl } : {}),
+        orgUuid: contrastOrgUuid,
+        username: contrastUsername || undefined,
+        apiKey: contrastApiKey || undefined,
+        serviceKey: contrastServiceKey || undefined
       }
     } : {}),
     defaults: {

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -882,7 +882,8 @@ async function initGlobalConfig(start: number): Promise<void> {
 
     if (snUseToken) {
       servicenowApiToken = await password({
-        message: 'ServiceNow API token:'
+        message: 'ServiceNow API token:',
+        validate: (v) => v.length > 0 || 'Token cannot be blank'
       });
     } else {
       servicenowPassword = await password({
@@ -951,6 +952,29 @@ async function initGlobalConfig(start: number): Promise<void> {
     contrastServiceKey = await password({
       message: 'Service key:'
     });
+
+    const contrastHasCreds = contrastOrgUuid && contrastUsername && contrastApiKey && contrastServiceKey;
+    if (contrastHasCreds) {
+      process.stderr.write('\n  Verifying connection...\n');
+      try {
+        const tempConfig = {
+          ...loadConfig(),
+          contrast: {
+            baseUrl: contrastBaseUrl || undefined,
+            orgUuid: contrastOrgUuid,
+            username: contrastUsername,
+            apiKey: contrastApiKey,
+            serviceKey: contrastServiceKey
+          }
+        };
+        const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
+        await tempHttp.contrast<unknown>(`/Contrast/api/ng/${contrastOrgUuid}/applications`, { params: { limit: 1 } });
+        process.stderr.write('  Connected.\n');
+      } catch (err) {
+        warn(`Could not connect to Contrast: ${err instanceof Error ? err.message : String(err)}`);
+        warn('Config will be saved anyway. Check your credentials and re-run pncli config init or pncli config test.');
+      }
+    }
   }
 
   process.stderr.write('\n── Defaults ──────────────────────────────────────\n');

--- a/src/services/contrast/commands.ts
+++ b/src/services/contrast/commands.ts
@@ -7,7 +7,7 @@ import { PncliError } from '../../lib/errors.js';
 function getHttpAndOrg(program: Command) {
   const opts = program.optsWithGlobals();
   const config = loadConfig({ configPath: opts.config as string | undefined });
-  if (!config.contrast.apiKey) throw new PncliError('Contrast not configured. Run: pncli config init');
+  if (!config.contrast.apiKey || !config.contrast.serviceKey || !config.contrast.username) throw new PncliError('Contrast not configured. Run: pncli config init');
   if (!config.contrast.orgUuid) throw new PncliError('Contrast org UUID not configured. Run: pncli config set contrast.orgUuid <uuid>');
   const http = createHttpClient(config, Boolean(opts.dryRun));
   return { http, orgUuid: config.contrast.orgUuid };

--- a/src/services/contrast/commands.ts
+++ b/src/services/contrast/commands.ts
@@ -1,0 +1,84 @@
+import { Command } from 'commander';
+import { loadConfig } from '../../lib/config.js';
+import { createHttpClient } from '../../lib/http.js';
+import { success, fail } from '../../lib/output.js';
+import { PncliError } from '../../lib/errors.js';
+
+function getHttpAndOrg(program: Command) {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config as string | undefined });
+  if (!config.contrast.apiKey) throw new PncliError('Contrast not configured. Run: pncli config init');
+  if (!config.contrast.orgUuid) throw new PncliError('Contrast org UUID not configured. Run: pncli config set contrast.orgUuid <uuid>');
+  const http = createHttpClient(config, Boolean(opts.dryRun));
+  return { http, orgUuid: config.contrast.orgUuid };
+}
+
+export function registerContrastCommands(program: Command): void {
+  const contrast = program.command('contrast').description('Contrast IAST operations');
+
+  const apps = contrast.command('apps').description('Application operations');
+
+  apps
+    .command('list')
+    .description('List applications in the organization')
+    .option('--limit <n>', 'Maximum number of results', '25')
+    .option('--offset <n>', 'Pagination offset', '0')
+    .action(async (opts: { limit?: string; offset?: string }) => {
+      const start = Date.now();
+      try {
+        const { http, orgUuid } = getHttpAndOrg(program);
+        const data = await http.contrast<unknown>(`/Contrast/api/ng/${orgUuid}/applications`, {
+          params: {
+            limit: opts.limit ? parseInt(opts.limit, 10) : 25,
+            offset: opts.offset ? parseInt(opts.offset, 10) : 0
+          }
+        });
+        success(data, 'contrast', 'apps list', start);
+      } catch (err) { fail(err, 'contrast', 'apps list', start); }
+    });
+
+  const findings = contrast.command('findings').description('Vulnerability findings operations');
+
+  findings
+    .command('list')
+    .description('List vulnerability findings for an application')
+    .requiredOption('--app <app-id>', 'Application ID (UUID)')
+    .option('--severity <level>', 'Filter by severity: CRITICAL, HIGH, MEDIUM, LOW, NOTE')
+    .option('--status <status>', 'Filter by status: REPORTED, CONFIRMED, SUSPICIOUS, NOT_A_PROBLEM, REMEDIATED, FIXED')
+    .option('--limit <n>', 'Maximum number of results', '25')
+    .option('--offset <n>', 'Pagination offset', '0')
+    .action(async (opts: { app: string; severity?: string; status?: string; limit?: string; offset?: string }) => {
+      const start = Date.now();
+      try {
+        const { http, orgUuid } = getHttpAndOrg(program);
+        const params: Record<string, string | number | boolean | undefined> = {
+          limit: opts.limit ? parseInt(opts.limit, 10) : 25,
+          offset: opts.offset ? parseInt(opts.offset, 10) : 0
+        };
+        if (opts.severity) params['severities'] = opts.severity;
+        if (opts.status) params['statuses'] = opts.status;
+
+        const data = await http.contrast<unknown>(
+          `/Contrast/api/ng/${orgUuid}/traces/${opts.app}/filter`,
+          { params }
+        );
+        success(data, 'contrast', 'findings list', start);
+      } catch (err) { fail(err, 'contrast', 'findings list', start); }
+    });
+
+  findings
+    .command('get')
+    .description('Get details for a specific vulnerability finding')
+    .requiredOption('--app <app-id>', 'Application ID (UUID)')
+    .requiredOption('--trace <trace-id>', 'Trace/finding UUID')
+    .action(async (opts: { app: string; trace: string }) => {
+      const start = Date.now();
+      try {
+        const { http, orgUuid } = getHttpAndOrg(program);
+        const data = await http.contrast<unknown>(
+          `/Contrast/api/ng/${orgUuid}/traces/${opts.app}/trace/${opts.trace}`
+        );
+        success(data, 'contrast', 'findings get', start);
+      } catch (err) { fail(err, 'contrast', 'findings get', start); }
+    });
+}

--- a/src/services/servicenow/commands.ts
+++ b/src/services/servicenow/commands.ts
@@ -52,9 +52,10 @@ export function registerServiceNowCommands(program: Command): void {
           sysparm_limit: opts.limit ? parseInt(opts.limit, 10) : 25,
           sysparm_display_value: 'true',
         };
+        const sanitize = (v: string) => v.replace(/\^/g, '');
         const queries: string[] = [];
-        if (opts.state !== undefined) queries.push(`state=${opts.state}`);
-        if (opts.assignedTo) queries.push(`assigned_to=${opts.assignedTo}`);
+        if (opts.state !== undefined) queries.push(`state=${sanitize(opts.state)}`);
+        if (opts.assignedTo) queries.push(`assigned_to=${sanitize(opts.assignedTo)}`);
         if (queries.length) params['sysparm_query'] = queries.join('^');
         if (opts.fields) params['sysparm_fields'] = opts.fields;
 
@@ -161,6 +162,8 @@ export function registerServiceNowCommands(program: Command): void {
         if (opts.assignedTo) body['assigned_to'] = opts.assignedTo;
         if (opts.startDate) body['start_date'] = opts.startDate;
         if (opts.endDate) body['end_date'] = opts.endDate;
+
+        if (Object.keys(body).length === 0) throw new PncliError('No fields to update. Provide at least one option besides --id.', 1);
 
         const data = await http.servicenow<SnowSingleResponse>(`/api/now/table/change_request/${opts.id}`, {
           method: 'PATCH',

--- a/src/services/servicenow/commands.ts
+++ b/src/services/servicenow/commands.ts
@@ -71,7 +71,6 @@ export function registerServiceNowCommands(program: Command): void {
       const start = Date.now();
       try {
         const http = getHttp(program);
-        let path: string;
         if (opts.id.toUpperCase().startsWith('CHG')) {
           const list = await http.servicenow<SnowListResponse>('/api/now/table/change_request', {
             params: { sysparm_query: `number=${opts.id}`, sysparm_display_value: 'true', sysparm_limit: 1 }
@@ -80,8 +79,7 @@ export function registerServiceNowCommands(program: Command): void {
           success(list.result[0], 'servicenow', 'change get', start);
           return;
         }
-        path = `/api/now/table/change_request/${opts.id}`;
-        const data = await http.servicenow<SnowSingleResponse>(path, {
+        const data = await http.servicenow<SnowSingleResponse>(`/api/now/table/change_request/${opts.id}`, {
           params: { sysparm_display_value: 'true' }
         });
         success(data.result, 'servicenow', 'change get', start);
@@ -182,7 +180,7 @@ export function registerServiceNowCommands(program: Command): void {
       const start = Date.now();
       try {
         const http = getHttp(program);
-        const body: Record<string, unknown> = { state: '3' };
+        const body: Record<string, unknown> = { state: 3 };
         if (opts.closeNotes) body['close_notes'] = opts.closeNotes;
         if (opts.closeCode) body['close_code'] = opts.closeCode;
 

--- a/src/services/servicenow/commands.ts
+++ b/src/services/servicenow/commands.ts
@@ -1,0 +1,196 @@
+import { Command } from 'commander';
+import { loadConfig } from '../../lib/config.js';
+import { createHttpClient } from '../../lib/http.js';
+import { success, fail } from '../../lib/output.js';
+import { PncliError } from '../../lib/errors.js';
+
+interface SnowChangeRecord {
+  sys_id: string;
+  number: string;
+  short_description: string;
+  state: string;
+  priority: string;
+  assigned_to?: { display_value?: string };
+  assignment_group?: { display_value?: string };
+  start_date?: string;
+  end_date?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+interface SnowListResponse {
+  result: SnowChangeRecord[];
+}
+
+interface SnowSingleResponse {
+  result: SnowChangeRecord;
+}
+
+function getHttp(program: Command) {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config as string | undefined });
+  if (!config.servicenow.baseUrl) throw new PncliError('ServiceNow not configured. Run: pncli config init');
+  return createHttpClient(config, Boolean(opts.dryRun));
+}
+
+export function registerServiceNowCommands(program: Command): void {
+  const sn = program.command('servicenow').description('ServiceNow operations');
+  const change = sn.command('change').description('Change request operations');
+
+  change
+    .command('list')
+    .description('List change requests')
+    .option('--state <state>', 'Filter by state (e.g. -1=Pending, 1=Open, 2=Work in Progress, 3=Closed Complete)')
+    .option('--assigned-to <user>', 'Filter by assigned user sys_id or display name')
+    .option('--limit <n>', 'Maximum number of results', '25')
+    .option('--fields <fields>', 'Comma-separated field names to return')
+    .action(async (opts: { state?: string; assignedTo?: string; limit?: string; fields?: string }) => {
+      const start = Date.now();
+      try {
+        const http = getHttp(program);
+        const params: Record<string, string | number | boolean | undefined> = {
+          sysparm_limit: opts.limit ? parseInt(opts.limit, 10) : 25,
+          sysparm_display_value: 'true',
+        };
+        const queries: string[] = [];
+        if (opts.state !== undefined) queries.push(`state=${opts.state}`);
+        if (opts.assignedTo) queries.push(`assigned_to=${opts.assignedTo}`);
+        if (queries.length) params['sysparm_query'] = queries.join('^');
+        if (opts.fields) params['sysparm_fields'] = opts.fields;
+
+        const data = await http.servicenow<SnowListResponse>('/api/now/table/change_request', { params });
+        success(data.result, 'servicenow', 'change list', start);
+      } catch (err) { fail(err, 'servicenow', 'change list', start); }
+    });
+
+  change
+    .command('get')
+    .description('Get a change request by sys_id or number')
+    .requiredOption('--id <id>', 'Change request sys_id or number (e.g. CHG0001234)')
+    .action(async (opts: { id: string }) => {
+      const start = Date.now();
+      try {
+        const http = getHttp(program);
+        let path: string;
+        if (opts.id.toUpperCase().startsWith('CHG')) {
+          const list = await http.servicenow<SnowListResponse>('/api/now/table/change_request', {
+            params: { sysparm_query: `number=${opts.id}`, sysparm_display_value: 'true', sysparm_limit: 1 }
+          });
+          if (!list.result.length) throw new PncliError(`Change request not found: ${opts.id}`, 1);
+          success(list.result[0], 'servicenow', 'change get', start);
+          return;
+        }
+        path = `/api/now/table/change_request/${opts.id}`;
+        const data = await http.servicenow<SnowSingleResponse>(path, {
+          params: { sysparm_display_value: 'true' }
+        });
+        success(data.result, 'servicenow', 'change get', start);
+      } catch (err) { fail(err, 'servicenow', 'change get', start); }
+    });
+
+  change
+    .command('create')
+    .description('Create a change request')
+    .requiredOption('--short-description <text>', 'Short description (title)')
+    .option('--description <text>', 'Full description')
+    .option('--type <type>', 'Change type: normal, standard, or emergency', 'normal')
+    .option('--priority <n>', 'Priority: 1=Critical, 2=High, 3=Moderate, 4=Low')
+    .option('--assigned-to <user>', 'Assigned user sys_id')
+    .option('--assignment-group <group>', 'Assignment group sys_id')
+    .option('--start-date <datetime>', 'Planned start date (yyyy-MM-dd HH:mm:ss)')
+    .option('--end-date <datetime>', 'Planned end date (yyyy-MM-dd HH:mm:ss)')
+    .action(async (opts: {
+      shortDescription: string;
+      description?: string;
+      type?: string;
+      priority?: string;
+      assignedTo?: string;
+      assignmentGroup?: string;
+      startDate?: string;
+      endDate?: string;
+    }) => {
+      const start = Date.now();
+      try {
+        const http = getHttp(program);
+        const body: Record<string, unknown> = {
+          short_description: opts.shortDescription,
+          type: opts.type ?? 'normal'
+        };
+        if (opts.description) body['description'] = opts.description;
+        if (opts.priority) body['priority'] = opts.priority;
+        if (opts.assignedTo) body['assigned_to'] = opts.assignedTo;
+        if (opts.assignmentGroup) body['assignment_group'] = opts.assignmentGroup;
+        if (opts.startDate) body['start_date'] = opts.startDate;
+        if (opts.endDate) body['end_date'] = opts.endDate;
+
+        const data = await http.servicenow<SnowSingleResponse>('/api/now/table/change_request', {
+          method: 'POST',
+          body
+        });
+        success(data.result, 'servicenow', 'change create', start);
+      } catch (err) { fail(err, 'servicenow', 'change create', start); }
+    });
+
+  change
+    .command('update')
+    .description('Update a change request')
+    .requiredOption('--id <sys_id>', 'Change request sys_id')
+    .option('--short-description <text>', 'New short description')
+    .option('--description <text>', 'New description')
+    .option('--state <state>', 'New state value')
+    .option('--priority <n>', 'New priority')
+    .option('--assigned-to <user>', 'New assigned user sys_id')
+    .option('--start-date <datetime>', 'New planned start date')
+    .option('--end-date <datetime>', 'New planned end date')
+    .action(async (opts: {
+      id: string;
+      shortDescription?: string;
+      description?: string;
+      state?: string;
+      priority?: string;
+      assignedTo?: string;
+      startDate?: string;
+      endDate?: string;
+    }) => {
+      const start = Date.now();
+      try {
+        const http = getHttp(program);
+        const body: Record<string, unknown> = {};
+        if (opts.shortDescription) body['short_description'] = opts.shortDescription;
+        if (opts.description) body['description'] = opts.description;
+        if (opts.state !== undefined) body['state'] = opts.state;
+        if (opts.priority) body['priority'] = opts.priority;
+        if (opts.assignedTo) body['assigned_to'] = opts.assignedTo;
+        if (opts.startDate) body['start_date'] = opts.startDate;
+        if (opts.endDate) body['end_date'] = opts.endDate;
+
+        const data = await http.servicenow<SnowSingleResponse>(`/api/now/table/change_request/${opts.id}`, {
+          method: 'PATCH',
+          body
+        });
+        success(data.result, 'servicenow', 'change update', start);
+      } catch (err) { fail(err, 'servicenow', 'change update', start); }
+    });
+
+  change
+    .command('close')
+    .description('Close a change request (state=3)')
+    .requiredOption('--id <sys_id>', 'Change request sys_id')
+    .option('--close-notes <text>', 'Closure notes')
+    .option('--close-code <code>', 'Close code (e.g. successful, unsuccessful)')
+    .action(async (opts: { id: string; closeNotes?: string; closeCode?: string }) => {
+      const start = Date.now();
+      try {
+        const http = getHttp(program);
+        const body: Record<string, unknown> = { state: '3' };
+        if (opts.closeNotes) body['close_notes'] = opts.closeNotes;
+        if (opts.closeCode) body['close_code'] = opts.closeCode;
+
+        const data = await http.servicenow<SnowSingleResponse>(`/api/now/table/change_request/${opts.id}`, {
+          method: 'PATCH',
+          body
+        });
+        success(data.result, 'servicenow', 'change close', start);
+      } catch (err) { fail(err, 'servicenow', 'change close', start); }
+    });
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -98,6 +98,21 @@ export interface CheckmarxConfig {
   password?: string;
 }
 
+export interface ServiceNowConfig {
+  baseUrl?: string;
+  username?: string;
+  password?: string;
+  apiToken?: string;
+}
+
+export interface ContrastConfig {
+  baseUrl?: string;
+  orgUuid?: string;
+  apiKey?: string;
+  serviceKey?: string;
+  username?: string;
+}
+
 export interface UdeployDefaults {
   application?: string;
   environment?: string;
@@ -129,6 +144,8 @@ export interface GlobalConfig {
   jenkins?: JenkinsConfig;
   udeploy?: UdeployConfig;
   checkmarx?: CheckmarxConfig;
+  servicenow?: ServiceNowConfig;
+  contrast?: ContrastConfig;
   defaults?: Defaults;
 }
 
@@ -188,6 +205,19 @@ export interface ResolvedConfig {
     baseUrl: string | undefined;
     username: string | undefined;
     password: string | undefined;
+  };
+  servicenow: {
+    baseUrl: string | undefined;
+    username: string | undefined;
+    password: string | undefined;
+    apiToken: string | undefined;
+  };
+  contrast: {
+    baseUrl: string | undefined;
+    orgUuid: string | undefined;
+    apiKey: string | undefined;
+    serviceKey: string | undefined;
+    username: string | undefined;
   };
   defaults: {
     jira: JiraDefaults;


### PR DESCRIPTION
## Summary

- Add ServiceNow integration: change list, get, create, update, close against `/api/now/table/change_request`
- Add Contrast IAST integration: apps list, findings list/get against Contrast Cloud REST API
- Both services wired into `config test`, `config check`, and interactive `config init` wizard (with connection verification)
- Add both services to `skills/local-setup/SKILL.md` Step 4
- Fix `scripts/update-copilot-instructions.mjs` to handle 3-level command nesting (Checkmarx, Jenkins, ServiceNow, Contrast now emit full leaf-command detail)
- Update CLAUDE.md project overview to list all 13 services

## Commands added / updated

- `pncli servicenow change list` — List change requests
  - `--state <state>` — Filter by state (-1=Pending, 1=Open, 2=Work in Progress, 3=Closed Complete)
  - `--assigned-to <user>` — Filter by assigned user sys_id or display name
  - `--limit <n>` — Maximum number of results (default: 25)
  - `--fields <fields>` — Comma-separated field names to return
- `pncli servicenow change get` — Get a change request by sys_id or number (CHGxxxxxxx)
  - `--id <id>` **(required)** — sys_id or change number
- `pncli servicenow change create` — Create a change request
  - `--short-description <text>` **(required)**
  - `--description <text>`, `--type <type>`, `--priority <n>`, `--assigned-to <user>`, `--assignment-group <group>`, `--start-date <datetime>`, `--end-date <datetime>`
- `pncli servicenow change update` — Update a change request
  - `--id <sys_id>` **(required)**, plus any of the create flags
- `pncli servicenow change close` — Close a change request (state=3)
  - `--id <sys_id>` **(required)**, `--close-notes <text>`, `--close-code <code>`
- `pncli contrast apps list` — List applications in the organization
  - `--limit <n>`, `--offset <n>`
- `pncli contrast findings list` — List vulnerability findings for an application
  - `--app <app-id>` **(required)**, `--severity <level>`, `--status <status>`, `--limit <n>`, `--offset <n>`
- `pncli contrast findings get` — Get details for a specific finding
  - `--app <app-id>` **(required)**, `--trace <trace-id>` **(required)**

## Pre-PR gate

- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: issues fixed (dead path var, missing Contrast guard, missing validate, state int fix, copilot-instructions regression fixed)
- ✅ Tests: 91 passed
- ✅ Docs: CLAUDE.md and copilot-instructions.md updated; six-file contract satisfied for both services

Closes #122
