### PR TITLE
feat(skills): add marketplace setup and sync commands

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -493,7 +493,9 @@ pncli deps frisk
   transitive) (default: false)
   --include-dev            Include dev/test dependencies (default: false)
   --source <source>        Vulnerability source (choices: "osv", "sonatype",
-  "all", default: "osv")
+  "sonatypeiq", "all", default: "osv")
+  --application-id <id>    Sonatype IQ Server application ID (required when
+  --source sonatypeiq)
 
 pncli deps scan
   --ecosystem <ecosystem>  Filter to one ecosystem: npm, nuget, maven, all
@@ -905,6 +907,21 @@ pncli contrast findings get
   --trace <trace-id>  Trace/finding UUID
 ```
 
+### Sonatypeiq
+
+```
+pncli sonatypeiq applications list
+  --organization-id <id>  Filter by organization ID
+
+pncli sonatypeiq applications get
+  --public-id <id>  Application public ID
+
+pncli sonatypeiq organizations list
+
+pncli sonatypeiq policies list
+  --organization-id <id>  Filter by organization ID
+```
+
 ### Skills
 
 ```
@@ -919,6 +936,12 @@ pncli skills list
   "github-copilot")
   --scope <scope>  Installation scope: project | user (default: "project")
   --target <dir>   Override skills directory to scan
+
+pncli skills marketplace setup <url> <localPath>
+  --branch <branch>  Branch to clone (default: "master")
+
+pncli skills marketplace sync [plugin]
+  --claude  Install to ~/.claude/skills instead of ~/.agents/skills
 ```
 
 <!-- COMMAND-REFERENCE:END -->

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -937,11 +937,11 @@ pncli skills list
   --scope <scope>  Installation scope: project | user (default: "project")
   --target <dir>   Override skills directory to scan
 
-pncli skills marketplace setup <url> <localPath>
+pncli skills marketplace setup
   --branch <branch>  Branch to clone (default: "master")
 
-pncli skills marketplace sync [plugin]
-  --claude  Install to ~/.claude/skills instead of ~/.agents/skills
+pncli skills marketplace sync
+  --claude    Install to ~/.claude/skills instead of ~/.agents/skills
 ```
 
 <!-- COMMAND-REFERENCE:END -->

--- a/skills/local-setup/SKILL.md
+++ b/skills/local-setup/SKILL.md
@@ -197,6 +197,26 @@ The `userCode` and `passcode` are User Token credentials generated in your IQ Se
 
 Once configured, use `pncli sonatypeiq applications list` to discover application IDs, then run `pncli deps frisk --source sonatypeiq --application-id <id>` to scan dependencies against your IQ Server policies.
 
+**Skills Marketplace** — "Do you have an internal Claude Code skills marketplace hosted in a git repository (e.g. on-premise Bitbucket)?"
+
+```
+pncli skills marketplace setup <git-clone-url> <local-path>
+```
+
+Use `--branch main` if the default branch is `main` instead of `master`. This clones the marketplace repo to `<local-path>` and stores the mapping in your pncli global config.
+
+To install plugins from the marketplace into `~/.agents/skills` (GitHub Copilot / Codex):
+
+```
+pncli skills marketplace sync
+```
+
+Pass a plugin name to skip the interactive picker, or add `--claude` to install to `~/.claude/skills` instead:
+
+```
+pncli skills marketplace sync <plugin-name> --claude
+```
+
 **Step 5 — Set repo-level defaults.**
 
 Ask the user for project-specific defaults:

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -322,4 +322,4 @@ export function maskConfig(config: ResolvedConfig): unknown {
   };
 }
 
-export { getGlobalConfigPath };
+export { getGlobalConfigPath, loadJsonFile };

--- a/src/services/skills/commands.test.ts
+++ b/src/services/skills/commands.test.ts
@@ -29,7 +29,7 @@ describe('resolvePluginChoices', () => {
       return s.endsWith('marketplace.json') || s.endsWith('plugins');
     });
     vi.spyOn(fs, 'readFileSync').mockReturnValue('not valid json{{{{');
