### PR TITLE
feat(git): add report command with date filtering and CSV export

### DIFF
--- a/src/services/git/client.test.ts
+++ b/src/services/git/client.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { parseBranchReportOutput, formatBranchReportCsv } from './client.js';
+
+const COMMIT_PREFIX = '__PNCLI_COMMIT__';
+
+describe('parseBranchReportOutput', () => {
+  it('returns an empty report when raw output is empty', () => {
+    const report = parseBranchReportOutput('', 'main', {});
+    expect(report.branch).toBe('main');
+    expect(report.commits).toHaveLength(0);
+    expect(report.summary.commitCount).toBe(0);
+    expect(report.summary.totalInsertions).toBe(0);
+    expect(report.summary.totalDeletions).toBe(0);
+    expect(report.summary.totalNetLines).toBe(0);
+  });
+
+  it('parses a single commit with no changed files', () => {
+    const raw = `${COMMIT_PREFIX}abc123\tJohn Doe\t2024-01-15T10:00:00Z\tFix bug`;
+    const report = parseBranchReportOutput(raw, 'feature', {});
+    expect(report.commits).toHaveLength(1);
+    const c = report.commits[0]!;
+    expect(c.hash).toBe('abc123');
+    expect(c.author).toBe('John Doe');
+    expect(c.date).toBe('2024-01-15T10:00:00Z');
+    expect(c.message).toBe('Fix bug');
+    expect(c.filesChanged).toBe(0);
+    expect(c.insertions).toBe(0);
+    expect(c.deletions).toBe(0);
+  });
+
+  it('parses a single commit with numstat lines', () => {
+    const raw = [
+      `${COMMIT_PREFIX}abc123\tJane Doe\t2024-02-01T08:00:00Z\tAdd feature`,
+      '5\t2\tsrc/foo.ts',
+      '10\t0\tsrc/bar.ts'
+    ].join('\n');
+
+    const report = parseBranchReportOutput(raw, 'feature', {});
+    expect(report.commits).toHaveLength(1);
+    const c = report.commits[0]!;
+    expect(c.filesChanged).toBe(2);
+    expect(c.insertions).toBe(15);
+    expect(c.deletions).toBe(2);
+    expect(c.netLines).toBe(13);
+  });
+
+  it('parses multiple commits', () => {
+    const raw = [
+      `${COMMIT_PREFIX}aaa\tAlice\t2024-03-01T00:00:00Z\tCommit A`,
+      '3\t1\tfile1.ts',
+      '',
+      `${COMMIT_PREFIX}bbb\tBob\t2024-03-02T00:00:00Z\tCommit B`,
+      '7\t4\tfile2.ts',
+      '2\t0\tfile3.ts'
+    ].join('\n');
+
+    const report = parseBranchReportOutput(raw, 'main', {});
+    expect(report.commits).toHaveLength(2);
+    expect(report.summary.commitCount).toBe(2);
+    expect(report.summary.totalInsertions).toBe(12);
+    expect(report.summary.totalDeletions).toBe(5);
+    expect(report.summary.totalNetLines).toBe(7);
+    expect(report.summary.totalFilesChanged).toBe(3);
+  });
+
+  it('handles binary files (- in numstat)', () => {
+    const raw = [
+      `${COMMIT_PREFIX}ccc\tCarol\t2024-04-01T00:00:00Z\tAdd image`,
+      '-\t-\tassets/logo.png'
+    ].join('\n');
+
+    const report = parseBranchReportOutput(raw, 'main', {});
+    const c = report.commits[0]!;
+    // binary files contribute to filesChanged count but 0 line counts
+    expect(c.filesChanged).toBe(1);
+    expect(c.insertions).toBe(0);
+    expect(c.deletions).toBe(0);
+  });
+
+  it('preserves since/until in report metadata', () => {
+    const report = parseBranchReportOutput('', 'main', { since: '2024-01-01', until: '2024-12-31' });
+    expect(report.since).toBe('2024-01-01');
+    expect(report.until).toBe('2024-12-31');
+  });
+
+  it('sets since/until to null when not provided', () => {
+    const report = parseBranchReportOutput('', 'main', {});
+    expect(report.since).toBeNull();
+    expect(report.until).toBeNull();
+  });
+});
+
+describe('formatBranchReportCsv', () => {
+  const report = {
+    branch: 'feature',
+    since: '2024-01-01',
+    until: '2024-12-31',
+    commits: [
+      {
+        hash: 'abc123',
+        date: '2024-06-15T12:00:00Z',
+        author: 'Alice',
+        message: 'Add feature',
+        filesChanged: 3,
+        insertions: 20,
+        deletions: 5,
+        netLines: 15
+      }
+    ],
+    summary: {
+      commitCount: 1,
+      totalInsertions: 20,
+      totalDeletions: 5,
+      totalNetLines: 15,
+      totalFilesChanged: 3
+    }
+  };
+
+  it('includes header row', () => {
+    const csv = formatBranchReportCsv(report);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe('hash,date,author,message,files_changed,insertions,deletions,net_lines');
+  });
+
+  it('includes one data row per commit', () => {
+    const csv = formatBranchReportCsv(report);
+    const lines = csv.trim().split('\n');
+    // header + 1 commit + TOTAL
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toBe('abc123,2024-06-15T12:00:00Z,Alice,Add feature,3,20,5,15');
+  });
+
+  it('includes TOTAL row', () => {
+    const csv = formatBranchReportCsv(report);
+    const lines = csv.trim().split('\n');
+    const totalRow = lines[lines.length - 1]!;
+    expect(totalRow.startsWith('TOTAL,')).toBe(true);
+    expect(totalRow).toContain('20');
+    expect(totalRow).toContain('15');
+  });
+
+  it('escapes commas in author/message fields', () => {
+    const r = {
+      ...report,
+      commits: [
+        {
+          ...report.commits[0]!,
+          author: 'Doe, Jane',
+          message: 'Fix: handle "quotes" and, commas'
+        }
+      ]
+    };
+    const csv = formatBranchReportCsv(r);
+    const dataLine = csv.split('\n')[1]!;
+    // Both fields should be quoted
+    expect(dataLine).toContain('"Doe, Jane"');
+    expect(dataLine).toContain('"Fix: handle ""quotes"" and, commas"');
+  });
+
+  it('ends with a newline', () => {
+    const csv = formatBranchReportCsv(report);
+    expect(csv.endsWith('\n')).toBe(true);
+  });
+});

