### PR TITLE
feat(github): add GitHub repository integration

### DIFF
--- a/skills/pncli/SKILL.md
+++ b/skills/pncli/SKILL.md
@@ -36,6 +36,7 @@ For detailed setup of any service, read the included file for that service.
 |---------|------|-------------------|
 | Jira | `jira.md` | Issues, sprints, custom fields |
 | Bitbucket | `bitbucket.md` | Repos, PRs, diffs |
+| GitHub | `github.md` | PRs, reviews, comments, checks |
 | Azure DevOps | `ado.md` | Work items, repos, PRs, pipelines |
 | Confluence | `confluence.md` | Pages, spaces |
 | JWT | `jwt.md` | Decode JWT tokens |
@@ -68,7 +69,7 @@ Ask: "Does this org use Jira or Azure DevOps for work items?" See `jira.md` or `
 
 **Step 3 — Source control**
 
-Ask: "Does this org use Bitbucket or Azure DevOps for PRs?" See `bitbucket.md` or `ado.md`.
+Ask: "Does this org use GitHub, Bitbucket, or Azure DevOps for PRs?" See `github.md`, `bitbucket.md`, or `ado.md`.
 
 **Step 4 — Optional services**
 

--- a/skills/pncli/github.md
+++ b/skills/pncli/github.md
@@ -1,0 +1,36 @@
+# GitHub
+
+Enables: `pncli github list-prs`, `pncli github create-pr`, `pncli github diff` — list and manage PRs, post reviews, get diffs.
+
+## Required config
+
+| Key | Env var | Description |
+|-----|---------|-------------|
+| `github.baseUrl` | `PNCLI_GITHUB_BASE_URL` | GitHub API base URL. GitHub.com: `https://api.github.com`. GitHub Enterprise: `https://<host>/api/v3` |
+| `github.token` | `PNCLI_GITHUB_TOKEN` | Personal access token (classic or fine-grained) |
+
+## Config file (persistent)
+
+```
+pncli config set github.baseUrl https://api.github.com
+pncli config set github.token <token>
+```
+
+## Env vars (ephemeral / CI)
+
+```
+export PNCLI_GITHUB_BASE_URL=https://api.github.com
+export PNCLI_GITHUB_TOKEN=<token>
+```
+
+## Repo defaults
+
+```
+pncli config set --repo defaults.github.owner myorg
+pncli config set --repo defaults.github.repo myrepo
+pncli config set --repo defaults.github.targetBranch main
+```
+
+## Auto-detection
+
+When the git remote matches the configured GitHub host, `--owner` and `--repo` are detected automatically from the remote URL. Both HTTPS (`https://github.com/owner/repo.git`) and SSH (`git@github.com:owner/repo.git`) formats are supported.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { loadConfig } from './lib/config.js';
 import { registerGitCommands } from './services/git/commands.js';
 import { registerJiraCommands } from './services/jira/commands.js';
 import { registerBitbucketCommands } from './services/bitbucket/commands.js';
+import { registerGitHubCommands } from './services/github/commands.js';
 import { registerConfluenceCommands } from './services/confluence/commands.js';
 import { registerSonarCommands } from './services/sonar/commands.js';
 import { registerSdeCommands } from './services/sde/commands.js';
@@ -69,6 +70,7 @@ program.hook('preAction', (thisCommand) => {
 registerGitCommands(program);
 registerJiraCommands(program);
 registerBitbucketCommands(program);
+registerGitHubCommands(program);
 registerConfluenceCommands(program);
 registerSonarCommands(program);
 registerSdeCommands(program);
@@ -92,6 +94,7 @@ Services:
   deps         Dependency scanning, CVE detection, license auditing
   jira         Jira Data Cloud
   bitbucket    Bitbucket Server
+  github       GitHub (PRs, reviews, comments, checks)
   confluence   Confluence
   sonar        SonarQube Server (quality gates, issues, metrics, hotspots)
   sde          SDElements (threat modeling, countermeasures, compliance)

--- a/src/lib/checkmarxFetch.test.ts
+++ b/src/lib/checkmarxFetch.test.ts
@@ -7,6 +7,7 @@ function makeConfig(overrides: Partial<ResolvedConfig['checkmarx']> = {}): Resol
     user: { email: undefined, userId: undefined },
     jira: { baseUrl: undefined, apiToken: undefined, customFields: [] },
     bitbucket: { baseUrl: undefined, pat: undefined },
+    github: { baseUrl: undefined, token: undefined },
     confluence: { baseUrl: undefined, apiToken: undefined, apiTokenExplicit: false },
     artifactory: {},
     sonar: { baseUrl: undefined, token: undefined },
@@ -24,7 +25,7 @@ function makeConfig(overrides: Partial<ResolvedConfig['checkmarx']> = {}): Resol
     contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     sonatypeiq: { baseUrl: undefined, userCode: undefined, passcode: undefined },
     openshift: { baseUrl: undefined, token: undefined },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
+    defaults: { jira: {}, bitbucket: {}, github: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
   };
 }
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -7,6 +7,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     user: { email: 'user@example.com', userId: 'user1' },
     jira: { baseUrl: 'https://jira.example.com', apiToken: 'secret-jira', customFields: [] },
     bitbucket: { baseUrl: 'https://bb.example.com', pat: 'secret-bb' },
+    github: { baseUrl: 'https://api.github.com', token: 'secret-gh' },
     confluence: { baseUrl: 'https://confluence.example.com', apiToken: 'secret-confluence', apiTokenExplicit: true },
     artifactory: { baseUrl: 'https://art.example.com', token: 'secret-art', npmRepo: 'npm', nugetRepo: 'nuget', mavenRepo: 'maven' },
     sonar: { baseUrl: 'https://sonar.example.com', token: 'secret-sonar' },
@@ -19,7 +20,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     sonatypeiq: { baseUrl: undefined, userCode: undefined, passcode: undefined },
     openshift: { baseUrl: undefined, token: undefined },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
+    defaults: { jira: {}, bitbucket: {}, github: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };
 }
