### PR TITLE
ci: auto-merge release-please PRs when CI passes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           release-type: node
 
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --merge "${{ steps.release.outputs.pull-request-number }}"
+
   publish:
     needs: [release-please]
     if: |


### PR DESCRIPTION
Adds a gh pr merge --auto step so that release-please PRs are merged
automatically once all required status checks succeed, making releases
fully hands-off.

https://claude.ai/code/session_013V1S6xeA5SbV77iSRpxk12