### PR TITLE
feat(site): add Beyond Boring Discord link to footer and feedback page

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -10,6 +10,7 @@
     <nav class="flex flex-wrap gap-x-6 gap-y-2 text-sm text-ink/50" aria-label="Footer navigation">
       <a href="https://github.com/kolatts/pncli" class="hover:text-ink transition-colors">GitHub</a>
       <a href="https://www.npmjs.com/package/@kolatts/pncli" class="hover:text-ink transition-colors">npm</a>
+      <a href="https://discord.gg/RKwEvAbtbx" target="_blank" rel="noopener noreferrer" class="hover:text-ink transition-colors">Discord</a>
       <a href="/pncli/changelog/" class="hover:text-ink transition-colors">Changelog</a>
       <a href="/pncli/feedback/" class="hover:text-ink transition-colors">Feedback</a>
     </nav>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -25,8 +25,8 @@ const skills = defineCollection({
   schema: z.object({
     title:       z.string(),
     description: z.string(),
-    providers:   z.enum(['both', 'bitbucket', 'ado', 'none']).optional(),
-    category:    z.enum(['setup', 'pr-workflow', 'security', 'planning', 'code-quality', 'other']).optional(),
+    providers:   z.enum(['both', 'bitbucket', 'ado', 'none', 'kubernetes']).optional(),
+    category:    z.enum(['setup', 'pr-workflow', 'security', 'planning', 'code-quality', 'other', 'infrastructure']).optional(),
     services:      z.string().optional(),
     userInvocable:  z.boolean().optional(),
     distributable:  z.boolean().optional(),

--- a/site/src/pages/feedback.astro
+++ b/site/src/pages/feedback.astro
@@ -64,7 +64,7 @@ import FeatureForm from '../components/FeatureForm.astro';
             </a>
           </div>
 
-          <div class="rounded-2xl border border-violet/20 bg-violet/5 p-6">
+          <div class="rounded-2xl border border-coral/20 bg-coral/5 p-6">
             <h2 class="font-display text-lg font-bold text-ink mb-2">
               Join the community
             </h2>
@@ -75,7 +75,7 @@ import FeatureForm from '../components/FeatureForm.astro';
               href="https://discord.gg/RKwEvAbtbx"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-center gap-2 border border-violet/30 text-violet font-semibold text-sm px-4 py-2.5 rounded-lg hover:bg-violet/10 transition-colors"
+              class="inline-flex items-center gap-2 border border-coral/30 text-coral font-semibold text-sm px-4 py-2.5 rounded-lg hover:bg-coral/10 transition-colors"
             >
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4 shrink-0" aria-hidden="true">
                 <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>

--- a/site/src/pages/feedback.astro
+++ b/site/src/pages/feedback.astro
@@ -63,6 +63,26 @@ import FeatureForm from '../components/FeatureForm.astro';
               Browse open issues →
             </a>
           </div>
+
+          <div class="rounded-2xl border border-violet/20 bg-violet/5 p-6">
+            <h2 class="font-display text-lg font-bold text-ink mb-2">
+              Join the community
+            </h2>
+            <p class="text-sm text-ink/60 leading-relaxed mb-4">
+              Chat with other pncli users, share workflows, and ask questions in the Beyond Boring Discord.
+            </p>
+            <a
+              href="https://discord.gg/RKwEvAbtbx"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-2 border border-violet/30 text-violet font-semibold text-sm px-4 py-2.5 rounded-lg hover:bg-violet/10 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4 shrink-0" aria-hidden="true">
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>
+              </svg>
+              Join Beyond Boring →
+            </a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add Discord link (discord.gg/RKwEvAbtbx) to footer nav alongside GitHub and npm
- Add "Join the community" card to the feedback page sidebar with Discord branding and icon
- Also fixes a pre-existing `InvalidContentEntryDataError` on `openshift-health` skill by extending the content schema with `kubernetes`/`infrastructure` enum values

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: approved (color rhythm fixed — Discord card uses coral to match alternating violet→coral pattern)
- ✅ Tests: 295 passed
- ✅ Docs: no changes needed

> **Note:** Screenshots not included — Docker MCP browser tool was unavailable in this session. Dev server started successfully on port 4323.

Closes #234