@@ -33,6 +34,18 @@ describe('maskConfig', () => {
   it('masks bitbucket pat', () => {
     const masked = maskConfig(baseConfig()) as ResolvedConfig;
     expect(masked.bitbucket.pat).toBe('***');
+  });
+
+  it('masks github token', () => {
+    const masked = maskConfig(baseConfig()) as ResolvedConfig;
+    expect(masked.github.token).toBe('***');
+  });
+
+  it('sets absent github token to undefined rather than ***', () => {
+    const config = baseConfig();
+    config.github.token = undefined;
+    const masked = maskConfig(config) as ResolvedConfig;
+    expect(masked.github.token).toBeUndefined();
   });
 
   it('masks confluence apiToken', () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, SonarDefaults, SdeDefaults, AdoDefaults, UdeployDefaults } from '../types/config.js';
+import type { GlobalConfig, RepoConfig, ResolvedConfig, JiraDefaults, BitbucketDefaults, GitHubDefaults, SonarDefaults, SdeDefaults, AdoDefaults, UdeployDefaults } from '../types/config.js';
 import type { CustomFieldDefinition } from '../types/jira.js';
 
 const ENV_KEYS = {
@@ -12,6 +12,8 @@ const ENV_KEYS = {
   JIRA_API_TOKEN: 'PNCLI_JIRA_API_TOKEN',
   BITBUCKET_BASE_URL: 'PNCLI_BITBUCKET_BASE_URL',
   BITBUCKET_PAT: 'PNCLI_BITBUCKET_PAT',
+  GITHUB_BASE_URL: 'PNCLI_GITHUB_BASE_URL',
+  GITHUB_TOKEN: 'PNCLI_GITHUB_TOKEN',
   CONFLUENCE_BASE_URL: 'PNCLI_CONFLUENCE_BASE_URL',
   CONFLUENCE_API_TOKEN: 'PNCLI_CONFLUENCE_API_TOKEN',
   ARTIFACTORY_BASE_URL: 'PNCLI_ARTIFACTORY_BASE_URL',
@@ -97,10 +99,11 @@ function mergeCustomFields(
 function mergeDefaults(
   global: GlobalConfig['defaults'],
   repo: RepoConfig['defaults']
-): { jira: JiraDefaults; bitbucket: BitbucketDefaults; sonar: SonarDefaults; sde: SdeDefaults; ado: AdoDefaults; udeploy: UdeployDefaults } {
+): { jira: JiraDefaults; bitbucket: BitbucketDefaults; github: GitHubDefaults; sonar: SonarDefaults; sde: SdeDefaults; ado: AdoDefaults; udeploy: UdeployDefaults } {
   return {
     jira: { ...global?.jira, ...repo?.jira },
     bitbucket: { ...global?.bitbucket, ...repo?.bitbucket },
+    github: { ...global?.github, ...repo?.github },
     sonar: { ...global?.sonar, ...repo?.sonar },
     sde: { ...global?.sde, ...repo?.sde },
     ado: { ...global?.ado, ...repo?.ado },
@@ -137,6 +140,10 @@ export function loadConfig(opts: LoadConfigOptions = {}): ResolvedConfig {
     bitbucket: {
       baseUrl: process.env[ENV_KEYS.BITBUCKET_BASE_URL] ?? globalConfig.bitbucket?.baseUrl,
       pat: process.env[ENV_KEYS.BITBUCKET_PAT] ?? globalConfig.bitbucket?.pat
+    },
+    github: {
+      baseUrl: process.env[ENV_KEYS.GITHUB_BASE_URL] ?? globalConfig.github?.baseUrl,
+      token: process.env[ENV_KEYS.GITHUB_TOKEN] ?? globalConfig.github?.token
     },
     confluence: {
       baseUrl: process.env[ENV_KEYS.CONFLUENCE_BASE_URL] ?? globalConfig.confluence?.baseUrl,
@@ -277,6 +284,10 @@ export function maskConfig(config: ResolvedConfig): unknown {
     bitbucket: {
       ...config.bitbucket,
       pat: config.bitbucket.pat ? '***' : undefined
+    },
+    github: {
+      ...config.github,
+      token: config.github.token ? '***' : undefined
     },
     confluence: {
       ...config.confluence,

--- a/src/lib/git-context.ts
+++ b/src/lib/git-context.ts
@@ -9,6 +9,8 @@ export interface GitContext {
   repo: string | null;
   // Azure DevOps Server-resolved fields
   ado: { collection: string; project: string; repo: string } | null;
+  // GitHub-resolved fields
+  github: { owner: string; repo: string } | null;
 }
 
 export function getRepoRoot(): string | null {
@@ -138,6 +140,56 @@ export function parseAdoRemote(
   return { collection, project, repo };
 }
 
+/**
+ * Parses a GitHub remote URL into { owner, repo }.
+ *
+ * Supported formats:
+ *   HTTPS : https://github.com/{owner}/{repo}[.git]
+ *           https://{githubHost}/{owner}/{repo}[.git]
+ *   SSH   : git@github.com:{owner}/{repo}[.git]
+ *           git@{githubHost}:{owner}/{repo}[.git]
+ *
+ * When baseUrl is provided (for GitHub Enterprise), only URLs matching that host are accepted.
+ * When baseUrl is undefined, only github.com URLs are matched.
+ */
+export function parseGitHubRemote(
+  remoteUrl: string,
+  baseUrl: string | undefined
+): { owner: string; repo: string } | null {
+  // Determine which host(s) to match
+  let targetHost: string;
+  if (baseUrl) {
+    try {
+      const normalizedBase = /^https?:\/\//i.test(baseUrl) ? baseUrl : `https://${baseUrl}`;
+      targetHost = new URL(normalizedBase).hostname.toLowerCase();
+    } catch {
+      targetHost = baseUrl.replace(/\/$/, '').replace(/^https?:\/\//i, '').split(/[:/]/)[0]!.toLowerCase();
+    }
+  } else {
+    targetHost = 'github.com';
+  }
+
+  // SSH format: git@{host}:{owner}/{repo}[.git]
+  const sshMatch = remoteUrl.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (sshMatch) {
+    const [, host, owner, repo] = sshMatch;
+    if (host!.toLowerCase() === targetHost) {
+      return { owner: owner!, repo: repo! };
+    }
+  }
+
+  // HTTPS format: https://{host}/{owner}/{repo}[.git]
+  const httpsMatch = remoteUrl.match(/^https?:\/\/([^/:]+)(?::\d+)?\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (httpsMatch) {
+    const [, host, owner, repo] = httpsMatch;
+    if (host!.toLowerCase() === targetHost) {
+      return { owner: owner!, repo: repo! };
+    }
+  }
+
+  return null;
+}
+
 function getRemoteUrls(repoRoot: string): string[] {
   try {
     const output = execSync('git remote -v', { encoding: 'utf8', cwd: repoRoot });
@@ -180,5 +232,15 @@ export function getGitContext(config: ResolvedConfig): GitContext | null {
     }
   }
 
-  return { root, branch, project, repo, ado: adoContext };
+  // GitHub: disambiguated by github.com host or configured baseUrl
+  let githubContext: GitContext['github'] = null;
+  for (const url of remoteUrls) {
+    const parsed = parseGitHubRemote(url, config.github.baseUrl);
+    if (parsed) {
+      githubContext = parsed;
+      break;
+    }
+  }
+
+  return { root, branch, project, repo, ado: adoContext, github: githubContext };
 }

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -8,6 +8,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     user: { email: undefined, userId: undefined },
     jira: { baseUrl: 'https://jira.example.com', apiToken: 'tok', customFields: [] },
     bitbucket: { baseUrl: 'https://bb.example.com', pat: 'tok' },
+    github: { baseUrl: 'https://api.github.com', token: 'tok' },
     confluence: { baseUrl: 'https://conf.example.com', apiToken: 'tok', apiTokenExplicit: true },
     artifactory: {},
     sonar: { baseUrl: 'https://sonar.example.com', token: 'tok' },
@@ -20,7 +21,7 @@ function baseConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     sonatypeiq: { baseUrl: undefined, userCode: undefined, passcode: undefined },
     openshift: { baseUrl: undefined, token: undefined },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
+    defaults: { jira: {}, bitbucket: {}, github: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} },
     ...overrides
   };
 }
@@ -34,6 +35,11 @@ describe('HttpClient — dry-run', () => {
   it('throws PncliError with status 0 on bitbucket dry-run', async () => {
     const client = new HttpClient(baseConfig(), true);
     await expect(client.bitbucket('/rest/api/1.0/projects')).rejects.toMatchObject({ status: 0 });
+  });
+
+  it('throws PncliError with status 0 on github dry-run', async () => {
+    const client = new HttpClient(baseConfig(), true);
+    await expect(client.github('/user')).rejects.toMatchObject({ status: 0 });
   });
 
   it('throws PncliError with status 0 on sonar dry-run', async () => {
@@ -74,6 +80,20 @@ describe('HttpClient — missing credentials', () => {
     config.bitbucket = { baseUrl: 'https://bb.example.com', pat: undefined };
     const client = new HttpClient(config);
     await expect(client.bitbucket('/rest/api/1.0/projects')).rejects.toMatchObject({ name: 'PncliError' });
+  });
+
+  it('throws on missing github baseUrl', async () => {
+    const config = baseConfig();
+    config.github = { baseUrl: undefined, token: 'tok' };
+    const client = new HttpClient(config);
+    await expect(client.github('/user')).rejects.toMatchObject({ name: 'PncliError' });
+  });
+
+  it('throws on missing github token', async () => {
+    const config = baseConfig();
+    config.github = { baseUrl: 'https://api.github.com', token: undefined };
+    const client = new HttpClient(config);
+    await expect(client.github('/user')).rejects.toMatchObject({ name: 'PncliError' });
   });
 
   it('throws on missing ado baseUrl', async () => {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -185,6 +185,18 @@ export class HttpClient {
     };
   }
 
+  private githubHeaders(): Record<string, string> {
+    const { token } = this.config.github;
+    if (!token) throw new PncliError('GitHub credentials not configured. Run: pncli config init');
+    return {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Connection': 'close'
+    };
+  }
+
   async jira<T>(
     path: string,
     opts: HttpRequestOptions = {}
@@ -303,6 +315,92 @@ export class HttpClient {
     }
 
     return request<T>(url, { method: 'POST', headers, body: formData }, opts.timeoutMs ?? 60000);
+  }
+
+  async github<T>(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<T> {
+    const baseUrl = this.config.github.baseUrl;
+    if (!baseUrl) throw new PncliError('GitHub baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+    const headers = this.githubHeaders();
+    const init: RequestInit = {
+      method: opts.method ?? 'GET',
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined
+    };
+
+    if (this.dryRun) {
+      const safeHeaders = { ...headers, Authorization: '[REDACTED]' };
+      const msg = `DRY RUN: ${init.method} ${url}\nHeaders: ${JSON.stringify(safeHeaders, null, 2)}\n`
+        + (opts.body ? `Body: ${JSON.stringify(opts.body, null, 2)}\n` : '');
+      fs.writeSync(process.stderr.fd, msg);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    return request<T>(url, init, opts.timeoutMs ?? 30000);
+  }
+
+  async githubText(
+    path: string,
+    opts: HttpRequestOptions = {}
+  ): Promise<string> {
+    const baseUrl = this.config.github.baseUrl;
+    if (!baseUrl) throw new PncliError('GitHub baseUrl not configured. Run: pncli config init');
+
+    const url = buildUrl(baseUrl, path, opts.params);
+    const token = this.config.github.token;
+    if (!token) throw new PncliError('GitHub credentials not configured. Run: pncli config init');
+
+    const headers: Record<string, string> = {
+      'Authorization': `Bearer ${token}`,
+      'Accept': 'application/vnd.github.v3.diff',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Connection': 'close'
+    };
+
+    if (this.dryRun) {
+      const safeHeaders = { ...headers, Authorization: '[REDACTED]' };
+      fs.writeSync(process.stderr.fd, `DRY RUN: ${opts.method ?? 'GET'} ${url}\nHeaders: ${JSON.stringify(safeHeaders, null, 2)}\n`);
+      process.exitCode = ExitCode.SUCCESS;
+      throw new PncliError('dry-run', 0);
+    }
+
+    const response = await fetchWithTimeout(url, {
+      method: opts.method ?? 'GET',
+      headers
+    }, opts.timeoutMs ?? 30000);
+
+    if (!response.ok) {
+      let message = `HTTP ${response.status} ${response.statusText}`;
+      try {
+        const parsed = JSON.parse(await response.text());
+        if (parsed.message) message = String(parsed.message);
+      } catch { /* ignore */ }
+      throw new PncliError(message, response.status, url);
+    }
+
+    return response.text();
+  }
+
+  async githubPaginate<T>(
+    fetchPage: (page: number, perPage: number) => Promise<T[]>
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const items = await fetchPage(page, perPage);
+      results.push(...items);
+      if (items.length < perPage) break;
+      page++;
+    }
+
+    return results;
   }
 
   async bitbucket<T>(

--- a/src/services/ado/client/build.test.ts
+++ b/src/services/ado/client/build.test.ts
@@ -8,6 +8,7 @@ function makeConfig(): ResolvedConfig {
     user: { email: undefined, userId: undefined },
     jira: { baseUrl: 'https://jira.example.com', apiToken: 'tok', customFields: [] },
     bitbucket: { baseUrl: 'https://bb.example.com', pat: 'tok' },
+    github: { baseUrl: undefined, token: undefined },
     confluence: { baseUrl: 'https://conf.example.com', apiToken: 'tok', apiTokenExplicit: true },
     artifactory: {},
     sonar: { baseUrl: 'https://sonar.example.com', token: 'tok' },
@@ -20,7 +21,7 @@ function makeConfig(): ResolvedConfig {
     contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     sonatypeiq: { baseUrl: undefined, userCode: undefined, passcode: undefined },
     openshift: { baseUrl: undefined, token: undefined },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
+    defaults: { jira: {}, bitbucket: {}, github: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
   };
 }
 

--- a/src/services/ado/client/work.test.ts
+++ b/src/services/ado/client/work.test.ts
@@ -11,6 +11,7 @@ function makeConfig(): ResolvedConfig {
     user: { email: undefined, userId: undefined },
     jira: { baseUrl: 'https://jira.example.com', apiToken: 'tok', customFields: [] },
     bitbucket: { baseUrl: 'https://bb.example.com', pat: 'tok' },
+    github: { baseUrl: undefined, token: undefined },
     confluence: { baseUrl: 'https://conf.example.com', apiToken: 'tok', apiTokenExplicit: true },
     artifactory: {},
     sonar: { baseUrl: 'https://sonar.example.com', token: 'tok' },
@@ -23,7 +24,7 @@ function makeConfig(): ResolvedConfig {
     contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     sonatypeiq: { baseUrl: undefined, userCode: undefined, passcode: undefined },
     openshift: { baseUrl: undefined, token: undefined },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
+    defaults: { jira: {}, bitbucket: {}, github: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
   };
 }
 

--- a/src/services/config/commands.ts
+++ b/src/services/config/commands.ts
@@ -117,6 +117,17 @@ export function registerConfigCommands(program: Command): void {
           results.bitbucket = { ok: null, message: 'not configured' };
         }
 
+        if (cfg.github.baseUrl) {
+          try {
+            await http.github<unknown>('/user');
+            results.github = { ok: true, message: 'connected' };
+          } catch (err) {
+            results.github = { ok: false, message: err instanceof Error ? err.message : String(err) };
+          }
+        } else {
+          results.github = { ok: null, message: 'not configured' };
+        }
+
         if (cfg.confluence.baseUrl) {
           try {
             await http.confluence<unknown>('/rest/api/space', { params: { limit: 1 } });
@@ -315,6 +326,20 @@ export function registerConfigCommands(program: Command): void {
           }
         }
 
+        // GitHub
+        if (!cfg.github.token) {
+          results.github = { status: 'blank', message: 'not configured' };
+        } else if (!cfg.github.baseUrl) {
+          results.github = { status: 'error', message: 'baseUrl not configured' };
+        } else {
+          try {
+            await http.github<unknown>('/user', { timeoutMs: 10_000 });
+            results.github = { status: 'valid', message: 'ok' };
+          } catch (err) {
+            results.github = categorize(err);
+          }
+        }
+
         // Confluence — distinguish explicit token from Jira fallback
         if (!cfg.confluence.apiTokenExplicit && !cfg.jira.apiToken) {
           results.confluence = { status: 'blank', message: 'not configured' };
@@ -496,7 +521,7 @@ export function registerConfigCommands(program: Command): void {
 
         if (cmdOpts.output === 'table') {
           // Human-readable table to stdout
-          const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx', 'servicenow', 'contrast', 'sonatypeiq', 'openshift'] as const;
+          const services = ['jira', 'bitbucket', 'github', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx', 'servicenow', 'contrast', 'sonatypeiq', 'openshift'] as const;
           const labelWidth = 14;
           const statusWidth = 9;
           for (const svc of services) {
@@ -514,7 +539,7 @@ export function registerConfigCommands(program: Command): void {
         } else {
           // Pretty table on stderr when --pretty is set (stdout stays JSON)
           if (opts.pretty) {
-            const services = ['jira', 'bitbucket', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx', 'servicenow', 'contrast', 'sonatypeiq', 'openshift'] as const;
+            const services = ['jira', 'bitbucket', 'github', 'confluence', 'sonar', 'sde', 'ado', 'jenkins', 'udeploy', 'artifactory', 'checkmarx', 'servicenow', 'contrast', 'sonatypeiq', 'openshift'] as const;
             const labelWidth = 14;
             const statusWidth = 9;
             for (const svc of services) {
@@ -577,6 +602,45 @@ async function initGlobalConfig(start: number): Promise<void> {
   const bitbucketPat = await password({
     message: 'Bitbucket personal access token:'
   });
+
+  process.stderr.write('\n── GitHub ────────────────────────────────────────\n');
+  const useGitHub = await confirm({
+    message: 'Configure GitHub for PR operations?',
+    default: false
+  });
+
+  let githubBaseUrl = '';
+  let githubToken = '';
+
+  if (useGitHub) {
+    githubBaseUrl = await input({
+      message: 'GitHub API base URL\n  GitHub.com: api.github.com\n  GitHub Enterprise: <host>/api/v3\n  URL: ',
+      default: ''
+    });
+
+    githubToken = await password({
+      message: 'GitHub personal access token (classic or fine-grained):'
+    });
+
+    if (githubBaseUrl && githubToken) {
+      process.stderr.write('\n  Verifying connection...\n');
+      try {
+        const tempConfig = {
+          ...loadConfig(),
+          github: {
+            baseUrl: normalizeBaseUrl(githubBaseUrl),
+            token: githubToken
+          }
+        };
+        const tempHttp = createHttpClient(tempConfig as Parameters<typeof createHttpClient>[0]);
+        await tempHttp.github<unknown>('/user');
+        process.stderr.write('  Connected.\n');
+      } catch (err) {
+        warn(`Could not connect to GitHub: ${err instanceof Error ? err.message : String(err)}`);
+        warn('Config will be saved anyway. Check your URL and token and re-run pncli config init or pncli config test.');
+      }
+    }
+  }
 
   process.stderr.write('\n── Confluence ────────────────────────────────────\n');
   const confluenceBaseUrl = await input({
@@ -1166,6 +1230,12 @@ async function initGlobalConfig(start: number): Promise<void> {
       baseUrl: normalizeBaseUrl(bitbucketBaseUrl) || undefined,
       pat: bitbucketPat || undefined
     },
+    ...(useGitHub && githubBaseUrl ? {
+      github: {
+        baseUrl: normalizeBaseUrl(githubBaseUrl),
+        token: githubToken || undefined
+      }
+    } : {}),
     ...(confluenceBaseUrl || confluenceApiToken ? {
       confluence: {
         baseUrl: normalizeBaseUrl(confluenceBaseUrl) || undefined,

--- a/src/services/github/client.ts
+++ b/src/services/github/client.ts
@@ -1,0 +1,250 @@
+import type { HttpClient } from '../../lib/http.js';
+import type {
+  GitHubPR,
+  GitHubComment,
+  GitHubReview,
+  GitHubFile,
+  GitHubCombinedStatus,
+  GitHubCheckRun
+} from '../../types/github.js';
+
+export interface ListPRsOpts {
+  owner: string;
+  repo: string;
+  state?: 'open' | 'closed' | 'all';
+  head?: string;
+  base?: string;
+}
+
+export interface CreatePROpts {
+  owner: string;
+  repo: string;
+  title: string;
+  head: string;
+  base: string;
+  body?: string;
+  draft?: boolean;
+}
+
+export interface UpdatePROpts {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  title?: string;
+  body?: string;
+  state?: 'open' | 'closed';
+  base?: string;
+}
+
+export interface MergePROpts {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  commitTitle?: string;
+  commitMessage?: string;
+  mergeMethod?: 'merge' | 'squash' | 'rebase';
+}
+
+export interface InlineCommentOpts {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  body: string;
+  commitId: string;
+  path: string;
+  line: number;
+  side?: 'LEFT' | 'RIGHT';
+}
+
+export interface SubmitReviewOpts {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+  body?: string;
+}
+
+export class GitHubClient {
+  constructor(private http: HttpClient) {}
+
+  async listPRs(opts: ListPRsOpts): Promise<GitHubPR[]> {
+    return this.http.githubPaginate((page, perPage) =>
+      this.http.github<GitHubPR[]>(
+        `/repos/${opts.owner}/${opts.repo}/pulls`,
+        {
+          params: {
+            state: opts.state ?? 'open',
+            ...(opts.head ? { head: opts.head } : {}),
+            ...(opts.base ? { base: opts.base } : {}),
+            per_page: perPage,
+            page
+          }
+        }
+      )
+    );
+  }
+
+  async getPR(owner: string, repo: string, pullNumber: number): Promise<GitHubPR> {
+    return this.http.github<GitHubPR>(`/repos/${owner}/${repo}/pulls/${pullNumber}`);
+  }
+
+  async createPR(opts: CreatePROpts): Promise<GitHubPR> {
+    return this.http.github<GitHubPR>(
+      `/repos/${opts.owner}/${opts.repo}/pulls`,
+      {
+        method: 'POST',
+        body: {
+          title: opts.title,
+          head: opts.head,
+          base: opts.base,
+          ...(opts.body !== undefined ? { body: opts.body } : {}),
+          ...(opts.draft !== undefined ? { draft: opts.draft } : {})
+        }
+      }
+    );
+  }
+
+  async updatePR(opts: UpdatePROpts): Promise<GitHubPR> {
+    const body: Record<string, unknown> = {};
+    if (opts.title !== undefined) body.title = opts.title;
+    if (opts.body !== undefined) body.body = opts.body;
+    if (opts.state !== undefined) body.state = opts.state;
+    if (opts.base !== undefined) body.base = opts.base;
+
+    return this.http.github<GitHubPR>(
+      `/repos/${opts.owner}/${opts.repo}/pulls/${opts.pullNumber}`,
+      { method: 'PATCH', body }
+    );
+  }
+
+  async mergePR(opts: MergePROpts): Promise<{ sha: string; merged: boolean; message: string }> {
+    const body: Record<string, unknown> = {};
+    if (opts.commitTitle) body.commit_title = opts.commitTitle;
+    if (opts.commitMessage) body.commit_message = opts.commitMessage;
+    if (opts.mergeMethod) body.merge_method = opts.mergeMethod;
+
+    return this.http.github<{ sha: string; merged: boolean; message: string }>(
+      `/repos/${opts.owner}/${opts.repo}/pulls/${opts.pullNumber}/merge`,
+      { method: 'PUT', body }
+    );
+  }
+
+  async closePR(owner: string, repo: string, pullNumber: number): Promise<GitHubPR> {
+    return this.updatePR({ owner, repo, pullNumber, state: 'closed' });
+  }
+
+  async listComments(owner: string, repo: string, pullNumber: number): Promise<GitHubComment[]> {
+    return this.http.githubPaginate((page, perPage) =>
+      this.http.github<GitHubComment[]>(
+        `/repos/${owner}/${repo}/issues/${pullNumber}/comments`,
+        { params: { per_page: perPage, page } }
+      )
+    );
+  }
+
+  async addComment(owner: string, repo: string, pullNumber: number, body: string): Promise<GitHubComment> {
+    return this.http.github<GitHubComment>(
+      `/repos/${owner}/${repo}/issues/${pullNumber}/comments`,
+      { method: 'POST', body: { body } }
+    );
+  }
+
+  async listReviewComments(owner: string, repo: string, pullNumber: number): Promise<GitHubComment[]> {
+    return this.http.githubPaginate((page, perPage) =>
+      this.http.github<GitHubComment[]>(
+        `/repos/${owner}/${repo}/pulls/${pullNumber}/comments`,
+        { params: { per_page: perPage, page } }
+      )
+    );
+  }
+
+  async addInlineComment(opts: InlineCommentOpts): Promise<GitHubComment> {
+    return this.http.github<GitHubComment>(
+      `/repos/${opts.owner}/${opts.repo}/pulls/${opts.pullNumber}/comments`,
+      {
+        method: 'POST',
+        body: {
+          body: opts.body,
+          commit_id: opts.commitId,
+          path: opts.path,
+          line: opts.line,
+          side: opts.side ?? 'RIGHT'
+        }
+      }
+    );
+  }
+
+  async replyComment(owner: string, repo: string, pullNumber: number, commentId: number, body: string): Promise<GitHubComment> {
+    return this.http.github<GitHubComment>(
+      `/repos/${owner}/${repo}/pulls/${pullNumber}/comments/${commentId}/replies`,
+      { method: 'POST', body: { body } }
+    );
+  }
+
+  async deleteComment(owner: string, repo: string, commentId: number): Promise<void> {
+    await this.http.github<void>(
+      `/repos/${owner}/${repo}/issues/comments/${commentId}`,
+      { method: 'DELETE' }
+    );
+  }
+
+  async deleteReviewComment(owner: string, repo: string, commentId: number): Promise<void> {
+    await this.http.github<void>(
+      `/repos/${owner}/${repo}/pulls/comments/${commentId}`,
+      { method: 'DELETE' }
+    );
+  }
+
+  async getDiff(owner: string, repo: string, pullNumber: number): Promise<string> {
+    return this.http.githubText(`/repos/${owner}/${repo}/pulls/${pullNumber}`);
+  }
+
+  async listFiles(owner: string, repo: string, pullNumber: number): Promise<GitHubFile[]> {
+    return this.http.githubPaginate((page, perPage) =>
+      this.http.github<GitHubFile[]>(
+        `/repos/${owner}/${repo}/pulls/${pullNumber}/files`,
+        { params: { per_page: perPage, page } }
+      )
+    );
+  }
+
+  async listReviews(owner: string, repo: string, pullNumber: number): Promise<GitHubReview[]> {
+    return this.http.githubPaginate((page, perPage) =>
+      this.http.github<GitHubReview[]>(
+        `/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`,
+        { params: { per_page: perPage, page } }
+      )
+    );
+  }
+
+  async submitReview(opts: SubmitReviewOpts): Promise<GitHubReview> {
+    return this.http.github<GitHubReview>(
+      `/repos/${opts.owner}/${opts.repo}/pulls/${opts.pullNumber}/reviews`,
+      {
+        method: 'POST',
+        body: {
+          event: opts.event,
+          ...(opts.body !== undefined ? { body: opts.body } : {})
+        }
+      }
+    );
+  }
+
+  async listRequestedReviewers(owner: string, repo: string, pullNumber: number): Promise<{ users: GitHubReview['user'][] }> {
+    return this.http.github<{ users: GitHubReview['user'][] }>(
+      `/repos/${owner}/${repo}/pulls/${pullNumber}/requested_reviewers`
+    );
+  }
+
+  async getCommitStatuses(owner: string, repo: string, ref: string): Promise<GitHubCombinedStatus> {
+    return this.http.github<GitHubCombinedStatus>(`/repos/${owner}/${repo}/commits/${ref}/status`);
+  }
+
+  async listCheckRuns(owner: string, repo: string, ref: string): Promise<GitHubCheckRun[]> {
+    const result = await this.http.github<{ check_runs: GitHubCheckRun[] }>(
+      `/repos/${owner}/${repo}/commits/${ref}/check-runs`,
+      { params: { per_page: 100 } }
+    );
+    return result.check_runs ?? [];
+  }
+}

--- a/src/services/github/commands.ts
+++ b/src/services/github/commands.ts
@@ -1,0 +1,375 @@
+import { Command } from 'commander';
+import { GitHubClient } from './client.js';
+import { createHttpClient } from '../../lib/http.js';
+import { loadConfig } from '../../lib/config.js';
+import { getGitContext } from '../../lib/git-context.js';
+import { success, fail } from '../../lib/output.js';
+import { PncliError } from '../../lib/errors.js';
+
+function getClient(
+  program: Command,
+  overrides?: { owner?: string; repo?: string }
+): { client: GitHubClient; owner: string; repo: string } {
+  const opts = program.optsWithGlobals();
+  const config = loadConfig({ configPath: opts.config });
+  const http = createHttpClient(config, Boolean(opts.dryRun));
+  const client = new GitHubClient(http);
+  const ctx = getGitContext(config);
+
+  const owner: string = overrides?.owner ?? opts.owner ?? ctx?.github?.owner ?? config.defaults.github?.owner ?? '';
+  const repo: string = overrides?.repo ?? opts.repo ?? ctx?.github?.repo ?? config.defaults.github?.repo ?? '';
+
+  if (!owner || !repo) {
+    throw new PncliError(
+      'Could not determine GitHub owner/repo. Pass --owner and --repo, or run pncli config init.',
+      1
+    );
+  }
+
+  return { client, owner, repo };
+}
+
+export function registerGitHubCommands(program: Command): void {
+  const gh = program
+    .command('github')
+    .description('GitHub repository operations')
+    .option('--owner <owner>', 'GitHub owner (user or org)')
+    .option('--repo <repo>', 'GitHub repository name');
+
+  // ── Pull Requests ──────────────────────────────────────────────────
+
+  gh.command('list-prs')
+    .description('List pull requests')
+    .option('--state <state>', 'PR state: open|closed|all', 'open')
+    .option('--head <branch>', 'Filter by head branch (user:branch)')
+    .option('--base <branch>', 'Filter by base branch')
+    .action(async (opts: { state?: string; head?: string; base?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.listPRs({
+          owner,
+          repo,
+          state: opts.state as 'open' | 'closed' | 'all',
+          head: opts.head,
+          base: opts.base
+        });
+        success(data, 'github', 'list-prs', start);
+      } catch (err) { fail(err, 'github', 'list-prs', start); }
+    });
+
+  gh.command('get-pr')
+    .description('Get a pull request by number')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.getPR(owner, repo, parseInt(opts.number, 10));
+        success(data, 'github', 'get-pr', start);
+      } catch (err) { fail(err, 'github', 'get-pr', start); }
+    });
+
+  gh.command('create-pr')
+    .description('Create a pull request')
+    .requiredOption('--title <title>', 'PR title')
+    .requiredOption('--head <branch>', 'Source branch (or user:branch for forks)')
+    .option('--base <branch>', 'Target branch (defaults to config or main)')
+    .option('--body <body>', 'PR description')
+    .option('--draft', 'Create as draft PR')
+    .option('--owner <owner>', 'GitHub owner (overrides parent --owner)')
+    .option('--repo <repo>', 'GitHub repository name (overrides parent --repo)')
+    .action(async (opts: { title: string; head: string; base?: string; body?: string; draft?: boolean; owner?: string; repo?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh, { owner: opts.owner, repo: opts.repo });
+        const config = loadConfig({ configPath: gh.optsWithGlobals().config });
+        const base = opts.base ?? config.defaults.github?.targetBranch ?? 'main';
+        const data = await client.createPR({
+          owner,
+          repo,
+          title: opts.title,
+          head: opts.head,
+          base,
+          body: opts.body,
+          draft: opts.draft
+        });
+        success(data, 'github', 'create-pr', start);
+      } catch (err) { fail(err, 'github', 'create-pr', start); }
+    });
+
+  gh.command('update-pr')
+    .description('Update a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .option('--title <title>', 'New title')
+    .option('--body <body>', 'New description')
+    .option('--base <branch>', 'New base branch')
+    .action(async (opts: { number: string; title?: string; body?: string; base?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.updatePR({
+          owner,
+          repo,
+          pullNumber: parseInt(opts.number, 10),
+          title: opts.title,
+          body: opts.body,
+          base: opts.base
+        });
+        success(data, 'github', 'update-pr', start);
+      } catch (err) { fail(err, 'github', 'update-pr', start); }
+    });
+
+  gh.command('merge-pr')
+    .description('Merge a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .option('--method <method>', 'Merge method: merge|squash|rebase', 'merge')
+    .option('--commit-title <title>', 'Commit title for merge/squash')
+    .option('--commit-message <msg>', 'Commit message for merge/squash')
+    .action(async (opts: { number: string; method?: string; commitTitle?: string; commitMessage?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.mergePR({
+          owner,
+          repo,
+          pullNumber: parseInt(opts.number, 10),
+          mergeMethod: opts.method as 'merge' | 'squash' | 'rebase',
+          commitTitle: opts.commitTitle,
+          commitMessage: opts.commitMessage
+        });
+        success(data, 'github', 'merge-pr', start);
+      } catch (err) { fail(err, 'github', 'merge-pr', start); }
+    });
+
+  gh.command('close-pr')
+    .description('Close a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.closePR(owner, repo, parseInt(opts.number, 10));
+        success(data, 'github', 'close-pr', start);
+      } catch (err) { fail(err, 'github', 'close-pr', start); }
+    });
+
+  // ── Comments ───────────────────────────────────────────────────────
+
+  gh.command('list-comments')
+    .description('List general comments on a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.listComments(owner, repo, parseInt(opts.number, 10));
+        success(data, 'github', 'list-comments', start);
+      } catch (err) { fail(err, 'github', 'list-comments', start); }
+    });
+
+  gh.command('add-comment')
+    .description('Add a general comment to a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .requiredOption('--body <text>', 'Comment text')
+    .action(async (opts: { number: string; body: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.addComment(owner, repo, parseInt(opts.number, 10), opts.body);
+        success(data, 'github', 'add-comment', start);
+      } catch (err) { fail(err, 'github', 'add-comment', start); }
+    });
+
+  gh.command('list-review-comments')
+    .description('List inline review comments on a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.listReviewComments(owner, repo, parseInt(opts.number, 10));
+        success(data, 'github', 'list-review-comments', start);
+      } catch (err) { fail(err, 'github', 'list-review-comments', start); }
+    });
+
+  gh.command('add-inline-comment')
+    .description('Add an inline review comment to a file in a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .requiredOption('--commit <sha>', 'Commit SHA the comment is on')
+    .requiredOption('--file <path>', 'File path')
+    .requiredOption('--line <n>', 'Line number')
+    .requiredOption('--body <text>', 'Comment text')
+    .option('--side <side>', 'Comment side: LEFT|RIGHT (default RIGHT)', 'RIGHT')
+    .action(async (opts: { number: string; commit: string; file: string; line: string; body: string; side?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.addInlineComment({
+          owner,
+          repo,
+          pullNumber: parseInt(opts.number, 10),
+          body: opts.body,
+          commitId: opts.commit,
+          path: opts.file,
+          line: parseInt(opts.line, 10),
+          side: opts.side as 'LEFT' | 'RIGHT'
+        });
+        success(data, 'github', 'add-inline-comment', start);
+      } catch (err) { fail(err, 'github', 'add-inline-comment', start); }
+    });
+
+  gh.command('reply-comment')
+    .description('Reply to a review comment on a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .requiredOption('--comment-id <id>', 'Review comment ID to reply to')
+    .requiredOption('--body <text>', 'Reply text')
+    .action(async (opts: { number: string; commentId: string; body: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.replyComment(owner, repo, parseInt(opts.number, 10), parseInt(opts.commentId, 10), opts.body);
+        success(data, 'github', 'reply-comment', start);
+      } catch (err) { fail(err, 'github', 'reply-comment', start); }
+    });
+
+  gh.command('delete-comment')
+    .description('Delete a general issue comment')
+    .requiredOption('--comment-id <id>', 'Comment ID')
+    .action(async (opts: { commentId: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        await client.deleteComment(owner, repo, parseInt(opts.commentId, 10));
+        success({ deleted: true }, 'github', 'delete-comment', start);
+      } catch (err) { fail(err, 'github', 'delete-comment', start); }
+    });
+
+  gh.command('delete-review-comment')
+    .description('Delete an inline review comment')
+    .requiredOption('--comment-id <id>', 'Review comment ID')
+    .action(async (opts: { commentId: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        await client.deleteReviewComment(owner, repo, parseInt(opts.commentId, 10));
+        success({ deleted: true }, 'github', 'delete-review-comment', start);
+      } catch (err) { fail(err, 'github', 'delete-review-comment', start); }
+    });
+
+  // ── Diff / Files ───────────────────────────────────────────────────
+
+  gh.command('diff')
+    .description('Get unified diff for a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const diff = await client.getDiff(owner, repo, parseInt(opts.number, 10));
+        success({ diff }, 'github', 'diff', start);
+      } catch (err) { fail(err, 'github', 'diff', start); }
+    });
+
+  gh.command('list-files')
+    .description('List files changed in a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.listFiles(owner, repo, parseInt(opts.number, 10));
+        success(data, 'github', 'list-files', start);
+      } catch (err) { fail(err, 'github', 'list-files', start); }
+    });
+
+  // ── Reviews ────────────────────────────────────────────────────────
+
+  gh.command('list-reviews')
+    .description('List reviews on a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.listReviews(owner, repo, parseInt(opts.number, 10));
+        success(data, 'github', 'list-reviews', start);
+      } catch (err) { fail(err, 'github', 'list-reviews', start); }
+    });
+
+  gh.command('approve')
+    .description('Approve a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .option('--body <text>', 'Review body text')
+    .action(async (opts: { number: string; body?: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.submitReview({
+          owner,
+          repo,
+          pullNumber: parseInt(opts.number, 10),
+          event: 'APPROVE',
+          body: opts.body
+        });
+        success(data, 'github', 'approve', start);
+      } catch (err) { fail(err, 'github', 'approve', start); }
+    });
+
+  gh.command('request-changes')
+    .description('Request changes on a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .requiredOption('--body <text>', 'Review feedback text')
+    .action(async (opts: { number: string; body: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.submitReview({
+          owner,
+          repo,
+          pullNumber: parseInt(opts.number, 10),
+          event: 'REQUEST_CHANGES',
+          body: opts.body
+        });
+        success(data, 'github', 'request-changes', start);
+      } catch (err) { fail(err, 'github', 'request-changes', start); }
+    });
+
+  gh.command('list-reviewers')
+    .description('List requested reviewers for a pull request')
+    .requiredOption('--number <n>', 'Pull request number')
+    .action(async (opts: { number: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.listRequestedReviewers(owner, repo, parseInt(opts.number, 10));
+        success(data, 'github', 'list-reviewers', start);
+      } catch (err) { fail(err, 'github', 'list-reviewers', start); }
+    });
+
+  // ── Status & Checks ────────────────────────────────────────────────
+
+  gh.command('get-status')
+    .description('Get combined commit status for a ref (branch, tag, or SHA)')
+    .requiredOption('--ref <ref>', 'Git ref (branch, tag, or commit SHA)')
+    .action(async (opts: { ref: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.getCommitStatuses(owner, repo, opts.ref);
+        success(data, 'github', 'get-status', start);
+      } catch (err) { fail(err, 'github', 'get-status', start); }
+    });
+
+  gh.command('list-checks')
+    .description('List check runs for a ref (branch, tag, or SHA)')
+    .requiredOption('--ref <ref>', 'Git ref (branch, tag, or commit SHA)')
+    .action(async (opts: { ref: string }) => {
+      const start = Date.now();
+      try {
+        const { client, owner, repo } = getClient(gh);
+        const data = await client.listCheckRuns(owner, repo, opts.ref);
+        success(data, 'github', 'list-checks', start);
+      } catch (err) { fail(err, 'github', 'list-checks', start); }
+    });
+}

--- a/src/services/jira/client.test.ts
+++ b/src/services/jira/client.test.ts
@@ -8,6 +8,7 @@ function makeConfig(): ResolvedConfig {
     user: { email: undefined, userId: undefined },
     jira: { baseUrl: 'https://jira.example.com', apiToken: 'tok', customFields: [] },
     bitbucket: { baseUrl: 'https://bb.example.com', pat: 'tok' },
+    github: { baseUrl: undefined, token: undefined },
     confluence: { baseUrl: 'https://conf.example.com', apiToken: 'tok', apiTokenExplicit: true },
     artifactory: {},
     sonar: { baseUrl: 'https://sonar.example.com', token: 'tok' },
@@ -20,7 +21,7 @@ function makeConfig(): ResolvedConfig {
     contrast: { baseUrl: undefined, orgUuid: undefined, apiKey: undefined, serviceKey: undefined, username: undefined },
     sonatypeiq: { baseUrl: undefined, userCode: undefined, passcode: undefined },
     openshift: { baseUrl: undefined, token: undefined },
-    defaults: { jira: {}, bitbucket: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
+    defaults: { jira: {}, bitbucket: {}, github: {}, sonar: {}, sde: {}, ado: {}, udeploy: {} }
   };
 }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -34,6 +34,11 @@ export interface BitbucketConfig {
   pat?: string;
 }
 
+export interface GitHubConfig {
+  baseUrl?: string;
+  token?: string;
+}
+
 export interface ConfluenceConfig {
   baseUrl?: string;
   apiToken?: string;
@@ -48,6 +53,12 @@ export interface JiraDefaults {
 export interface BitbucketDefaults {
   project?: string | null;
   repo?: string | null;
+  targetBranch?: string;
+}
+
+export interface GitHubDefaults {
+  owner?: string;
+  repo?: string;
   targetBranch?: string;
 }
 
@@ -138,6 +149,7 @@ export interface UdeployDefaults {
 export interface Defaults {
   jira?: JiraDefaults;
   bitbucket?: BitbucketDefaults;
+  github?: GitHubDefaults;
   sonar?: SonarDefaults;
   sde?: SdeDefaults;
   ado?: AdoDefaults;
@@ -153,6 +165,7 @@ export interface GlobalConfig {
   user?: UserConfig;
   jira?: JiraConfig;
   bitbucket?: BitbucketConfig;
+  github?: GitHubConfig;
   confluence?: ConfluenceConfig;
   artifactory?: ArtifactoryConfig;
   sonar?: SonarConfig;
@@ -187,6 +200,10 @@ export interface ResolvedConfig {
   bitbucket: {
     baseUrl: string | undefined;
     pat: string | undefined;
+  };
+  github: {
+    baseUrl: string | undefined;
+    token: string | undefined;
   };
   confluence: {
     baseUrl: string | undefined;
@@ -251,6 +268,7 @@ export interface ResolvedConfig {
   defaults: {
     jira: JiraDefaults;
     bitbucket: BitbucketDefaults;
+    github: GitHubDefaults;
     sonar: SonarDefaults;
     sde: SdeDefaults;
     ado: AdoDefaults;

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,118 @@
+// GitHub REST API types
+
+export interface GitHubUser {
+  login: string;
+  id: number;
+  name?: string;
+  email?: string;
+  avatar_url?: string;
+}
+
+export interface GitHubLabel {
+  id: number;
+  name: string;
+  color: string;
+  description?: string;
+}
+
+export interface GitHubRef {
+  label: string;
+  ref: string;
+  sha: string;
+  repo: {
+    name: string;
+    full_name: string;
+    html_url: string;
+  };
+}
+
+export interface GitHubPR {
+  number: number;
+  title: string;
+  body?: string;
+  state: 'open' | 'closed';
+  merged: boolean;
+  draft: boolean;
+  html_url: string;
+  user: GitHubUser;
+  head: GitHubRef;
+  base: GitHubRef;
+  labels: GitHubLabel[];
+  requested_reviewers: GitHubUser[];
+  assignees: GitHubUser[];
+  created_at: string;
+  updated_at: string;
+  merged_at?: string;
+  closed_at?: string;
+  merge_commit_sha?: string;
+  commits: number;
+  additions: number;
+  deletions: number;
+  changed_files: number;
+}
+
+export interface GitHubComment {
+  id: number;
+  body: string;
+  user: GitHubUser;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+  /** pull_request_review_id is present on review (inline) comments */
+  pull_request_review_id?: number;
+  /** path is present on inline review comments */
+  path?: string;
+  /** line is present on inline review comments */
+  line?: number;
+  /** side is present on inline review comments */
+  side?: 'LEFT' | 'RIGHT';
+  /** in_reply_to_id is present when this is a reply to another comment */
+  in_reply_to_id?: number;
+}
+
+export interface GitHubReview {
+  id: number;
+  user: GitHubUser;
+  body?: string;
+  state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'DISMISSED' | 'PENDING';
+  submitted_at?: string;
+  html_url: string;
+  commit_id: string;
+}
+
+export interface GitHubFile {
+  sha: string;
+  filename: string;
+  status: 'added' | 'removed' | 'modified' | 'renamed' | 'copied' | 'changed' | 'unchanged';
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch?: string;
+}
+
+export interface GitHubCommitStatus {
+  state: 'error' | 'failure' | 'pending' | 'success';
+  context: string;
+  description?: string;
+  target_url?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GitHubCombinedStatus {
+  state: 'error' | 'failure' | 'pending' | 'success';
+  sha: string;
+  total_count: number;
+  statuses: GitHubCommitStatus[];
+}
+
+export interface GitHubCheckRun {
+  id: number;
+  name: string;
+  status: 'queued' | 'in_progress' | 'completed';
+  conclusion?: 'success' | 'failure' | 'neutral' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | null;
+  html_url: string;
+  started_at?: string;
+  completed_at?: string;
+  app?: { name: string };
+}


### PR DESCRIPTION
Implements `pncli github` with PR lifecycle operations, review management, comment operations, diff, file listing, and commit status/check-run queries. Supports both github.com and GitHub Enterprise Server.

Closes #228

Generated with [Claude Code](https://claude.ai/code)