--- a/src/services/git/client.test.ts
+++ b/src/services/git/client.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseBranchReportOutput, formatBranchReportCsv } from './client.js';
-
-const COMMIT_PREFIX = '__PNCLI_COMMIT__';
+import { parseBranchReportOutput, formatBranchReportCsv, buildReportArgs, COMMIT_PREFIX, type BranchReport } from './client.js';
 
 describe('parseBranchReportOutput', () => {
   it('returns an empty report when raw output is empty', () => {
@@ -90,48 +88,114 @@ describe('parseBranchReportOutput', () => {
   });
 });
 
-describe('formatBranchReportCsv', () => {
-  const report = {
-    branch: 'feature',
-    since: '2024-01-01',
-    until: '2024-12-31',
-    commits: [
-      {
-        hash: 'abc123',
-        date: '2024-06-15T12:00:00Z',
-        author: 'Alice',
-        message: 'Add feature',
-        filesChanged: 3,
-        insertions: 20,
-        deletions: 5,
-        netLines: 15
-      }
-    ],
-    summary: {
-      commitCount: 1,
-      totalInsertions: 20,
-      totalDeletions: 5,
-      totalNetLines: 15,
-      totalFilesChanged: 3
-    }
-  };
-
-  it('includes header row', () => {
-    const csv = formatBranchReportCsv(report);
-    const lines = csv.split('\n');
-    expect(lines[0]).toBe('hash,date,author,message,files_changed,insertions,deletions,net_lines');
+describe('weekly and author breakdown', () => {
+  it('single author, single week', () => {
+    const raw = [
+      `${COMMIT_PREFIX}aaa\tAlice\t2024-04-10T10:00:00Z\tCommit A`,
+      '5\t2\tsrc/foo.ts'
+    ].join('\n');
+    const report = parseBranchReportOutput(raw, 'main', {});
+    expect(report.weeks).toHaveLength(1);
+    expect(report.weeks[0]!.week).toBe('2024-W15');
+    expect(report.weeks[0]!.weekStart).toBe('2024-04-08');
+    expect(report.weeks[0]!.weekEnd).toBe('2024-04-14');
+    expect(report.weeks[0]!.authors).toHaveLength(1);
+    expect(report.weeks[0]!.authors[0]!.author).toBe('Alice');
+    expect(report.weeks[0]!.authors[0]!.commitCount).toBe(1);
+    expect(report.weeks[0]!.authors[0]!.insertions).toBe(5);
+    expect(report.weeks[0]!.authors[0]!.deletions).toBe(2);
+    expect(report.weeks[0]!.authors[0]!.netLines).toBe(3);
+    expect(report.weeks[0]!.summary.commitCount).toBe(1);
+    expect(report.byAuthor).toHaveLength(1);
+    expect(report.byAuthor[0]!.author).toBe('Alice');
   });
 
-  it('includes one data row per commit', () => {
-    const csv = formatBranchReportCsv(report);
+  it('multiple authors in same week are sorted alphabetically', () => {
+    const raw = [
+      `${COMMIT_PREFIX}aaa\tZara\t2024-04-09T10:00:00Z\tCommit Z`,
+      '3\t1\tfile.ts',
+      `${COMMIT_PREFIX}bbb\tAlice\t2024-04-10T10:00:00Z\tCommit A`,
+      '7\t2\tfile.ts'
+    ].join('\n');
+    const report = parseBranchReportOutput(raw, 'main', {});
+    expect(report.weeks).toHaveLength(1);
+    const authors = report.weeks[0]!.authors;
+    expect(authors).toHaveLength(2);
+    expect(authors[0]!.author).toBe('Alice');
+    expect(authors[1]!.author).toBe('Zara');
+    expect(report.weeks[0]!.summary.commitCount).toBe(2);
+    expect(report.weeks[0]!.summary.totalInsertions).toBe(10);
+  });
+
+  it('commits spanning two weeks produce two entries in chronological order', () => {
+    const raw = [
+      `${COMMIT_PREFIX}aaa\tAlice\t2024-04-08T10:00:00Z\tWeek 15`,
+      '2\t0\tfile.ts',
+      `${COMMIT_PREFIX}bbb\tAlice\t2024-04-15T10:00:00Z\tWeek 16`,
+      '4\t1\tfile.ts'
+    ].join('\n');
+    const report = parseBranchReportOutput(raw, 'main', {});
+    expect(report.weeks).toHaveLength(2);
+    expect(report.weeks[0]!.week).toBe('2024-W15');
+    expect(report.weeks[1]!.week).toBe('2024-W16');
+  });
+
+  it('byAuthor rolls up across all weeks', () => {
+    const raw = [
+      `${COMMIT_PREFIX}aaa\tAlice\t2024-04-08T10:00:00Z\tWeek 15`,
+      '2\t0\tfile.ts',
+      `${COMMIT_PREFIX}bbb\tAlice\t2024-04-15T10:00:00Z\tWeek 16`,
+      '4\t1\tfile.ts',
+      `${COMMIT_PREFIX}ccc\tBob\t2024-04-15T10:00:00Z\tWeek 16 Bob`,
+      '1\t1\tfile.ts'
+    ].join('\n');
+    const report = parseBranchReportOutput(raw, 'main', {});
+    expect(report.byAuthor).toHaveLength(2);
+    const alice = report.byAuthor.find(a => a.author === 'Alice')!;
+    expect(alice.commitCount).toBe(2);
+    expect(alice.insertions).toBe(6);
+    expect(alice.deletions).toBe(1);
+    const bob = report.byAuthor.find(a => a.author === 'Bob')!;
+    expect(bob.commitCount).toBe(1);
+  });
+
+  it('empty commits produce empty weeks and byAuthor', () => {
+    const report = parseBranchReportOutput('', 'main', {});
+    expect(report.weeks).toHaveLength(0);
+    expect(report.byAuthor).toHaveLength(0);
+  });
+});
+
+describe('formatBranchReportCsv', () => {
+  const makeReport = (overrides?: Partial<BranchReport>): BranchReport => {
+    const base = parseBranchReportOutput(
+      [
+        `${COMMIT_PREFIX}abc123\tAlice\t2024-06-15T12:00:00Z\tAdd feature`,
+        '20\t5\tsrc/foo.ts',
+        '0\t0\tsrc/bar.ts'
+      ].join('\n'),
+      'feature',
+      { since: '2024-01-01', until: '2024-12-31' }
+    );
+    return { ...base, ...overrides };
+  };
+
+  it('includes weekly/author header row', () => {
+    const csv = formatBranchReportCsv(makeReport());
+    expect(csv.split('\n')[0]).toBe('week,week_start,author,commits,insertions,deletions,net_lines,files_changed');
+  });
+
+  it('includes one data row per author per week', () => {
+    const csv = formatBranchReportCsv(makeReport());
     const lines = csv.trim().split('\n');
-    // header + 1 commit + TOTAL
+    // header + 1 author row + TOTAL
     expect(lines).toHaveLength(3);
-    expect(lines[1]).toBe('abc123,2024-06-15T12:00:00Z,Alice,Add feature,3,20,5,15');
+    expect(lines[1]).toContain('Alice');
+    expect(lines[1]).toContain('2024-W24');
   });
 
   it('includes TOTAL row', () => {
-    const csv = formatBranchReportCsv(report);
+    const csv = formatBranchReportCsv(makeReport());
     const lines = csv.trim().split('\n');
     const totalRow = lines[lines.length - 1]!;
     expect(totalRow.startsWith('TOTAL,')).toBe(true);
@@ -139,26 +203,49 @@ describe('formatBranchReportCsv', () => {
     expect(totalRow).toContain('15');
   });
 
-  it('escapes commas in author/message fields', () => {
-    const r = {
-      ...report,
-      commits: [
-        {
-          ...report.commits[0]!,
-          author: 'Doe, Jane',
-          message: 'Fix: handle "quotes" and, commas'
-        }
-      ]
-    };
-    const csv = formatBranchReportCsv(r);
-    const dataLine = csv.split('\n')[1]!;
-    // Both fields should be quoted
-    expect(dataLine).toContain('"Doe, Jane"');
-    expect(dataLine).toContain('"Fix: handle ""quotes"" and, commas"');
+  it('escapes commas in author field', () => {
+    const raw = [
+      `${COMMIT_PREFIX}aaa\tDoe, Jane\t2024-04-10T10:00:00Z\tFix`,
+      '1\t0\tfile.ts'
+    ].join('\n');
+    const report = parseBranchReportOutput(raw, 'main', {});
+    const csv = formatBranchReportCsv(report);
+    expect(csv).toContain('"Doe, Jane"');
   });
 
   it('ends with a newline', () => {
-    const csv = formatBranchReportCsv(report);
+    const csv = formatBranchReportCsv(makeReport());
     expect(csv.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('buildReportArgs', () => {
+  it('adds base..HEAD when --base given without --branch', () => {
+    const args = buildReportArgs({ base: 'main' });
+    expect(args).toContain('main..HEAD');
+  });
+
+  it('adds base..branch when both --base and --branch given', () => {
+    const args = buildReportArgs({ base: 'main', branch: 'feature' });
+    expect(args).toContain('main..feature');
+    expect(args).not.toContain('main..HEAD');
+  });
+
+  it('adds branch alone when only --branch given', () => {
+    const args = buildReportArgs({ branch: 'feature' });
+    expect(args).toContain('feature');
+    expect(args).not.toContain('..');
+  });
+
+  it('adds --since and --until flags', () => {
+    const args = buildReportArgs({ since: '2024-01-01', until: '2024-12-31' });
+    expect(args).toContain('--since=2024-01-01');
+    expect(args).toContain('--until=2024-12-31');
+  });
+
+  it('adds no range arg when no base, branch, since, or until', () => {
+    const args = buildReportArgs({});
+    expect(args).not.toContain('..');
+    expect(args.some(a => a.startsWith('--since'))).toBe(false);
   });
 });

--- a/src/services/git/client.ts
+++ b/src/services/git/client.ts
@@ -209,11 +209,20 @@ export interface CommitStats {
   netLines: number;
 }
 
-export interface BranchReport {
-  branch: string;
-  since: string | null;
-  until: string | null;
-  commits: CommitStats[];
+export interface AuthorStats {
+  author: string;
+  commitCount: number;
+  insertions: number;
+  deletions: number;
+  netLines: number;
+  filesChanged: number;
+}
+
+export interface WeeklyBreakdown {
+  week: string;
+  weekStart: string;
+  weekEnd: string;
+  authors: AuthorStats[];
   summary: {
     commitCount: number;
     totalInsertions: number;
@@ -223,7 +232,118 @@ export interface BranchReport {
   };
 }
 
-const COMMIT_PREFIX = '__PNCLI_COMMIT__';
+export interface BranchReport {
+  branch: string;
+  since: string | null;
+  until: string | null;
+  commits: CommitStats[];
+  weeks: WeeklyBreakdown[];
+  byAuthor: AuthorStats[];
+  summary: {
+    commitCount: number;
+    totalInsertions: number;
+    totalDeletions: number;
+    totalNetLines: number;
+    totalFilesChanged: number;
+  };
+}
+
+export const COMMIT_PREFIX = '__PNCLI_COMMIT__';
+
+function getWeekMonday(dateStr: string): string {
+  const d = new Date(dateStr);
+  const day = d.getUTCDay(); // 0=Sun
+  const diff = day === 0 ? -6 : 1 - day;
+  const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + diff));
+  return monday.toISOString().slice(0, 10);
+}
+
+function getWeekSunday(mondayStr: string): string {
+  const d = new Date(mondayStr);
+  const sunday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 6));
+  return sunday.toISOString().slice(0, 10);
+}
+
+function getISOWeekLabel(mondayStr: string): string {
+  const d = new Date(mondayStr);
+  // Thursday of the same week determines the ISO year
+  const thursday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 3));
+  const year = thursday.getUTCFullYear();
+  const jan4 = new Date(Date.UTC(year, 0, 4)); // Jan 4 is always in week 1
+  const jan4Monday = new Date(Date.UTC(year, 0, 4 - (jan4.getUTCDay() === 0 ? 6 : jan4.getUTCDay() - 1)));
+  const weekNum = Math.round((d.getTime() - jan4Monday.getTime()) / (7 * 86400000)) + 1;
+  return `${year}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+function buildWeeklyBreakdown(commits: CommitStats[]): WeeklyBreakdown[] {
+  const weekMap = new Map<string, Map<string, AuthorStats>>();
+
+  for (const commit of commits) {
+    const monday = getWeekMonday(commit.date);
+    if (!weekMap.has(monday)) weekMap.set(monday, new Map());
+    const authorMap = weekMap.get(monday)!;
+
+    if (!authorMap.has(commit.author)) {
+      authorMap.set(commit.author, {
+        author: commit.author,
+        commitCount: 0,
+        insertions: 0,
+        deletions: 0,
+        netLines: 0,
+        filesChanged: 0
+      });
+    }
+
+    const stats = authorMap.get(commit.author)!;
+    stats.commitCount++;
+    stats.insertions += commit.insertions;
+    stats.deletions += commit.deletions;
+    stats.netLines += commit.netLines;
+    stats.filesChanged += commit.filesChanged;
+  }
+
+  return [...weekMap.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([monday, authorMap]) => {
+      const authors = [...authorMap.values()].sort((a, b) => a.author.localeCompare(b.author));
+      return {
+        week: getISOWeekLabel(monday),
+        weekStart: monday,
+        weekEnd: getWeekSunday(monday),
+        authors,
+        summary: {
+          commitCount: authors.reduce((s, a) => s + a.commitCount, 0),
+          totalInsertions: authors.reduce((s, a) => s + a.insertions, 0),
+          totalDeletions: authors.reduce((s, a) => s + a.deletions, 0),
+          totalNetLines: authors.reduce((s, a) => s + a.netLines, 0),
+          totalFilesChanged: authors.reduce((s, a) => s + a.filesChanged, 0)
+        }
+      };
+    });
+}
+
+function buildByAuthor(commits: CommitStats[]): AuthorStats[] {
+  const map = new Map<string, AuthorStats>();
+  for (const commit of commits) {
+    if (!map.has(commit.author)) {
+      map.set(commit.author, {
+        author: commit.author,
+        commitCount: 0,
+        insertions: 0,
+        deletions: 0,
+        netLines: 0,
+        filesChanged: 0
+      });
+    }
+    const stats = map.get(commit.author)!;
+    stats.commitCount++;
+    stats.insertions += commit.insertions;
+    stats.deletions += commit.deletions;
+    stats.netLines += commit.netLines;
+    stats.filesChanged += commit.filesChanged;
+  }
+  return [...map.values()].sort((a, b) => a.author.localeCompare(b.author));
+}
 
 // Exported for unit testing
 export function parseBranchReportOutput(
@@ -272,6 +392,8 @@ export function parseBranchReportOutput(
     since: opts.since ?? null,
     until: opts.until ?? null,
     commits,
+    weeks: buildWeeklyBreakdown(commits),
+    byAuthor: buildByAuthor(commits),
     summary: {
       commitCount: commits.length,
       totalInsertions,
@@ -282,10 +404,8 @@ export function parseBranchReportOutput(
   };
 }
 
-export function getBranchReport(
-  root: string,
-  opts: { branch?: string; since?: string; until?: string; base?: string }
-): BranchReport {
+// Exported for unit testing — pure arg construction with no I/O
+export function buildReportArgs(opts: { branch?: string; since?: string; until?: string; base?: string }): string[] {
   const fmt = `${COMMIT_PREFIX}%H\t%an\t%aI\t%s`;
   const args = ['log', `--format=${fmt}`, '--numstat'];
 
@@ -294,9 +414,20 @@ export function getBranchReport(
 
   if (opts.base && opts.branch) {
     args.push(`${opts.base}..${opts.branch}`);
+  } else if (opts.base) {
+    args.push(`${opts.base}..HEAD`);
   } else if (opts.branch) {
     args.push(opts.branch);
   }
+
+  return args;
+}
+
+export function getBranchReport(
+  root: string,
+  opts: { branch?: string; since?: string; until?: string; base?: string }
+): BranchReport {
+  const args = buildReportArgs(opts);
 
   let raw = '';
   try {
@@ -328,31 +459,28 @@ function escapeCsvField(value: string): string {
 }
 
 export function formatBranchReportCsv(report: BranchReport): string {
-  const header = 'hash,date,author,message,files_changed,insertions,deletions,net_lines';
-  const rows = report.commits.map(c =>
-    [
-      c.hash,
-      c.date,
-      escapeCsvField(c.author),
-      escapeCsvField(c.message),
-      c.filesChanged,
-      c.insertions,
-      c.deletions,
-      c.netLines
-    ].join(',')
-  );
+  const header = 'week,week_start,author,commits,insertions,deletions,net_lines,files_changed';
+  const rows: string[] = [];
+
+  for (const week of report.weeks) {
+    for (const a of week.authors) {
+      rows.push(
+        [
+          week.week,
+          week.weekStart,
+          escapeCsvField(a.author),
+          a.commitCount,
+          a.insertions,
+          a.deletions,
+          a.netLines,
+          a.filesChanged
+        ].join(',')
+      );
+    }
+  }
 
   const s = report.summary;
-  const totalRow = [
-    'TOTAL',
-    '',
-    '',
-    escapeCsvField(`commits:${s.commitCount}`),
-    s.totalFilesChanged,
-    s.totalInsertions,
-    s.totalDeletions,
-    s.totalNetLines
-  ].join(',');
+  const totalRow = ['TOTAL', '', '', s.commitCount, s.totalInsertions, s.totalDeletions, s.totalNetLines, s.totalFilesChanged].join(',');
 
   return [header, ...rows, totalRow].join('\n') + '\n';
 }

--- a/src/services/git/client.ts
+++ b/src/services/git/client.ts
@@ -197,3 +197,162 @@ export function getBranches(root: string): BranchResult {
 
   return { current, local, remote };
 }
+
+export interface CommitStats {
+  hash: string;
+  date: string;
+  author: string;
+  message: string;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  netLines: number;
+}
+
+export interface BranchReport {
+  branch: string;
+  since: string | null;
+  until: string | null;
+  commits: CommitStats[];
+  summary: {
+    commitCount: number;
+    totalInsertions: number;
+    totalDeletions: number;
+    totalNetLines: number;
+    totalFilesChanged: number;
+  };
+}
+
+const COMMIT_PREFIX = '__PNCLI_COMMIT__';
+
+// Exported for unit testing
+export function parseBranchReportOutput(
+  raw: string,
+  branchName: string,
+  opts: { since?: string; until?: string }
+): BranchReport {
+  const commits: CommitStats[] = [];
+  let current: CommitStats | null = null;
+
+  for (const line of raw.split('\n')) {
+    if (line.startsWith(COMMIT_PREFIX)) {
+      if (current) commits.push(current);
+      const parts = line.slice(COMMIT_PREFIX.length).split('\t');
+      current = {
+        hash: parts[0] ?? '',
+        author: parts[1] ?? '',
+        date: parts[2] ?? '',
+        message: parts[3] ?? '',
+        filesChanged: 0,
+        insertions: 0,
+        deletions: 0,
+        netLines: 0
+      };
+    } else if (current && /^(\d+|-)\t(\d+|-)/.test(line)) {
+      // numstat line: insertions\tdeletions\tfilename
+      const [ins, del] = line.split('\t');
+      const insertions = ins === '-' ? 0 : parseInt(ins ?? '0', 10);
+      const deletions = del === '-' ? 0 : parseInt(del ?? '0', 10);
+      if (!isNaN(insertions) && !isNaN(deletions)) {
+        current.insertions += insertions;
+        current.deletions += deletions;
+        current.filesChanged++;
+        current.netLines = current.insertions - current.deletions;
+      }
+    }
+  }
+
+  if (current) commits.push(current);
+
+  const totalInsertions = commits.reduce((sum, c) => sum + c.insertions, 0);
+  const totalDeletions = commits.reduce((sum, c) => sum + c.deletions, 0);
+
+  return {
+    branch: branchName,
+    since: opts.since ?? null,
+    until: opts.until ?? null,
+    commits,
+    summary: {
+      commitCount: commits.length,
+      totalInsertions,
+      totalDeletions,
+      totalNetLines: totalInsertions - totalDeletions,
+      totalFilesChanged: commits.reduce((sum, c) => sum + c.filesChanged, 0)
+    }
+  };
+}
+
+export function getBranchReport(
+  root: string,
+  opts: { branch?: string; since?: string; until?: string; base?: string }
+): BranchReport {
+  const fmt = `${COMMIT_PREFIX}%H\t%an\t%aI\t%s`;
+  const args = ['log', `--format=${fmt}`, '--numstat'];
+
+  if (opts.since) args.push(`--since=${opts.since}`);
+  if (opts.until) args.push(`--until=${opts.until}`);
+
+  if (opts.base && opts.branch) {
+    args.push(`${opts.base}..${opts.branch}`);
+  } else if (opts.branch) {
+    args.push(opts.branch);
+  }
+
+  let raw = '';
+  try {
+    raw = execFileSync('git', args, { encoding: 'utf8', cwd: root }).trim();
+  } catch {
+    // no commits or invalid ref — return empty report
+  }
+
+  let branchName = opts.branch ?? '';
+  if (!branchName) {
+    try {
+      branchName = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+        encoding: 'utf8',
+        cwd: root
+      }).trim();
+    } catch {
+      branchName = 'HEAD';
+    }
+  }
+
+  return parseBranchReportOutput(raw, branchName, opts);
+}
+
+function escapeCsvField(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function formatBranchReportCsv(report: BranchReport): string {
+  const header = 'hash,date,author,message,files_changed,insertions,deletions,net_lines';
+  const rows = report.commits.map(c =>
+    [
+      c.hash,
+      c.date,
+      escapeCsvField(c.author),
+      escapeCsvField(c.message),
+      c.filesChanged,
+      c.insertions,
+      c.deletions,
+      c.netLines
+    ].join(',')
+  );
+
+  const s = report.summary;
+  const totalRow = [
+    'TOTAL',
+    '',
+    '',
+    escapeCsvField(`commits:${s.commitCount}`),
+    s.totalFilesChanged,
+    s.totalInsertions,
+    s.totalDeletions,
+    s.totalNetLines
+  ].join(',');
+
+  return [header, ...rows, totalRow].join('\n') + '\n';
+}

--- a/src/services/git/commands.ts
+++ b/src/services/git/commands.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { getStatus, getDiff, getLog, getBranches } from './client.js';
+import { getStatus, getDiff, getLog, getBranches, getBranchReport, formatBranchReportCsv } from './client.js';
 import { getRepoRoot, getCurrentBranch } from '../../lib/git-context.js';
 import { success, fail } from '../../lib/output.js';
 import { PncliError } from '../../lib/errors.js';
@@ -75,6 +75,34 @@ export function registerGitCommands(program: Command): void {
         success(data, 'git', 'branch', start);
       } catch (err) {
         fail(err, 'git', 'branch', start);
+      }
+    });
+
+  git
+    .command('report')
+    .description('Report lines of code and commit counts for a branch, optionally filtered by date')
+    .option('--branch <name>', 'Branch to report on (defaults to current branch)')
+    .option('--base <ref>', 'Base ref to compare against, e.g. "main" (uses range base..branch)')
+    .option('--since <date>', 'Include commits on or after this date (e.g. "2024-01-01")')
+    .option('--until <date>', 'Include commits on or before this date (e.g. "2024-12-31")')
+    .option('--csv', 'Output as CSV instead of JSON')
+    .action((opts: { branch?: string; base?: string; since?: string; until?: string; csv?: boolean }) => {
+      const start = Date.now();
+      try {
+        const root = requireRepoRoot();
+        const report = getBranchReport(root, {
+          branch: opts.branch,
+          base: opts.base,
+          since: opts.since,
+          until: opts.until
+        });
+        if (opts.csv) {
+          process.stdout.write(formatBranchReportCsv(report));
+        } else {
+          success(report, 'git', 'report', start);
+        }
+      } catch (err) {
+        fail(err, 'git', 'report', start);
       }
     });
 

--- a/src/services/git/commands.ts
+++ b/src/services/git/commands.ts
@@ -82,7 +82,7 @@ export function registerGitCommands(program: Command): void {
     .command('report')
     .description('Report lines of code and commit counts for a branch, optionally filtered by date')
     .option('--branch <name>', 'Branch to report on (defaults to current branch)')
-    .option('--base <ref>', 'Base ref to compare against, e.g. "main" (uses range base..branch)')
+    .option('--base <ref>', 'Base ref to compare against, e.g. "main" (base..branch, or base..HEAD if --branch is omitted)')
     .option('--since <date>', 'Include commits on or after this date (e.g. "2024-01-01")')
     .option('--until <date>', 'Include commits on or before this date (e.g. "2024-12-31")')
     .option('--csv', 'Output as CSV instead of JSON')


### PR DESCRIPTION
Adds `pncli git report` — a new subcommand that walks a branch's commit history (optionally filtered by --since/--until dates and compared against a --base ref) and produces a per-commit breakdown of insertions, deletions, files changed, and net lines.

Output is structured JSON by default; pass --csv for a flat CSV file with a TOTAL summary row.

Closes #147

Generated with [Claude Code](https://claude.ai/code)