-    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-a'] as any);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-a'] as unknown as fs.Dirent[]);
     vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
 
     const choices = resolvePluginChoices('/market');
@@ -42,7 +42,7 @@ describe('resolvePluginChoices', () => {
       return s.endsWith('marketplace.json') || s.endsWith('plugins');
     });
     vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ name: 'marketplace' }));
-    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-b'] as any);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-b'] as unknown as fs.Dirent[]);
     vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
 
     const choices = resolvePluginChoices('/market');
@@ -61,7 +61,7 @@ describe('resolvePluginChoices', () => {
       const s = String(p);
       return !s.endsWith('marketplace.json') && s.endsWith('plugins');
     });
-    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-a', 'README.md'] as any);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-a', 'README.md'] as unknown as fs.Dirent[]);
     vi.spyOn(fs, 'statSync').mockImplementation(p =>
       ({ isDirectory: () => !String(p).endsWith('README.md') } as fs.Stats)
     );
@@ -96,7 +96,7 @@ describe('copyPluginSkills', () => {
 
   it('copies skill directories and returns installed list', () => {
     vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
-    vi.spyOn(fs, 'readdirSync').mockReturnValue(['skill-one', 'skill-two'] as any);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['skill-one', 'skill-two'] as unknown as fs.Dirent[]);
     vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
     vi.spyOn(fs, 'rmSync').mockReturnValue(undefined);
     vi.spyOn(fs, 'cpSync').mockReturnValue(undefined);
@@ -108,7 +108,7 @@ describe('copyPluginSkills', () => {
 
   it('skips and tracks skills with traversal names', () => {
     vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
-    vi.spyOn(fs, 'readdirSync').mockReturnValue(['good-skill', '../evil'] as any);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['good-skill', '../evil'] as unknown as fs.Dirent[]);
     vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
     const rmSpy = vi.spyOn(fs, 'rmSync').mockReturnValue(undefined);
     const cpSpy = vi.spyOn(fs, 'cpSync').mockReturnValue(undefined);
@@ -122,7 +122,7 @@ describe('copyPluginSkills', () => {
 
   it('returns empty installed when source dir has no skill directories', () => {
     vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
-    vi.spyOn(fs, 'readdirSync').mockReturnValue([] as any);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue([] as unknown as fs.Dirent[]);
 
     const { installed, failed } = copyPluginSkills('/market/plugins/sunny/skills', targetDir);
     expect(installed).toEqual([]);

--- a/src/services/skills/commands.test.ts
+++ b/src/services/skills/commands.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { resolvePluginChoices, resolveSkillsSrc, copyPluginSkills } from './commands.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── resolvePluginChoices ──────────────────────────────────────────────────────
+
+describe('resolvePluginChoices', () => {
+  it('reads plugins from marketplace.json when present and valid', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation(p =>
+      String(p).endsWith('marketplace.json')
+    );
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      JSON.stringify({ plugins: [{ name: 'sunny', description: 'My plugin' }] })
+    );
+
+    const choices = resolvePluginChoices('/market');
+    expect(choices).toEqual([{ name: 'sunny', description: 'My plugin' }]);
+  });
+
+  it('falls back to dir scan when marketplace.json parse fails', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation(p => {
+      const s = String(p);
+      return s.endsWith('marketplace.json') || s.endsWith('plugins');
+    });
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('not valid json{{{{');
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-a'] as any);
+    vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+    const choices = resolvePluginChoices('/market');
+    expect(choices).toEqual([{ name: 'plugin-a', description: '' }]);
+  });
+
+  it('falls back to dir scan when marketplace.json has no plugins array', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation(p => {
+      const s = String(p);
+      return s.endsWith('marketplace.json') || s.endsWith('plugins');
+    });
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ name: 'marketplace' }));
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-b'] as any);
+    vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+    const choices = resolvePluginChoices('/market');
+    expect(choices).toEqual([{ name: 'plugin-b', description: '' }]);
+  });
+
+  it('returns empty array when neither source exists', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    const choices = resolvePluginChoices('/market');
+    expect(choices).toEqual([]);
+  });
+
+  it('skips non-directory entries during dir scan', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation(p => {
+      const s = String(p);
+      return !s.endsWith('marketplace.json') && s.endsWith('plugins');
+    });
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['plugin-a', 'README.md'] as any);
+    vi.spyOn(fs, 'statSync').mockImplementation(p =>
+      ({ isDirectory: () => !String(p).endsWith('README.md') } as fs.Stats)
+    );
+
+    const choices = resolvePluginChoices('/market');
+    expect(choices.map(c => c.name)).toEqual(['plugin-a']);
+  });
+});
+
+// ── resolveSkillsSrc ──────────────────────────────────────────────────────────
+
+describe('resolveSkillsSrc', () => {
+  it('returns resolved skills path for a valid plugin name', () => {
+    const result = resolveSkillsSrc('/market', 'sunny');
+    expect(result).toBe(path.resolve('/market', 'plugins', 'sunny', 'skills'));
+  });
+
+  it('throws on path traversal attempt with ../', () => {
+    expect(() => resolveSkillsSrc('/market', '../evil')).toThrow('Invalid plugin name');
+  });
+
+  it('throws on deep path traversal', () => {
+    expect(() => resolveSkillsSrc('/market', '../../etc/passwd')).toThrow('Invalid plugin name');
+  });
+});
+
+// ── copyPluginSkills ──────────────────────────────────────────────────────────
+
+describe('copyPluginSkills', () => {
+  const home = os.homedir();
+  const targetDir = path.join(home, '.agents', 'skills');
+
+  it('copies skill directories and returns installed list', () => {
+    vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['skill-one', 'skill-two'] as any);
+    vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    vi.spyOn(fs, 'rmSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'cpSync').mockReturnValue(undefined);
+
+    const { installed, failed } = copyPluginSkills('/market/plugins/sunny/skills', targetDir);
+    expect(installed).toEqual(['skill-one', 'skill-two']);
+    expect(failed).toEqual([]);
+  });
+
+  it('skips and tracks skills with traversal names', () => {
+    vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['good-skill', '../evil'] as any);
+    vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    const rmSpy = vi.spyOn(fs, 'rmSync').mockReturnValue(undefined);
+    const cpSpy = vi.spyOn(fs, 'cpSync').mockReturnValue(undefined);
+
+    const { installed, failed } = copyPluginSkills('/market/plugins/sunny/skills', targetDir);
+    expect(installed).toEqual(['good-skill']);
+    expect(failed).toEqual(['../evil']);
+    expect(rmSpy).toHaveBeenCalledOnce();
+    expect(cpSpy).toHaveBeenCalledOnce();
+  });
+
+  it('returns empty installed when source dir has no skill directories', () => {
+    vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue([] as any);
+
+    const { installed, failed } = copyPluginSkills('/market/plugins/sunny/skills', targetDir);
+    expect(installed).toEqual([]);
+    expect(failed).toEqual([]);
+  });
+});

