### PR TITLE
fix(functions): send close-reason email when GitHub issues are resolved

### DIFF
--- a/functions/feedback/IssueWebhookFunction.cs
+++ b/functions/feedback/IssueWebhookFunction.cs
@@ -7,6 +7,7 @@ using Feedback.Services;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Octokit;
 
 namespace Feedback;
 
@@ -18,6 +19,7 @@ namespace Feedback;
 public class IssueWebhookFunction(
     ILogger<IssueWebhookFunction> logger,
     IssueEmailStore issueEmailStore,
+    GitHubClient github,
     EmailService? emailService = null)
 {
     [Function("IssueWebhook")]
@@ -88,18 +90,42 @@ public class IssueWebhookFunction(
             return req.CreateResponse(HttpStatusCode.OK);
         }
 
-        // ── Send closed notification ──────────────────────────────────────────
-        if (emailService is not null)
+        // ── Fetch last comment as closing context ─────────────────────────────
+        string? closingComment = null;
+        try
         {
-            await emailService.SendClosedNotificationAsync(
-                mapping.Email,
-                payload.Issue.Number,
-                payload.Issue.HtmlUrl,
-                mapping.Title);
+            var repoStr = Environment.GetEnvironmentVariable("GITHUB_REPO") ?? "kolatts/pncli";
+            var parts   = repoStr.Split('/');
+            if (parts.Length == 2)
+            {
+                var comments = await github.Issue.Comment.GetAllForIssue(parts[0], parts[1], payload.Issue.Number);
+                closingComment = comments.LastOrDefault()?.Body;
+            }
         }
-        else
+        catch (Exception ex)
         {
-            logger.LogWarning("EmailService not configured — cannot send closed notification for issue #{Number}", payload.Issue.Number);
+            logger.LogWarning(ex, "Could not fetch closing comment for issue #{Number}", payload.Issue.Number);
+        }
+
+        // ── Send closed notification ──────────────────────────────────────────
+        if (emailService is null)
+        {
+            logger.LogError("EmailService not configured — cannot send closed notification for issue #{Number}", payload.Issue.Number);
+            return req.CreateResponse(HttpStatusCode.InternalServerError);
+        }
+
+        var sent = await emailService.SendClosedNotificationAsync(
+            mapping.Email,
+            payload.Issue.Number,
+            payload.Issue.HtmlUrl,
+            mapping.Title,
+            payload.Issue.StateReason,
+            closingComment);
+
+        if (!sent)
+        {
+            logger.LogError("Failed to send closed notification for issue #{Number} — returning 500 for GitHub retry", payload.Issue.Number);
+            return req.CreateResponse(HttpStatusCode.InternalServerError);
         }
 
         return req.CreateResponse(HttpStatusCode.OK);

--- a/functions/feedback/Models/GitHubWebhookPayload.cs
+++ b/functions/feedback/Models/GitHubWebhookPayload.cs
@@ -24,6 +24,10 @@ public record GitHubWebhookIssue
 
     [JsonPropertyName("labels")]
     public List<GitHubWebhookLabel> Labels { get; init; } = [];
+
+    /// <summary>"completed", "not_planned", or null for legacy closes.</summary>
+    [JsonPropertyName("state_reason")]
+    public string? StateReason { get; init; }
 }
 
 public record GitHubWebhookLabel

--- a/functions/feedback/Services/EmailService.cs
+++ b/functions/feedback/Services/EmailService.cs
@@ -44,21 +44,45 @@ public sealed class EmailService
                 "Confirmation email sent to {Email} for issue #{Number}", toEmail, issueNumber));
     }
 
