### PR TITLE
feat(ci): Discord notifications for issues and NPM releases

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,43 @@
+name: Discord Notifications
+
+on:
+  issues:
+    types: [opened, closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord (issue opened)
+        if: github.event.action == 'opened'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          NUMBER: ${{ github.event.issue.number }}
+          TITLE: ${{ github.event.issue.title }}
+          URL: ${{ github.event.issue.html_url }}
+          USER: ${{ github.event.issue.user.login }}
+        run: |
+          jq -n \
+            --arg title "Issue #${NUMBER} opened: ${TITLE}" \
+            --arg url "$URL" \
+            --arg desc "Opened by [@${USER}](https://github.com/${USER})" \
+            --argjson color 5793266 \
+            '{"embeds":[{"title":$title,"url":$url,"description":$desc,"color":$color}]}' \
+          | curl -sf -X POST "$DISCORD_WEBHOOK" -H "Content-Type: application/json" -d @-
+
+      - name: Notify Discord (issue closed)
+        if: github.event.action == 'closed'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          NUMBER: ${{ github.event.issue.number }}
+          TITLE: ${{ github.event.issue.title }}
+          URL: ${{ github.event.issue.html_url }}
+          USER: ${{ github.event.issue.user.login }}
+        run: |
+          jq -n \
+            --arg title "Issue #${NUMBER} closed: ${TITLE}" \
+            --arg url "$URL" \
+            --arg desc "Closed by [@${USER}](https://github.com/${USER})" \
+            --argjson color 3066993 \
+            '{"embeds":[{"title":$title,"url":$url,"description":$desc,"color":$color}]}' \
+          | curl -sf -X POST "$DISCORD_WEBHOOK" -H "Content-Type: application/json" -d @-

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -8,36 +8,29 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Discord (issue opened)
-        if: github.event.action == 'opened'
+      - name: Notify Discord
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          ACTION: ${{ github.event.action }}
           NUMBER: ${{ github.event.issue.number }}
           TITLE: ${{ github.event.issue.title }}
           URL: ${{ github.event.issue.html_url }}
-          USER: ${{ github.event.issue.user.login }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && echo "DISCORD_WEBHOOK not set, skipping" && exit 0
+          if [[ "$ACTION" == "opened" ]]; then
+            VERB="Opened"
+            COLOR=5793266
+          elif [[ "$ACTION" == "closed" ]]; then
+            VERB="Closed"
+            COLOR=3066993
+          else
+            exit 0
+          fi
           jq -n \
-            --arg title "Issue #${NUMBER} opened: ${TITLE}" \
+            --arg title "Issue #${NUMBER} ${ACTION}: ${TITLE}" \
             --arg url "$URL" \
-            --arg desc "Opened by [@${USER}](https://github.com/${USER})" \
-            --argjson color 5793266 \
-            '{"embeds":[{"title":$title,"url":$url,"description":$desc,"color":$color}]}' \
-          | curl -sf -X POST "$DISCORD_WEBHOOK" -H "Content-Type: application/json" -d @-
-
-      - name: Notify Discord (issue closed)
-        if: github.event.action == 'closed'
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          NUMBER: ${{ github.event.issue.number }}
-          TITLE: ${{ github.event.issue.title }}
-          URL: ${{ github.event.issue.html_url }}
-          USER: ${{ github.event.issue.user.login }}
-        run: |
-          jq -n \
-            --arg title "Issue #${NUMBER} closed: ${TITLE}" \
-            --arg url "$URL" \
-            --arg desc "Closed by [@${USER}](https://github.com/${USER})" \
-            --argjson color 3066993 \
+            --arg desc "${VERB} by [@${ISSUE_USER}](https://github.com/${ISSUE_USER})" \
+            --argjson color $COLOR \
             '{"embeds":[{"title":$title,"url":$url,"description":$desc,"color":$color}]}' \
           | curl -sf -X POST "$DISCORD_WEBHOOK" -H "Content-Type: application/json" -d @-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,11 +52,14 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Notify Discord
+        if: needs.release-please.outputs.release_created == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
         run: |
+          [[ -z "$DISCORD_WEBHOOK" ]] && echo "DISCORD_WEBHOOK not set, skipping" && exit 0
           VERSION=$(node -p "require('./package.json').version")
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
           NPM_URL="https://www.npmjs.com/package/@kolatts/pncli/v/${VERSION}"
           jq -n \
             --arg title "@kolatts/pncli v${VERSION} published" \
@@ -64,4 +67,5 @@ jobs:
             --arg desc "[Release notes](${RELEASE_URL}) · [npm](${NPM_URL})" \
             --argjson color 16750848 \
             '{"embeds":[{"title":$title,"url":$url,"description":$desc,"color":$color}]}' \
-          | curl -sf -X POST "$DISCORD_WEBHOOK" -H "Content-Type: application/json" -d @-
+          | curl -sf -X POST "$DISCORD_WEBHOOK" -H "Content-Type: application/json" -d @- \
+          || echo "Discord notify failed (non-fatal)"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,3 +50,18 @@ jobs:
       - run: npm publish --access=public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
+          NPM_URL="https://www.npmjs.com/package/@kolatts/pncli/v/${VERSION}"
+          jq -n \
+            --arg title "@kolatts/pncli v${VERSION} published" \
+            --arg url "$RELEASE_URL" \
+            --arg desc "[Release notes](${RELEASE_URL}) · [npm](${NPM_URL})" \
+            --argjson color 16750848 \
+            '{"embeds":[{"title":$title,"url":$url,"description":$desc,"color":$color}]}' \
+          | curl -sf -X POST "$DISCORD_WEBHOOK" -H "Content-Type: application/json" -d @-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ When working on pncli, always use the repo-internal `/ship`.
 Always use `kolatts/<description>` or `kolatts/<issue#>-<description>`.
 - Example: `kolatts/add-ship-skill` or `kolatts/75-add-ship-skill`
 
+## GitHub Issues
+
+Every new branch that represents a work request must have a corresponding GitHub issue. Create the issue before or immediately after creating the branch. Use the issue number in the branch name where possible (`kolatts/<issue#>-<description>`).
+
 ## Adding a New Service Integration
 
 When adding a new service integration (new entry under `src/services/`), these files must all be updated together:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Always use `kolatts/<description>` or `kolatts/<issue#>-<description>`.
 
 ## GitHub Issues
 
-Every new branch that represents a work request must have a corresponding GitHub issue. Create the issue before or immediately after creating the branch. Use the issue number in the branch name where possible (`kolatts/<issue#>-<description>`).
+Every new branch that represents a work request must have a corresponding GitHub issue. Create the issue before or immediately after creating the branch. Always include the issue number in the branch name (`kolatts/<issue#>-<description>`).
 
 ## Adding a New Service Integration
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/discord-notify.yml` — posts to Discord on issue opened/closed
- Add Discord notify step to `release-please.yml` publish job — fires after npm publish on real releases only
- Require GitHub issues for every work branch in CLAUDE.md

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: approved (minors fixed — webhook guard, non-fatal curl, env var scoping, single consolidated step)
- ✅ Tests: 295 passed
- ✅ Docs: no changes needed

Closes #237