--- a/src/services/skills/commands.ts
+++ b/src/services/skills/commands.ts
@@ -4,6 +4,10 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+import { select } from '@inquirer/prompts';
+import { writeGlobalConfig, getGlobalConfigPath } from '../../lib/config.js';
+import type { GlobalConfig } from '../../types/config.js';
 
 const AGENT_PATHS: Record<string, { project: string; user: string }> = {
   'github-copilot': { project: '.agents/skills',  user: path.join(os.homedir(), '.copilot/skills') },
@@ -177,6 +181,149 @@ export function registerSkillsCommands(program: Command): void {
         success({ skills: skillsList, total: skillsList.length }, 'skills', 'list', start);
       } catch (err) {
         fail(err, 'skills', 'list', start);
+      }
+    });
+
+  const marketplace = skills.command('marketplace').description('Manage a Bitbucket-hosted skills marketplace');
+
+  marketplace
+    .command('setup')
+    .description('Clone a skills marketplace repo and register it in global config')
+    .argument('<url>', 'Git clone URL of the marketplace repository')
+    .argument('<localPath>', 'Local directory to clone the marketplace into')
+    .option('--branch <branch>', 'Branch to clone', 'master')
+    .action(async (url: string, localPath: string, opts: { branch: string }) => {
+      const start = Date.now();
+      try {
+        const resolvedPath = path.resolve(localPath);
+
+        if (fs.existsSync(resolvedPath)) {
+          const entries = fs.readdirSync(resolvedPath);
+          if (entries.length > 0 && !fs.existsSync(path.join(resolvedPath, '.git'))) {
+            throw new Error(`Directory already exists and is not a git repo: ${resolvedPath}`);
+          }
+          if (fs.existsSync(path.join(resolvedPath, '.git'))) {
+            warn(`Directory already contains a git repo at ${resolvedPath} — skipping clone, updating config only.`);
+          } else {
+            warn(`Cloning ${url} (branch: ${opts.branch}) → ${resolvedPath}...`);
+            execSync(`git clone --branch ${opts.branch} ${url} ${resolvedPath}`, { stdio: 'inherit' });
+          }
+        } else {
+          warn(`Cloning ${url} (branch: ${opts.branch}) → ${resolvedPath}...`);
+          execSync(`git clone --branch ${opts.branch} ${url} ${resolvedPath}`, { stdio: 'inherit' });
+        }
+
+        const configPath = getGlobalConfigPath();
+        let existing: GlobalConfig = {};
+        try {
+          existing = JSON.parse(fs.readFileSync(configPath, 'utf8')) as GlobalConfig;
+        } catch { /* config file may not exist yet */ }
+
+        existing.marketplace = { repoUrl: url, localPath: resolvedPath };
+        writeGlobalConfig(existing, configPath);
+
+        success({ repoUrl: url, localPath: resolvedPath, branch: opts.branch }, 'skills', 'marketplace-setup', start);
+      } catch (err) {
+        fail(err, 'skills', 'marketplace-setup', start);
+      }
+    });
+
+  marketplace
+    .command('sync')
+    .description('Pull latest marketplace content and install a plugin\'s skills')
+    .argument('[plugin]', 'Plugin name to install (skips interactive selection)')
+    .option('--claude', 'Install to ~/.claude/skills instead of ~/.agents/skills')
+    .action(async (plugin: string | undefined, opts: { claude?: boolean }) => {
+      const start = Date.now();
+      try {
+        const configPath = getGlobalConfigPath();
+        let globalConfig: GlobalConfig = {};
+        try {
+          globalConfig = JSON.parse(fs.readFileSync(configPath, 'utf8')) as GlobalConfig;
+        } catch { /* ignore */ }
+
+        const marketplacePath = globalConfig.marketplace?.localPath;
+        if (!marketplacePath || !fs.existsSync(marketplacePath)) {
+          throw new Error('Marketplace not configured. Run: pncli skills marketplace setup <url> <localPath>');
+        }
+
+        warn('Fetching latest marketplace content...');
+        execSync(`git -C ${marketplacePath} fetch`, { stdio: 'inherit' });
+        execSync(`git -C ${marketplacePath} pull`, { stdio: 'inherit' });
+
+        // Resolve plugin list from marketplace.json, falling back to directory scan
+        const marketplaceJsonPath = path.join(marketplacePath, '.claude-plugin', 'marketplace.json');
+        let pluginChoices: { name: string; description: string }[] = [];
+
+        if (fs.existsSync(marketplaceJsonPath)) {
+          const meta = JSON.parse(fs.readFileSync(marketplaceJsonPath, 'utf8')) as {
+            plugins?: { name: string; description?: string }[];
+          };
+          if (Array.isArray(meta.plugins)) {
+            pluginChoices = meta.plugins.map(p => ({ name: p.name, description: p.description ?? '' }));
+          }
+        }
+
+        if (pluginChoices.length === 0) {
+          const pluginsDir = path.join(marketplacePath, 'plugins');
+          if (fs.existsSync(pluginsDir)) {
+            pluginChoices = fs.readdirSync(pluginsDir)
+              .filter(name => fs.statSync(path.join(pluginsDir, name)).isDirectory())
+              .map(name => ({ name, description: '' }));
+          }
+        }
+
+        if (pluginChoices.length === 0) {
+          throw new Error('No plugins found in marketplace. Check the marketplace repository structure.');
+        }
+
+        let selectedPlugin: string;
+        if (plugin) {
+          if (!pluginChoices.some(p => p.name === plugin)) {
+            throw new Error(`Plugin "${plugin}" not found. Available: ${pluginChoices.map(p => p.name).join(', ')}`);
+          }
+          selectedPlugin = plugin;
+        } else {
+          selectedPlugin = await select({
+            message: 'Select a plugin to install:',
+            choices: pluginChoices.map(p => ({
+              value: p.name,
+              name: p.description ? `${p.name} — ${p.description}` : p.name,
+            })),
+          });
+        }
+
+        const skillsSrc = path.join(marketplacePath, 'plugins', selectedPlugin, 'skills');
+        if (!fs.existsSync(skillsSrc)) {
+          throw new Error(`No skills directory found at ${skillsSrc}`);
+        }
+
+        const targetDir = opts.claude
+          ? path.join(os.homedir(), '.claude', 'skills')
+          : path.join(os.homedir(), '.agents', 'skills');
+
+        fs.mkdirSync(targetDir, { recursive: true });
+
+        const skillNames = fs.readdirSync(skillsSrc).filter(name =>
+          fs.statSync(path.join(skillsSrc, name)).isDirectory()
+        );
+
+        const installed: string[] = [];
+        for (const skillName of skillNames) {
+          const dest = path.join(targetDir, skillName);
+          fs.rmSync(dest, { recursive: true, force: true });
+          fs.cpSync(path.join(skillsSrc, skillName), dest, { recursive: true });
+          installed.push(skillName);
+        }
+
+        success({
+          plugin: selectedPlugin,
+          installed,
+          total: installed.length,
+          target: targetDir,
+        }, 'skills', 'marketplace-sync', start);
+      } catch (err) {
+        fail(err, 'skills', 'marketplace-sync', start);
       }
     });
 }