-    public async Task<bool> SendClosedNotificationAsync(string toEmail, int issueNumber, string issueUrl, string title)
+    public async Task<bool> SendClosedNotificationAsync(
+        string toEmail, int issueNumber, string issueUrl, string title,
+        string? stateReason = null, string? closingComment = null)
     {
         var encodedTitle = WebUtility.HtmlEncode(title);
-        var subject      = $"Your feedback has been resolved — Issue #{issueNumber}";
+
+        var (heading, subject, blurb) = stateReason switch
+        {
+            "completed"   => ("Your feedback has been resolved!",
+                              $"Your feedback has been resolved — Issue #{issueNumber}",
+                              "We've addressed it."),
+            "not_planned" => ("A decision has been made on your feedback",
+                              $"Update on your feedback — Issue #{issueNumber}",
+                              "This issue was closed as not planned. See the issue for details."),
+            _             => ("Your issue has been closed",
+                              $"Your feedback has been closed — Issue #{issueNumber}",
+                              "This issue has been closed."),
+        };
+
+        var commentHtml = closingComment is not null
+            ? EmailTemplates.Quote(WebUtility.HtmlEncode(TruncateComment(closingComment)))
+            : "";
+
+        var commentPlain = closingComment is not null
+            ? $"\n\nNote from the team:\n{TruncateComment(closingComment)}"
+            : "";
 
         var bodyHtml =
-            EmailTemplates.Heading("Your issue has been resolved!") +
-            EmailTemplates.Para($"<strong>{encodedTitle}</strong> ({EmailTemplates.IssueLink(issueNumber, issueUrl)}) has been closed.") +
+            EmailTemplates.Heading(heading) +
+            EmailTemplates.Para($"<strong>{encodedTitle}</strong> ({EmailTemplates.IssueLink(issueNumber, issueUrl)}) — {blurb}") +
+            commentHtml +
             EmailTemplates.Para("Thanks for helping improve pncli!") +
             EmailTemplates.Button(issueUrl, "View Resolution →");
 
         var plain = $"""
-            Your issue has been resolved!
+            {heading}
 
-            "{title}" (issue #{issueNumber}) has been closed.
+            "{title}" (issue #{issueNumber}) — {blurb}{commentPlain}
+
             See the details here: {issueUrl}
 
             Thanks for helping improve pncli!
@@ -70,6 +94,9 @@ public sealed class EmailService
             onSuccess: () => _logger.LogInformation(
                 "Closed notification sent to {Email} for issue #{Number}", toEmail, issueNumber));
     }
+
+    private static string TruncateComment(string text, int maxLength = 500) =>
+        text.Length <= maxLength ? text : text[..maxLength] + "…";
 
     private async Task<bool> SendAsync(string toEmail, string subject, string plain, string html, Action onSuccess)
     {

--- a/functions/feedback/Services/EmailTemplates.cs
+++ b/functions/feedback/Services/EmailTemplates.cs
@@ -83,6 +83,10 @@ internal static class EmailTemplates
     public static string IssueLink(int number, string url) =>
         $"""<a href="{url}" style="color:{Violet};text-decoration:none;font-family:'JetBrains Mono',Menlo,Monaco,'Courier New',monospace;font-size:14px">#{number}</a>""";
 
+    /// <param name="text">Must be HTML-encoded by the caller.</param>
+    public static string Quote(string text) =>
+        $"""<blockquote style="margin:0 0 16px 0;padding:12px 16px;background-color:{OuterBg};border-left:4px solid {Violet};border-radius:0 4px 4px 0"><p style="margin:0;font-size:14px;line-height:1.6;color:{Ink};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;white-space:pre-wrap">{text}</p></blockquote>""";
+
     public static string Button(string url, string label) => $"""
         <table cellpadding="0" cellspacing="0" border="0" style="margin:8px 0 24px">
           <tr>


### PR DESCRIPTION
## Summary

- Return HTTP 500 (not 200) when ACS email send fails — GitHub was treating every delivery as successful and never retrying, so notifications were silently lost
- Return 500 (and log error) when `EmailService` is absent due to missing `ACS_CONNECTION_STRING`, surfacing misconfiguration on the first webhook instead of swallowing it
- Add `state_reason` to `GitHubWebhookPayload` — GitHub has sent `"completed"` / `"not_planned"` since Feb 2022; we were ignoring it
- Inject `GitHubClient` into `IssueWebhookFunction` and fetch the last comment on close to include as context in the notification email
- Vary subject line, heading, and body copy based on close reason; include closing comment as a styled quote block (truncated at 500 chars)
- Add `EmailTemplates.Quote()` helper (caller must HTML-encode input — documented on the method)

## Pre-PR gate

- ✅ Build: passed (`npm run build` + `dotnet build`)
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: approved (Major concern resolved — PartitionKey default confirmed correct in `IssueEmailEntity`; Minor fixed — `emailService null` now returns 500)
- ✅ Tests: 295 passed (no C# tests — pre-existing gap)
- ✅ Docs: no changes needed (`GITHUB_REPO` already set in `provision.sh`)

Closes #233