--- a/src/services/skills/commands.ts
+++ b/src/services/skills/commands.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { select } from '@inquirer/prompts';
 import { writeGlobalConfig, getGlobalConfigPath } from '../../lib/config.js';
 import type { GlobalConfig } from '../../types/config.js';
@@ -197,20 +197,15 @@ export function registerSkillsCommands(program: Command): void {
       try {
         const resolvedPath = path.resolve(localPath);
 
-        if (fs.existsSync(resolvedPath)) {
-          const entries = fs.readdirSync(resolvedPath);
-          if (entries.length > 0 && !fs.existsSync(path.join(resolvedPath, '.git'))) {
-            throw new Error(`Directory already exists and is not a git repo: ${resolvedPath}`);
-          }
-          if (fs.existsSync(path.join(resolvedPath, '.git'))) {
-            warn(`Directory already contains a git repo at ${resolvedPath} — skipping clone, updating config only.`);
-          } else {
-            warn(`Cloning ${url} (branch: ${opts.branch}) → ${resolvedPath}...`);
-            execSync(`git clone --branch ${opts.branch} ${url} ${resolvedPath}`, { stdio: 'inherit' });
-          }
+        const hasGit = fs.existsSync(path.join(resolvedPath, '.git'));
+        if (fs.existsSync(resolvedPath) && !hasGit && fs.readdirSync(resolvedPath).length > 0) {
+          throw new Error(`Directory already exists and is not a git repo: ${resolvedPath}`);
+        }
+        if (hasGit) {
+          warn(`Directory already contains a git repo at ${resolvedPath} — skipping clone, updating config only.`);
         } else {
           warn(`Cloning ${url} (branch: ${opts.branch}) → ${resolvedPath}...`);
-          execSync(`git clone --branch ${opts.branch} ${url} ${resolvedPath}`, { stdio: 'inherit' });
+          execFileSync('git', ['clone', '--branch', opts.branch, url, resolvedPath], { stdio: 'inherit' });
         }
 
         const configPath = getGlobalConfigPath();
@@ -248,8 +243,8 @@ export function registerSkillsCommands(program: Command): void {
         }
 
         warn('Fetching latest marketplace content...');
-        execSync(`git -C ${marketplacePath} fetch`, { stdio: 'inherit' });
-        execSync(`git -C ${marketplacePath} pull`, { stdio: 'inherit' });
+        execFileSync('git', ['-C', marketplacePath, 'fetch'], { stdio: 'inherit' });
+        execFileSync('git', ['-C', marketplacePath, 'pull'], { stdio: 'inherit' });
 
         // Resolve plugin list from marketplace.json, falling back to directory scan
         const marketplaceJsonPath = path.join(marketplacePath, '.claude-plugin', 'marketplace.json');
@@ -293,7 +288,11 @@ export function registerSkillsCommands(program: Command): void {
           });
         }
 
-        const skillsSrc = path.join(marketplacePath, 'plugins', selectedPlugin, 'skills');
+        const pluginsBase = path.resolve(marketplacePath, 'plugins');
+        const skillsSrc = path.resolve(pluginsBase, selectedPlugin, 'skills');
+        if (!skillsSrc.startsWith(pluginsBase + path.sep)) {
+          throw new Error(`Invalid plugin name: "${selectedPlugin}"`);
+        }
         if (!fs.existsSync(skillsSrc)) {
           throw new Error(`No skills directory found at ${skillsSrc}`);
         }
@@ -304,13 +303,15 @@ export function registerSkillsCommands(program: Command): void {
 
         fs.mkdirSync(targetDir, { recursive: true });
 
+        const resolvedTarget = path.resolve(targetDir);
         const skillNames = fs.readdirSync(skillsSrc).filter(name =>
           fs.statSync(path.join(skillsSrc, name)).isDirectory()
         );
 
         const installed: string[] = [];
         for (const skillName of skillNames) {
-          const dest = path.join(targetDir, skillName);
+          const dest = path.resolve(targetDir, skillName);
+          if (!dest.startsWith(resolvedTarget + path.sep)) continue;
           fs.rmSync(dest, { recursive: true, force: true });
           fs.cpSync(path.join(skillsSrc, skillName), dest, { recursive: true });
           installed.push(skillName);

--- a/src/services/skills/commands.ts
+++ b/src/services/skills/commands.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import { select } from '@inquirer/prompts';
-import { writeGlobalConfig, getGlobalConfigPath } from '../../lib/config.js';
+import { writeGlobalConfig, getGlobalConfigPath, loadJsonFile } from '../../lib/config.js';
 import type { GlobalConfig } from '../../types/config.js';
 
 const AGENT_PATHS: Record<string, { project: string; user: string }> = {
@@ -184,7 +184,7 @@ export function registerSkillsCommands(program: Command): void {
       }
     });
 
-  const marketplace = skills.command('marketplace').description('Manage a Bitbucket-hosted skills marketplace');
+  const marketplace = skills.command('marketplace').description('Manage a git-hosted skills marketplace');
 
   marketplace
     .command('setup')
@@ -209,11 +209,7 @@ export function registerSkillsCommands(program: Command): void {
         }
 
         const configPath = getGlobalConfigPath();
-        let existing: GlobalConfig = {};
-        try {
-          existing = JSON.parse(fs.readFileSync(configPath, 'utf8')) as GlobalConfig;
-        } catch { /* config file may not exist yet */ }
-
+        const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
         existing.marketplace = { repoUrl: url, localPath: resolvedPath };
         writeGlobalConfig(existing, configPath);
 
@@ -232,42 +228,17 @@ export function registerSkillsCommands(program: Command): void {
       const start = Date.now();
       try {
         const configPath = getGlobalConfigPath();
-        let globalConfig: GlobalConfig = {};
-        try {
-          globalConfig = JSON.parse(fs.readFileSync(configPath, 'utf8')) as GlobalConfig;
-        } catch { /* ignore */ }
+        const globalConfig: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
 
         const marketplacePath = globalConfig.marketplace?.localPath;
         if (!marketplacePath || !fs.existsSync(marketplacePath)) {
           throw new Error('Marketplace not configured. Run: pncli skills marketplace setup <url> <localPath>');
         }
 
-        warn('Fetching latest marketplace content...');
-        execFileSync('git', ['-C', marketplacePath, 'fetch'], { stdio: 'inherit' });
+        warn('Pulling latest marketplace content...');
         execFileSync('git', ['-C', marketplacePath, 'pull'], { stdio: 'inherit' });
 
-        // Resolve plugin list from marketplace.json, falling back to directory scan
-        const marketplaceJsonPath = path.join(marketplacePath, '.claude-plugin', 'marketplace.json');
-        let pluginChoices: { name: string; description: string }[] = [];
-
-        if (fs.existsSync(marketplaceJsonPath)) {
-          const meta = JSON.parse(fs.readFileSync(marketplaceJsonPath, 'utf8')) as {
-            plugins?: { name: string; description?: string }[];
-          };
-          if (Array.isArray(meta.plugins)) {
-            pluginChoices = meta.plugins.map(p => ({ name: p.name, description: p.description ?? '' }));
-          }
-        }
-
-        if (pluginChoices.length === 0) {
-          const pluginsDir = path.join(marketplacePath, 'plugins');
-          if (fs.existsSync(pluginsDir)) {
-            pluginChoices = fs.readdirSync(pluginsDir)
-              .filter(name => fs.statSync(path.join(pluginsDir, name)).isDirectory())
-              .map(name => ({ name, description: '' }));
-          }
-        }
-
+        const pluginChoices = resolvePluginChoices(marketplacePath);
         if (pluginChoices.length === 0) {
           throw new Error('No plugins found in marketplace. Check the marketplace repository structure.');
         }
@@ -288,11 +259,7 @@ export function registerSkillsCommands(program: Command): void {
           });
         }
 
-        const pluginsBase = path.resolve(marketplacePath, 'plugins');
-        const skillsSrc = path.resolve(pluginsBase, selectedPlugin, 'skills');
-        if (!skillsSrc.startsWith(pluginsBase + path.sep)) {
-          throw new Error(`Invalid plugin name: "${selectedPlugin}"`);
-        }
+        const skillsSrc = resolveSkillsSrc(marketplacePath, selectedPlugin);
         if (!fs.existsSync(skillsSrc)) {
           throw new Error(`No skills directory found at ${skillsSrc}`);
         }
@@ -301,25 +268,15 @@ export function registerSkillsCommands(program: Command): void {
           ? path.join(os.homedir(), '.claude', 'skills')
           : path.join(os.homedir(), '.agents', 'skills');
 
-        fs.mkdirSync(targetDir, { recursive: true });
-
-        const resolvedTarget = path.resolve(targetDir);
-        const skillNames = fs.readdirSync(skillsSrc).filter(name =>
-          fs.statSync(path.join(skillsSrc, name)).isDirectory()
-        );
-
-        const installed: string[] = [];
-        for (const skillName of skillNames) {
-          const dest = path.resolve(targetDir, skillName);
-          if (!dest.startsWith(resolvedTarget + path.sep)) continue;
-          fs.rmSync(dest, { recursive: true, force: true });
-          fs.cpSync(path.join(skillsSrc, skillName), dest, { recursive: true });
-          installed.push(skillName);
+        const { installed, failed } = copyPluginSkills(skillsSrc, targetDir);
+        if (failed.length > 0) {
+          warn(`Skipped ${failed.length} skill(s) with invalid names: ${failed.join(', ')}`);
         }
 
         success({
           plugin: selectedPlugin,
           installed,
+          failed,
           total: installed.length,
           target: targetDir,
         }, 'skills', 'marketplace-sync', start);
@@ -327,4 +284,61 @@ export function registerSkillsCommands(program: Command): void {
         fail(err, 'skills', 'marketplace-sync', start);
       }
     });
+}
+
+export function resolvePluginChoices(marketplacePath: string): { name: string; description: string }[] {
+  const marketplaceJsonPath = path.join(marketplacePath, '.claude-plugin', 'marketplace.json');
+  if (fs.existsSync(marketplaceJsonPath)) {
+    try {
+      const meta = JSON.parse(fs.readFileSync(marketplaceJsonPath, 'utf8')) as {
+        plugins?: { name: string; description?: string }[];
+      };
+      if (Array.isArray(meta.plugins) && meta.plugins.length > 0) {
+        return meta.plugins.map(p => ({ name: p.name, description: p.description ?? '' }));
+      }
+    } catch { /* fallthrough to dir scan */ }
+  }
+
+  const pluginsDir = path.join(marketplacePath, 'plugins');
+  if (fs.existsSync(pluginsDir)) {
+    return fs.readdirSync(pluginsDir)
+      .filter(name => fs.statSync(path.join(pluginsDir, name)).isDirectory())
+      .map(name => ({ name, description: '' }));
+  }
+
+  return [];
+}
+
+export function resolveSkillsSrc(marketplacePath: string, selectedPlugin: string): string {
+  const pluginsBase = path.resolve(marketplacePath, 'plugins');
+  const skillsSrc = path.resolve(pluginsBase, selectedPlugin, 'skills');
+  if (!skillsSrc.startsWith(pluginsBase + path.sep)) {
+    throw new Error(`Invalid plugin name: "${selectedPlugin}"`);
+  }
+  return skillsSrc;
+}
+
+export function copyPluginSkills(skillsSrc: string, targetDir: string): { installed: string[]; failed: string[] } {
+  fs.mkdirSync(targetDir, { recursive: true });
+  const resolvedTarget = path.resolve(targetDir);
+
+  const skillNames = fs.readdirSync(skillsSrc).filter(name =>
+    fs.statSync(path.join(skillsSrc, name)).isDirectory()
+  );
+
+  const installed: string[] = [];
+  const failed: string[] = [];
+
+  for (const skillName of skillNames) {
+    const dest = path.resolve(targetDir, skillName);
+    if (!dest.startsWith(resolvedTarget + path.sep)) {
+      failed.push(skillName);
+      continue;
+    }
+    fs.rmSync(dest, { recursive: true, force: true });
+    fs.cpSync(path.join(skillsSrc, skillName), dest, { recursive: true });
+    installed.push(skillName);
+  }
+
+  return { installed, failed };
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -119,6 +119,11 @@ export interface SonatypeIqConfig {
   passcode?: string;
 }
 
+export interface MarketplaceConfig {
+  repoUrl?: string;
+  localPath?: string;
+}
+
 export interface UdeployDefaults {
   application?: string;
   environment?: string;
@@ -153,6 +158,7 @@ export interface GlobalConfig {
   servicenow?: ServiceNowConfig;
   contrast?: ContrastConfig;
   sonatypeiq?: SonatypeIqConfig;
+  marketplace?: MarketplaceConfig;
   defaults?: Defaults;
 }
 


### PR DESCRIPTION
## Summary

- Add `pncli skills marketplace setup` to clone an on-premise (or GitHub-hosted) skills marketplace repo and register it in global config
- Add `pncli skills marketplace sync` to pull the latest marketplace content and install a chosen plugin's skills globally
- Add `MarketplaceConfig` to `GlobalConfig` type (`repoUrl`, `localPath`)
- Update `copilot-instructions.md` command reference and `skills/local-setup/SKILL.md` setup guide

## Commands added / updated

- `pncli skills marketplace setup <url> <localPath>` — Clone a marketplace repo and register it in `~/.pncli/config.json`
  - `--branch <branch>` — Branch to clone (default: `"master"`)
- `pncli skills marketplace sync [plugin]` — Pull latest and install a plugin's skills globally
  - `[plugin]` — Plugin name (optional positional); skips interactive selection if provided
  - `--claude` — Install to `~/.claude/skills` instead of `~/.agents/skills`

## Pre-PR gate

- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: security issues fixed (execFileSync, path containment, traversal guard)
- ✅ Tests: 134 passed
- ✅ Docs: copilot-instructions.md and local-setup SKILL.md updated

Closes #143