### PR TITLE
feat(skills): support multiple marketplaces with seamless sync and CRUD

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1099,7 +1099,17 @@ pncli skills list
   --scope <scope>  Installation scope: project | user (default: "project")
   --target <dir>   Override skills directory to scan
 
-pncli skills marketplace setup
+pncli skills uninstall
+  --agent <agent>  Target agent host: github-copilot | claude-code (default:
+  "github-copilot")
+  --scope <scope>  Installation scope to uninstall from: project | user
+  (default: "user")
+  --claude         Shorthand for --agent claude-code
+  --target <dir>   Override skills directory
+
+pncli skills marketplace add
+  --name <name>      Human-readable name for this marketplace (default: derived
+  from URL)
   --branch <branch>  Branch to clone (default: remote HEAD)
   --token <token>    HTTP access token for authenticated clone and pull (GitHub
   PAT or Bitbucket token)
@@ -1107,12 +1117,30 @@ pncli skills marketplace setup
   claude-code (default: github-copilot)
   --claude           Shorthand for --agent claude-code
 
+pncli skills marketplace setup
+  --name <name>      Human-readable name for this marketplace (default: derived
+  from URL)
+  --branch <branch>  Branch to clone (default: remote HEAD)
+  --token <token>    HTTP access token for authenticated clone and pull (GitHub
+  PAT or Bitbucket token)
+  --agent <agent>    Target agent host for plugin install: github-copilot |
+  claude-code (default: github-copilot)
+  --claude           Shorthand for --agent claude-code
+
+pncli skills marketplace list
+
+pncli skills marketplace plugins
+
+pncli skills marketplace remove
+
 pncli skills marketplace sync
-  --agent <agent>  Target agent host: github-copilot | claude-code (default:
-  github-copilot)
-  --claude         Shorthand for --agent claude-code
-  --force          Force reinstall even if the marketplace repo has no new
-  changes
+  --marketplace <name>  Marketplace name to sync, or "all" to sync every
+  registered marketplace (skips interactive selection)
+  --agent <agent>       Target agent host: github-copilot | claude-code
+  (default: github-copilot)
+  --claude              Shorthand for --agent claude-code
+  --force               Reinstall even if a marketplace has no new changes
+  (applies to single-plugin and "all" installs alike)
 ```
 
 ### Jwt

--- a/skills/pncli/marketplace.md
+++ b/skills/pncli/marketplace.md
@@ -1,21 +1,34 @@
 # Skills Marketplace
 
-Enables installing org-internal Claude Code or GitHub Copilot skills from a private git-hosted marketplace repository.
+Enables installing org-internal Claude Code or GitHub Copilot skills from one or more private git-hosted marketplace repositories.
 
-## Setup
+## Add a marketplace
 
 ```
-pncli skills marketplace setup <git-clone-url> <local-path>
+pncli skills marketplace add <git-clone-url> [local-path]
 ```
 
-Use `--branch main` if the default branch is `main` instead of `master`. This clones the repo to `<local-path>` and stores the mapping in your pncli global config.
+Use `--branch main` if the default branch is `main` instead of `master`. Use `--name` to give the marketplace a short, human-friendly identifier (defaults to the repo name). This clones the repo to `local-path` (default: `~/.agents/marketplaces/<repo-name>`), registers it in your pncli global config, and installs all of its plugins.
 
 **Example:**
 ```
-pncli skills marketplace setup https://bitbucket.company.com/scm/ai/skills.git ~/ai-skills
+pncli skills marketplace add https://bitbucket.company.com/scm/ai/skills.git --name internal-ai
 ```
 
-## Sync (install a plugin)
+You can register as many marketplaces as you like — just run `add` again with a different URL. `marketplace setup` is kept as an alias of `add` for backward compatibility.
+
+If you upgrade pncli from a version that only supported a single marketplace, your existing config is migrated to the multi-marketplace format automatically the first time you run any `marketplace` command — no manual steps required.
+
+## List marketplaces and browse plugins
+
+```
+pncli skills marketplace list
+pncli skills marketplace plugins <name>
+```
+
+`list` shows every registered marketplace. `plugins` shows the plugins available inside one of them, without installing anything.
+
+## Sync (pull + install)
 
 Install to `~/.agents/skills` (GitHub Copilot / Codex):
 ```
@@ -27,10 +40,37 @@ Install to `~/.claude/skills` (Claude Code):
 pncli skills marketplace sync --claude
 ```
 
-Pass a plugin name to skip the interactive picker:
+With a single registered marketplace, `sync` just prompts you to pick a plugin (or pass one explicitly). With more than one marketplace registered, it first prompts you to pick a marketplace — if you pick the wrong plugin from the wrong marketplace, choose "← Back to marketplace selection" to reselect rather than restarting the command.
+
+Pass a plugin name to skip the interactive plugin picker:
 ```
 pncli skills marketplace sync my-plugin --claude
 ```
+
+Pass `--marketplace <name>` to skip the interactive marketplace picker:
+```
+pncli skills marketplace sync my-plugin --marketplace internal-ai
+```
+
+Install every plugin from one marketplace:
+```
+pncli skills marketplace sync all --marketplace internal-ai
+```
+
+Sync every plugin from every registered marketplace in one shot:
+```
+pncli skills marketplace sync --marketplace all
+```
+
+`sync` skips reinstalling when a marketplace has no new upstream changes (single-plugin and `all` installs alike). Pass `--force` to reinstall anyway.
+
+## Remove a marketplace
+
+```
+pncli skills marketplace remove <name>
+```
+
+Unregisters the marketplace from your config. It does not delete the local clone on disk.
 
 ## Marketplace repo structure
 

--- a/src/services/skills/commands.test.ts
+++ b/src/services/skills/commands.test.ts
@@ -269,6 +269,20 @@ describe('getAllMarketplaces', () => {
     const config: GlobalConfig = {};
     expect(getAllMarketplaces(config)).toEqual([]);
   });
+
+  it('disambiguates a legacy marketplace whose derived name collides with an existing entry', () => {
+    const config: GlobalConfig = {
+      marketplace: { repoUrl: 'https://bitbucket.example.com/scm/other/skills.git', localPath: '/home/user/.agents/marketplaces/skills' },
+      marketplaces: [
+        { name: 'skills', repoUrl: 'https://github.com/org/skills.git', localPath: '/home/user/.agents/marketplaces/skills-gh' },
+      ],
+    };
+    const result = getAllMarketplaces(config);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('skills');
+    expect(result[1].name).toBe('skills-2');
+    expect(result[1].repoUrl).toBe('https://bitbucket.example.com/scm/other/skills.git');
+  });
 });
 
 // ── getInstalledMetaPath ──────────────────────────────────────────────────────

--- a/src/services/skills/commands.test.ts
+++ b/src/services/skills/commands.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { resolvePluginChoices, resolveSkillsSrc, copyPluginSkills, injectTokenIntoUrl, repoNameFromUrl, defaultMarketplacePath, getAllMarketplaces, getInstalledMetaPath, readInstalledMeta, recordInstalledSkills } from './commands.js';
+import { resolvePluginChoices, resolveSkillsSrc, copyPluginSkills, injectTokenIntoUrl, repoNameFromUrl, defaultMarketplacePath, getAllMarketplaces, getInstalledMetaPath, readInstalledMeta, recordInstalledSkills, upsertMarketplace } from './commands.js';
 import type { GlobalConfig } from '../../types/config.js';
 
 type ReaddirResult = ReturnType<typeof fs.readdirSync>;
@@ -282,6 +282,52 @@ describe('getAllMarketplaces', () => {
     expect(result[0].name).toBe('skills');
     expect(result[1].name).toBe('skills-2');
     expect(result[1].repoUrl).toBe('https://bitbucket.example.com/scm/other/skills.git');
+  });
+});
+
+// ── upsertMarketplace ──────────────────────────────────────────────────────────
+
+describe('upsertMarketplace', () => {
+  it('adds a new entry when neither name nor repoUrl match an existing one', () => {
+    const all: ReturnType<typeof getAllMarketplaces> = [];
+    upsertMarketplace(all, { name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha' });
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe('alpha');
+  });
+
+  it('updates the existing entry in place when repoUrl matches', () => {
+    const all = [{ name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha' }];
+    upsertMarketplace(all, { name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha-new' });
+    expect(all).toHaveLength(1);
+    expect(all[0].localPath).toBe('/p/alpha-new');
+  });
+
+  it('preserves a previously stored token when re-adding without --token', () => {
+    const all = [{ name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha', token: 'secret123' }];
+    upsertMarketplace(all, { name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha' });
+    expect(all[0].token).toBe('secret123');
+  });
+
+  it('overwrites the stored token when a new one is supplied', () => {
+    const all = [{ name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha', token: 'old' }];
+    upsertMarketplace(all, { name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha', token: 'new' });
+    expect(all[0].token).toBe('new');
+  });
+
+  it('throws when --name collides with a different registered repo', () => {
+    const all = [{ name: 'shared', repoUrl: 'https://github.com/org/a.git', localPath: '/p/a' }];
+    expect(() => upsertMarketplace(all, { name: 'shared', repoUrl: 'https://github.com/org/b.git', localPath: '/p/b' })).toThrow('already registered for a different repo');
+    expect(all).toHaveLength(1);
+  });
+
+  it('throws when an existing repoUrl is renamed to a name already used by a different marketplace', () => {
+    const all = [
+      { name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/p/alpha' },
+      { name: 'beta', repoUrl: 'https://github.com/org/beta.git', localPath: '/p/beta' },
+    ];
+    expect(() => upsertMarketplace(all, { name: 'alpha', repoUrl: 'https://github.com/org/beta.git', localPath: '/p/beta' })).toThrow('already used by a different marketplace');
+    expect(all).toHaveLength(2);
+    expect(all[1].name).toBe('beta');
   });
 });
 

--- a/src/services/skills/commands.test.ts
+++ b/src/services/skills/commands.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { resolvePluginChoices, resolveSkillsSrc, copyPluginSkills, injectTokenIntoUrl, repoNameFromUrl, defaultMarketplacePath } from './commands.js';
+import { resolvePluginChoices, resolveSkillsSrc, copyPluginSkills, injectTokenIntoUrl, repoNameFromUrl, defaultMarketplacePath, getAllMarketplaces, getInstalledMetaPath, readInstalledMeta, recordInstalledSkills } from './commands.js';
+import type { GlobalConfig } from '../../types/config.js';
 
 type ReaddirResult = ReturnType<typeof fs.readdirSync>;
 
@@ -195,5 +196,131 @@ describe('copyPluginSkills', () => {
     const { installed, failed } = copyPluginSkills('/market/plugins/sunny/skills', targetDir);
     expect(installed).toEqual([]);
     expect(failed).toEqual([]);
+  });
+
+  it('writes install metadata with source "marketplace" when meta context is provided', () => {
+    vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'readdirSync').mockImplementation((p) => {
+      const s = String(p);
+      if (s === '/market/plugins/sunny/skills') return ['skill-one'] as unknown as ReaddirResult;
+      return [] as unknown as ReaddirResult;
+    });
+    vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    vi.spyOn(fs, 'rmSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'cpSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const writeFileSpy = vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined);
+
+    const { installed } = copyPluginSkills('/market/plugins/sunny/skills', targetDir, {
+      marketplace: 'my-market',
+      plugin: 'sunny',
+      installedFrom: 'https://github.com/owner/my-market.git',
+    });
+    expect(installed).toEqual(['skill-one']);
+
+    expect(writeFileSpy).toHaveBeenCalled();
+    const [writePath, writeContent] = writeFileSpy.mock.calls[0] as [string, string];
+    expect(writePath).toContain('.pncli-installed.json');
+    const parsed = JSON.parse(writeContent) as { version: number; skills: Record<string, { source: string; marketplace: string }> };
+    expect(parsed.version).toBe(1);
+    expect(parsed.skills['skill-one'].source).toBe('marketplace');
+    expect(parsed.skills['skill-one'].marketplace).toBe('my-market');
+  });
+});
+
+// ── getAllMarketplaces ─────────────────────────────────────────────────────────
+
+describe('getAllMarketplaces', () => {
+  it('returns entries from the new marketplaces array', () => {
+    const config: GlobalConfig = {
+      marketplaces: [
+        { name: 'alpha', repoUrl: 'https://github.com/org/alpha.git', localPath: '/home/user/.agents/marketplaces/alpha' },
+        { name: 'beta', repoUrl: 'https://github.com/org/beta.git', localPath: '/home/user/.agents/marketplaces/beta' },
+      ],
+    };
+    const result = getAllMarketplaces(config);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('alpha');
+    expect(result[1].name).toBe('beta');
+  });
+
+  it('migrates a legacy single marketplace field when not already in the array', () => {
+    const config: GlobalConfig = {
+      marketplace: { repoUrl: 'https://github.com/org/legacy.git', localPath: '/home/user/.agents/marketplaces/legacy' },
+    };
+    const result = getAllMarketplaces(config);
+    expect(result).toHaveLength(1);
+    expect(result[0].repoUrl).toBe('https://github.com/org/legacy.git');
+    expect(result[0].name).toBe('legacy');
+  });
+
+  it('does not duplicate a legacy marketplace already present in the array', () => {
+    const config: GlobalConfig = {
+      marketplace: { repoUrl: 'https://github.com/org/mkt.git', localPath: '/home/user/.agents/marketplaces/mkt' },
+      marketplaces: [
+        { name: 'mkt', repoUrl: 'https://github.com/org/mkt.git', localPath: '/home/user/.agents/marketplaces/mkt' },
+      ],
+    };
+    const result = getAllMarketplaces(config);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array when no marketplaces are configured', () => {
+    const config: GlobalConfig = {};
+    expect(getAllMarketplaces(config)).toEqual([]);
+  });
+});
+
+// ── getInstalledMetaPath ──────────────────────────────────────────────────────
+
+describe('getInstalledMetaPath', () => {
+  it('returns the correct metadata path within the target directory', () => {
+    const targetDir = path.join(os.homedir(), '.agents', 'skills');
+    expect(getInstalledMetaPath(targetDir)).toBe(path.join(targetDir, '.pncli-installed.json'));
+  });
+});
+
+// ── readInstalledMeta ─────────────────────────────────────────────────────────
+
+describe('readInstalledMeta', () => {
+  it('returns an empty meta object when no file exists', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const meta = readInstalledMeta('/some/target');
+    expect(meta).toEqual({ version: 1, skills: {} });
+  });
+
+  it('parses an existing valid metadata file', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({
+      version: 1,
+      skills: {
+        'my-skill': { source: 'marketplace', marketplace: 'mkt', plugin: 'sunny', installedAt: '2026-06-30T00:00:00Z', installedFrom: 'https://github.com/org/mkt.git' },
+      },
+    }));
+    const meta = readInstalledMeta('/some/target');
+    expect(meta.skills['my-skill'].marketplace).toBe('mkt');
+  });
+});
+
+// ── recordInstalledSkills ──────────────────────────────────────────────────────
+
+describe('recordInstalledSkills', () => {
+  it('writes a "bundled" source record for each skill name', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const writeFileSpy = vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined);
+
+    recordInstalledSkills('/target', ['skill-a', 'skill-b'], { source: 'bundled' });
+
+    expect(writeFileSpy).toHaveBeenCalledOnce();
+    const [, writeContent] = writeFileSpy.mock.calls[0] as [string, string];
+    const parsed = JSON.parse(writeContent) as { skills: Record<string, { source: string }> };
+    expect(parsed.skills['skill-a'].source).toBe('bundled');
+    expect(parsed.skills['skill-b'].source).toBe('bundled');
+  });
+
+  it('does nothing when skillNames is empty', () => {
+    const writeFileSpy = vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined);
+    recordInstalledSkills('/target', [], { source: 'bundled' });
+    expect(writeFileSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/services/skills/commands.ts
+++ b/src/services/skills/commands.ts
@@ -64,9 +64,13 @@ function scrubToken(msg: string): string {
   return msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@');
 }
 
-/** Throws a clear error instead of hanging when an interactive prompt would otherwise block a non-TTY caller. */
+/**
+ * Throws a clear error instead of hanging when an interactive prompt would otherwise block a
+ * non-TTY caller. Only stdin needs to be a TTY — pncli's stdout is JSON and piping it (to a file,
+ * `jq`, etc.) is a normal, fully-interactive usage pattern.
+ */
 function assertInteractive(hint: string): void {
-  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+  if (!process.stdin.isTTY) {
     throw new Error(`This selection requires an interactive terminal. ${hint}`);
   }
 }
@@ -208,14 +212,15 @@ function loadMarketplaces(configPath: string): MarketplaceConfig[] {
  * Adds or updates a marketplace entry in-place, refusing to silently clobber an unrelated
  * marketplace when its name or repo URL collides with an existing entry's identity.
  */
-function upsertMarketplace(all: MarketplaceConfig[], entry: MarketplaceConfig): void {
+export function upsertMarketplace(all: MarketplaceConfig[], entry: MarketplaceConfig): void {
   const idxByUrl = all.findIndex(m => m.repoUrl === entry.repoUrl);
   const idxByName = all.findIndex(m => m.name === entry.name);
   if (idxByUrl !== -1) {
     if (idxByName !== -1 && idxByName !== idxByUrl) {
       throw new Error(`Marketplace name "${entry.name}" is already used by a different marketplace (${all[idxByName].repoUrl}). Choose a different --name.`);
     }
-    all[idxByUrl] = entry;
+    // Re-running `add` without --token shouldn't silently wipe a previously stored token.
+    all[idxByUrl] = { ...entry, token: entry.token ?? all[idxByUrl].token };
   } else if (idxByName !== -1) {
     throw new Error(`Marketplace name "${entry.name}" is already registered for a different repo (${all[idxByName].repoUrl}). Choose a different --name, or remove the existing marketplace first.`);
   } else {
@@ -341,35 +346,41 @@ function installAllPlugins(resolvedPath: string, marketplaceName: string, url: s
  */
 function syncMarketplacePlugins(m: MarketplaceConfig, targetDir: string, force: boolean, pluginFilter: string): Record<string, unknown> {
   const marketplaceName = marketplaceLabel(m);
-  const marketplacePath = m.localPath;
-  if (!marketplacePath || !fs.existsSync(marketplacePath)) {
-    warn(`Marketplace "${marketplaceName}" local path not found — skipping.`);
-    return { marketplace: marketplaceName, skipped: true, message: 'Local path not found.' };
-  }
+  try {
+    const marketplacePath = m.localPath;
+    if (!marketplacePath || !fs.existsSync(marketplacePath)) {
+      warn(`Marketplace "${marketplaceName}" local path not found — skipping.`);
+      return { marketplace: marketplaceName, skipped: true, message: 'Local path not found.' };
+    }
 
-  const { updated } = pullMarketplace(marketplacePath, m.repoUrl, m.token, marketplaceName);
-  if (!updated && !force) {
-    return { marketplace: marketplaceName, marketplaceUpdated: false, skipped: true, message: 'No changes detected — skipping install. Use --force to reinstall anyway.' };
-  }
+    const { updated } = pullMarketplace(marketplacePath, m.repoUrl, m.token, marketplaceName);
+    if (!updated && !force) {
+      return { marketplace: marketplaceName, marketplaceUpdated: false, skipped: true, message: 'No changes detected — skipping install. Use --force to reinstall anyway.' };
+    }
 
-  const pluginChoices = resolvePluginChoices(marketplacePath);
-  if (pluginChoices.length === 0) {
-    warn(`No plugins found in marketplace "${marketplaceName}" — skipping.`);
-    return { marketplace: marketplaceName, skipped: true, message: 'No plugins found.' };
-  }
+    const pluginChoices = resolvePluginChoices(marketplacePath);
+    if (pluginChoices.length === 0) {
+      warn(`No plugins found in marketplace "${marketplaceName}" — skipping.`);
+      return { marketplace: marketplaceName, skipped: true, message: 'No plugins found.' };
+    }
 
-  let pluginNames: string[];
-  if (pluginFilter === 'all') {
-    pluginNames = pluginChoices.map(p => p.name);
-  } else if (pluginChoices.some(p => p.name === pluginFilter)) {
-    pluginNames = [pluginFilter];
-  } else {
-    warn(`Plugin "${pluginFilter}" not found in "${marketplaceName}" — skipping.`);
-    return { marketplace: marketplaceName, skipped: true, message: `Plugin "${pluginFilter}" not found.` };
-  }
+    let pluginNames: string[];
+    if (pluginFilter === 'all') {
+      pluginNames = pluginChoices.map(p => p.name);
+    } else if (pluginChoices.some(p => p.name === pluginFilter)) {
+      pluginNames = [pluginFilter];
+    } else {
+      warn(`Plugin "${pluginFilter}" not found in "${marketplaceName}" — skipping.`);
+      return { marketplace: marketplaceName, skipped: true, message: `Plugin "${pluginFilter}" not found.` };
+    }
 
-  const { results, totalInstalled } = installPluginsForMarketplace(marketplacePath, marketplaceName, m.repoUrl, pluginNames, targetDir);
-  return { marketplace: marketplaceName, plugins: results, total: totalInstalled, marketplaceUpdated: updated };
+    const { results, totalInstalled } = installPluginsForMarketplace(marketplacePath, marketplaceName, m.repoUrl, pluginNames, targetDir);
+    return { marketplace: marketplaceName, plugins: results, total: totalInstalled, marketplaceUpdated: updated };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    warn(`Marketplace "${marketplaceName}" failed — skipping. ${message}`);
+    return { marketplace: marketplaceName, skipped: true, error: message };
+  }
 }
 
 interface MarketplaceAddOptions {

--- a/src/services/skills/commands.ts
+++ b/src/services/skills/commands.ts
@@ -7,7 +7,10 @@ import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import select from '@inquirer/select';
 import { writeGlobalConfig, getGlobalConfigPath, loadJsonFile } from '../../lib/config.js';
-import type { GlobalConfig } from '../../types/config.js';
+import type { GlobalConfig, MarketplaceConfig } from '../../types/config.js';
+
+const BACK = '__back__';
+const ALL_MARKETPLACES = '__all_marketplaces__';
 
 /**
  * Injects an HTTP access token into a git clone URL.
@@ -52,6 +55,10 @@ export function defaultMarketplacePath(url: string): string {
   return path.join(os.homedir(), '.agents', 'marketplaces', repoNameFromUrl(url));
 }
 
+function marketplaceLabel(m: MarketplaceConfig): string {
+  return m.name ?? repoNameFromUrl(m.repoUrl ?? '');
+}
+
 const AGENT_PATHS: Record<string, { project: string; user: string }> = {
   'github-copilot': { project: '.agents/skills',  user: path.join(os.homedir(), '.copilot/skills') },
   'claude-code':    { project: '.claude/skills',   user: path.join(os.homedir(), '.claude/skills') },
@@ -64,6 +71,309 @@ function getBundledSkillsDir(): string {
     return path.resolve(path.dirname(thisFile), '..', 'skills');
   } catch {
     return '';
+  }
+}
+
+/**
+ * Path to the skill install metadata file inside a given skills target directory.
+ */
+export function getInstalledMetaPath(targetDir: string): string {
+  return path.join(targetDir, '.pncli-installed.json');
+}
+
+export interface InstalledSkillRecord {
+  source: 'marketplace' | 'bundled';
+  marketplace?: string;
+  plugin?: string;
+  installedFrom?: string;
+  installedAt: string;
+}
+
+export interface InstalledMeta {
+  version: 1;
+  skills: Record<string, InstalledSkillRecord>;
+}
+
+/**
+ * Reads the installed-skills metadata from the target directory.
+ */
+export function readInstalledMeta(targetDir: string): InstalledMeta {
+  const metaPath = getInstalledMetaPath(targetDir);
+  const raw = loadJsonFile<InstalledMeta>(metaPath);
+  if (raw && raw.version === 1 && raw.skills) return raw;
+  return { version: 1, skills: {} };
+}
+
+/**
+ * Records install provenance for one or more skills already copied into targetDir.
+ * Shared by marketplace installs (source: 'marketplace') and bundled installs (source: 'bundled').
+ */
+export function recordInstalledSkills(targetDir: string, skillNames: string[], record: Omit<InstalledSkillRecord, 'installedAt'>): void {
+  if (skillNames.length === 0) return;
+  const meta = readInstalledMeta(targetDir);
+  const now = new Date().toISOString();
+  for (const skillName of skillNames) {
+    meta.skills[skillName] = { ...record, installedAt: now };
+  }
+  fs.writeFileSync(getInstalledMetaPath(targetDir), JSON.stringify(meta, null, 2), 'utf8');
+}
+
+/**
+ * Returns all registered marketplaces from the global config, merging the
+ * legacy single `marketplace` field into the new `marketplaces` array.
+ */
+export function getAllMarketplaces(globalConfig: GlobalConfig): MarketplaceConfig[] {
+  const result: MarketplaceConfig[] = [];
+  if (Array.isArray(globalConfig.marketplaces)) {
+    result.push(...globalConfig.marketplaces);
+  }
+  if (globalConfig.marketplace?.repoUrl) {
+    const legacyUrl = globalConfig.marketplace.repoUrl;
+    const alreadyPresent = result.some(m => m.repoUrl === legacyUrl);
+    if (!alreadyPresent) {
+      result.push({
+        name: globalConfig.marketplace.name ?? repoNameFromUrl(legacyUrl),
+        repoUrl: globalConfig.marketplace.repoUrl,
+        localPath: globalConfig.marketplace.localPath,
+        token: globalConfig.marketplace.token,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Saves an updated marketplaces array back to the global config, removing
+ * the legacy `marketplace` field so it doesn't produce duplicate entries on next read.
+ */
+function saveMarketplaces(configPath: string, existing: GlobalConfig, marketplaces: MarketplaceConfig[]): void {
+  const updated: GlobalConfig = { ...existing, marketplaces };
+  delete updated.marketplace;
+  writeGlobalConfig(updated, configPath);
+}
+
+/**
+ * Reads all registered marketplaces and, if the legacy single-marketplace field is
+ * still present, persists the migration immediately so every pncli upgrade transitions
+ * seamlessly to the multi-marketplace format without the user re-running `marketplace add`.
+ */
+function loadMarketplaces(configPath: string): MarketplaceConfig[] {
+  const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
+  const all = getAllMarketplaces(existing);
+  if (existing.marketplace?.repoUrl) {
+    saveMarketplaces(configPath, existing, all);
+    warn('Migrated legacy single-marketplace config to the multi-marketplace format.');
+  }
+  return all;
+}
+
+/**
+ * Clones (or re-clones) a marketplace repo to disk. Handles the Windows + Git Credential
+ * Manager case where git writes auth warnings to stderr and exits non-zero even though the
+ * clone succeeded — verified by checking that `git rev-parse HEAD` resolves at the destination.
+ */
+function cloneOrReuseMarketplace(url: string, resolvedPath: string, opts: { branch?: string; token?: string }): void {
+  const hasGit = fs.existsSync(path.join(resolvedPath, '.git'));
+  if (fs.existsSync(resolvedPath) && !hasGit && fs.readdirSync(resolvedPath).length > 0) {
+    throw new Error(`Directory already exists and is not a git repo: ${resolvedPath}`);
+  }
+  if (hasGit) {
+    warn(`Directory already contains a git repo at ${resolvedPath} — skipping clone, updating config and re-installing plugins.`);
+    return;
+  }
+
+  const branchLabel = opts.branch ?? 'remote default';
+  warn(`Cloning ${url} (branch: ${branchLabel}) → ${resolvedPath}...`);
+  const cloneUrl = opts.token ? injectTokenIntoUrl(url, opts.token) : url;
+  const cloneArgs = ['clone'];
+  if (opts.branch) cloneArgs.push('--branch', opts.branch);
+  cloneArgs.push(cloneUrl, resolvedPath);
+  try {
+    execFileSync('git', cloneArgs, { stdio: ['inherit', 'inherit', 'pipe'] });
+  } catch (e: unknown) {
+    let cloneActuallySucceeded = false;
+    try {
+      execFileSync('git', ['-C', resolvedPath, 'rev-parse', 'HEAD'], { stdio: 'pipe' });
+      cloneActuallySucceeded = true;
+    } catch { /* repo not valid — fall through and re-throw original error */ }
+    if (!cloneActuallySucceeded) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@'));
+    }
+  }
+}
+
+/**
+ * Pulls the latest content for a marketplace repo. Returns whether the pull brought in new changes.
+ */
+function pullMarketplace(marketplacePath: string, repoUrl: string | undefined, token: string | undefined, marketplaceName: string): { updated: boolean } {
+  warn(`Pulling latest content for "${marketplaceName}"...`);
+  const gitArgs = ['-C', marketplacePath];
+  if (repoUrl && token) {
+    gitArgs.push('-c', `remote.origin.url=${injectTokenIntoUrl(repoUrl, token)}`);
+  }
+  gitArgs.push('pull');
+  let pullOutput: string;
+  try {
+    pullOutput = execFileSync('git', gitArgs, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe'], env: { ...process.env, LANG: 'C', LC_ALL: 'C' } });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@'));
+  }
+  const updated = !pullOutput.includes('Already up to date');
+  if (pullOutput.trim() && updated) warn(pullOutput.trim());
+  warn(updated ? `"${marketplaceName}" updated.` : `"${marketplaceName}" already up to date — no changes to sync.`);
+  return { updated };
+}
+
+/**
+ * Installs the given plugin names from a marketplace into targetDir, recording provenance.
+ */
+function installPluginsForMarketplace(
+  marketplacePath: string,
+  marketplaceName: string,
+  repoUrl: string | undefined,
+  pluginNames: string[],
+  targetDir: string
+): { results: Record<string, { installed: string[]; failed: string[] }>; totalInstalled: number } {
+  const results: Record<string, { installed: string[]; failed: string[] }> = {};
+  let totalInstalled = 0;
+
+  for (const pluginName of pluginNames) {
+    const skillsSrc = resolveSkillsSrc(marketplacePath, pluginName);
+    if (!fs.existsSync(skillsSrc)) {
+      results[pluginName] = { installed: [], failed: [] };
+      warn(`No skills directory found for plugin "${pluginName}" in "${marketplaceName}" — skipping.`);
+      continue;
+    }
+    const { installed, failed } = copyPluginSkills(skillsSrc, targetDir, {
+      marketplace: marketplaceName,
+      plugin: pluginName,
+      installedFrom: repoUrl ?? '',
+    });
+    results[pluginName] = { installed, failed };
+    totalInstalled += installed.length;
+    for (const skill of installed) {
+      warn(`  ${skill}: ${path.join(skillsSrc, skill)} → ${path.join(targetDir, skill)}`);
+    }
+    if (failed.length > 0) {
+      warn(`Skipped ${failed.length} skill(s) with invalid names in "${pluginName}": ${failed.join(', ')}`);
+    }
+  }
+
+  return { results, totalInstalled };
+}
+
+/**
+ * Installs every plugin from a freshly cloned marketplace (used by `marketplace add`/`setup`).
+ */
+function installAllPlugins(resolvedPath: string, marketplaceName: string, url: string, targetDir: string): { pluginResults: Record<string, { installed: string[]; failed: string[] }>; totalInstalled: number } {
+  const pluginChoices = resolvePluginChoices(resolvedPath);
+  if (pluginChoices.length === 0) {
+    warn('No plugins found in marketplace. Check the marketplace repository structure.');
+    return { pluginResults: {}, totalInstalled: 0 };
+  }
+  warn(`Installing ${pluginChoices.length} plugin(s) to ${targetDir}...`);
+  const { results, totalInstalled } = installPluginsForMarketplace(resolvedPath, marketplaceName, url, pluginChoices.map(p => p.name), targetDir);
+  return { pluginResults: results, totalInstalled };
+}
+
+/**
+ * Pulls and installs plugins for one marketplace, honoring an optional plugin name filter
+ * ("all" installs every plugin). Used by the "sync every marketplace" flows. Never throws —
+ * problems are reported back as a `skipped` result so one bad marketplace doesn't abort the rest.
+ */
+function syncMarketplacePlugins(m: MarketplaceConfig, targetDir: string, force: boolean, pluginFilter: string): Record<string, unknown> {
+  const marketplaceName = marketplaceLabel(m);
+  const marketplacePath = m.localPath;
+  if (!marketplacePath || !fs.existsSync(marketplacePath)) {
+    warn(`Marketplace "${marketplaceName}" local path not found — skipping.`);
+    return { marketplace: marketplaceName, skipped: true, message: 'Local path not found.' };
+  }
+
+  const { updated } = pullMarketplace(marketplacePath, m.repoUrl, m.token, marketplaceName);
+  if (!updated && !force) {
+    return { marketplace: marketplaceName, marketplaceUpdated: false, skipped: true, message: 'No changes detected — skipping install. Use --force to reinstall anyway.' };
+  }
+
+  const pluginChoices = resolvePluginChoices(marketplacePath);
+  if (pluginChoices.length === 0) {
+    warn(`No plugins found in marketplace "${marketplaceName}" — skipping.`);
+    return { marketplace: marketplaceName, skipped: true, message: 'No plugins found.' };
+  }
+
+  let pluginNames: string[];
+  if (pluginFilter === 'all') {
+    pluginNames = pluginChoices.map(p => p.name);
+  } else if (pluginChoices.some(p => p.name === pluginFilter)) {
+    pluginNames = [pluginFilter];
+  } else {
+    warn(`Plugin "${pluginFilter}" not found in "${marketplaceName}" — skipping.`);
+    return { marketplace: marketplaceName, skipped: true, message: `Plugin "${pluginFilter}" not found.` };
+  }
+
+  const { results, totalInstalled } = installPluginsForMarketplace(marketplacePath, marketplaceName, m.repoUrl, pluginNames, targetDir);
+  return { marketplace: marketplaceName, plugins: results, total: totalInstalled, marketplaceUpdated: updated };
+}
+
+interface MarketplaceAddOptions {
+  name?: string;
+  branch?: string;
+  token?: string;
+  agent?: string;
+  claude?: boolean;
+}
+
+/**
+ * Shared implementation for `marketplace add` and `marketplace setup` (kept as a backward-compatible
+ * alias) — clones/registers the marketplace and installs all of its plugins.
+ */
+async function marketplaceAddAction(url: string, localPath: string | undefined, opts: MarketplaceAddOptions, commandName: 'marketplace-add' | 'marketplace-setup'): Promise<void> {
+  const start = Date.now();
+  try {
+    const resolvedPath = path.resolve(localPath ?? defaultMarketplacePath(url));
+    const marketplaceName = opts.name ?? repoNameFromUrl(url);
+
+    cloneOrReuseMarketplace(url, resolvedPath, opts);
+
+    const configPath = getGlobalConfigPath();
+    const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
+    const all = getAllMarketplaces(existing);
+    const idx = all.findIndex(m => m.name === marketplaceName || m.repoUrl === url);
+    const entry: MarketplaceConfig = {
+      name: marketplaceName,
+      repoUrl: url,
+      localPath: resolvedPath,
+      ...(opts.token ? { token: opts.token } : {}),
+    };
+    if (idx !== -1) {
+      all[idx] = entry;
+    } else {
+      all.push(entry);
+    }
+    saveMarketplaces(configPath, existing, all);
+
+    const agentName = opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
+    const agentConfig = AGENT_PATHS[agentName];
+    if (!agentConfig) {
+      throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
+    }
+    const targetDir = agentConfig.user;
+
+    const { pluginResults, totalInstalled } = installAllPlugins(resolvedPath, marketplaceName, url, targetDir);
+
+    success({
+      name: marketplaceName,
+      repoUrl: url,
+      localPath: resolvedPath,
+      branch: opts.branch ?? null,
+      tokenConfigured: !!opts.token,
+      plugins: pluginResults,
+      total: totalInstalled,
+      target: targetDir,
+    }, 'skills', commandName, start);
+  } catch (err) {
+    fail(err, 'skills', commandName, start);
   }
 }
 
@@ -148,6 +458,8 @@ export function registerSkillsCommands(program: Command): void {
           warn(`Failed to install: ${failed.join(', ')}`);
         }
 
+        recordInstalledSkills(targetDir, installed, { source: 'bundled' });
+
         success({
           installed,
           failed,
@@ -188,7 +500,10 @@ export function registerSkillsCommands(program: Command): void {
           return;
         }
 
+        const meta = readInstalledMeta(targetDir);
+
         const skillDirs = fs.readdirSync(targetDir).filter(name => {
+          if (name.startsWith('.')) return false;
           const skillPath = path.join(targetDir, name, 'SKILL.md');
           return fs.existsSync(skillPath);
         });
@@ -222,6 +537,7 @@ export function registerSkillsCommands(program: Command): void {
             services: metadata.services || data.services || '',
             providers: metadata.providers || data.providers || 'none',
             userInvocable: data['user-invocable'] === 'true',
+            installed: meta.skills[name] ?? null,
           };
         });
 
@@ -231,153 +547,184 @@ export function registerSkillsCommands(program: Command): void {
       }
     });
 
-  const marketplace = skills.command('marketplace').description('Manage a git-hosted skills marketplace');
+  skills
+    .command('uninstall')
+    .description('Uninstall a skill (defaults to user scope, matching the marketplace install target; pass --scope project for skills installed via `skills install`)')
+    .argument('<name>', 'Skill name to uninstall (the directory name under your skills folder)')
+    .option('--agent <agent>', 'Target agent host: github-copilot | claude-code', 'github-copilot')
+    .option('--scope <scope>', 'Installation scope to uninstall from: project | user', 'user')
+    .option('--claude', 'Shorthand for --agent claude-code')
+    .option('--target <dir>', 'Override skills directory')
+    .action((name: string, opts: { agent?: string; scope?: string; claude?: boolean; target?: string }) => {
+      const start = Date.now();
+      try {
+        let targetDir: string;
+        if (opts.target) {
+          targetDir = path.resolve(opts.target);
+        } else {
+          const agentName = opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
+          const agentConfig = AGENT_PATHS[agentName];
+          if (!agentConfig) {
+            throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
+          }
+          const scopePath = opts.scope === 'project' ? agentConfig.project : agentConfig.user;
+          targetDir = path.resolve(scopePath);
+        }
+
+        const resolvedTarget = path.resolve(targetDir);
+        const skillDir = path.resolve(targetDir, name);
+        if (!skillDir.startsWith(resolvedTarget + path.sep)) {
+          throw new Error(`Invalid skill name: "${name}"`);
+        }
+
+        if (!fs.existsSync(skillDir)) {
+          throw new Error(`Skill "${name}" not found at ${skillDir}`);
+        }
+
+        const meta = readInstalledMeta(targetDir);
+        const record = meta.skills[name];
+
+        fs.rmSync(skillDir, { recursive: true, force: true });
+
+        delete meta.skills[name];
+        fs.writeFileSync(getInstalledMetaPath(targetDir), JSON.stringify(meta, null, 2), 'utf8');
+
+        success({
+          uninstalled: name,
+          target: targetDir,
+          wasTracked: !!record,
+          ...(record ? { installedFrom: record } : {}),
+        }, 'skills', 'uninstall', start);
+      } catch (err) {
+        fail(err, 'skills', 'uninstall', start);
+      }
+    });
+
+  const marketplace = skills.command('marketplace').description('Manage git-hosted skills marketplaces');
 
   marketplace
-    .command('setup')
-    .description('Clone a skills marketplace repo, register it in global config, and install all plugins')
+    .command('add')
+    .description('Register a new marketplace, clone it, and install all its plugins')
     .argument('<url>', 'Git clone URL of the marketplace repository')
     .argument('[localPath]', 'Local directory to clone into (default: ~/.agents/marketplaces/<repo-name>)')
+    .option('--name <name>', 'Human-readable name for this marketplace (default: derived from URL)')
     .option('--branch <branch>', 'Branch to clone (default: remote HEAD)')
     .option('--token <token>', 'HTTP access token for authenticated clone and pull (GitHub PAT or Bitbucket token)')
     .option('--agent <agent>', 'Target agent host for plugin install: github-copilot | claude-code (default: github-copilot)')
     .option('--claude', 'Shorthand for --agent claude-code')
-    .action(async (url: string, localPath: string | undefined, opts: { branch?: string; token?: string; agent?: string; claude?: boolean }) => {
+    .action((url: string, localPath: string | undefined, opts: MarketplaceAddOptions) => marketplaceAddAction(url, localPath, opts, 'marketplace-add'));
+
+  // Kept as an alias for `add` for backward compatibility with existing scripts/docs.
+  marketplace
+    .command('setup')
+    .description('Alias for `marketplace add` — clone a marketplace and install all its plugins')
+    .argument('<url>', 'Git clone URL of the marketplace repository')
+    .argument('[localPath]', 'Local directory to clone into (default: ~/.agents/marketplaces/<repo-name>)')
+    .option('--name <name>', 'Human-readable name for this marketplace (default: derived from URL)')
+    .option('--branch <branch>', 'Branch to clone (default: remote HEAD)')
+    .option('--token <token>', 'HTTP access token for authenticated clone and pull (GitHub PAT or Bitbucket token)')
+    .option('--agent <agent>', 'Target agent host for plugin install: github-copilot | claude-code (default: github-copilot)')
+    .option('--claude', 'Shorthand for --agent claude-code')
+    .action((url: string, localPath: string | undefined, opts: MarketplaceAddOptions) => marketplaceAddAction(url, localPath, opts, 'marketplace-setup'));
+
+  marketplace
+    .command('list')
+    .description('List all registered marketplaces')
+    .action(() => {
       const start = Date.now();
       try {
-        const resolvedPath = path.resolve(localPath ?? defaultMarketplacePath(url));
-
-        const hasGit = fs.existsSync(path.join(resolvedPath, '.git'));
-        if (fs.existsSync(resolvedPath) && !hasGit && fs.readdirSync(resolvedPath).length > 0) {
-          throw new Error(`Directory already exists and is not a git repo: ${resolvedPath}`);
-        }
-        if (hasGit) {
-          warn(`Directory already contains a git repo at ${resolvedPath} — skipping clone, updating config and re-installing plugins.`);
-        } else {
-          const branchLabel = opts.branch ?? 'remote default';
-          warn(`Cloning ${url} (branch: ${branchLabel}) → ${resolvedPath}...`);
-          const cloneUrl = opts.token ? injectTokenIntoUrl(url, opts.token) : url;
-          const cloneArgs = ['clone'];
-          if (opts.branch) cloneArgs.push('--branch', opts.branch);
-          cloneArgs.push(cloneUrl, resolvedPath);
-          try {
-            execFileSync('git', cloneArgs, { stdio: ['inherit', 'inherit', 'pipe'] });
-          } catch (e: unknown) {
-            // On some platforms (e.g. Windows with Git Credential Manager), git may
-            // write authentication warnings to stderr and exit non-zero even though
-            // the clone was successfully written to disk.  Verify by running
-            // `git rev-parse HEAD` at the destination; if that succeeds the repo is
-            // valid and we continue rather than surfacing a spurious error.
-            let cloneActuallySucceeded = false;
-            try {
-              execFileSync('git', ['-C', resolvedPath, 'rev-parse', 'HEAD'], { stdio: 'pipe' });
-              cloneActuallySucceeded = true;
-            } catch { /* repo not valid — fall through and re-throw original error */ }
-            if (!cloneActuallySucceeded) {
-              const msg = e instanceof Error ? e.message : String(e);
-              throw new Error(msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@'));
-            }
-          }
-        }
-
         const configPath = getGlobalConfigPath();
-        const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
-        existing.marketplace = { repoUrl: url, localPath: resolvedPath, ...(opts.token ? { token: opts.token } : {}) };
-        writeGlobalConfig(existing, configPath);
-
-        // Determine install target
-        const agentName = opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
-        const agentConfig = AGENT_PATHS[agentName];
-        if (!agentConfig) {
-          throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
-        }
-        const targetDir = agentConfig.user;
-
-        // Install all plugins from the marketplace
-        const pluginChoices = resolvePluginChoices(resolvedPath);
-        const pluginResults: Record<string, { installed: string[]; failed: string[] }> = {};
-        let totalInstalled = 0;
-
-        if (pluginChoices.length === 0) {
-          warn('No plugins found in marketplace. Check the marketplace repository structure.');
-        } else {
-          warn(`Installing ${pluginChoices.length} plugin(s) to ${targetDir}...`);
-          for (const pluginChoice of pluginChoices) {
-            const skillsSrc = resolveSkillsSrc(resolvedPath, pluginChoice.name);
-            if (!fs.existsSync(skillsSrc)) {
-              pluginResults[pluginChoice.name] = { installed: [], failed: [] };
-              warn(`No skills directory found for plugin "${pluginChoice.name}" — skipping.`);
-              continue;
-            }
-            const { installed, failed } = copyPluginSkills(skillsSrc, targetDir);
-            pluginResults[pluginChoice.name] = { installed, failed };
-            totalInstalled += installed.length;
-            for (const skill of installed) {
-              warn(`  ${skill}: ${path.join(skillsSrc, skill)} → ${path.join(targetDir, skill)}`);
-            }
-            if (failed.length > 0) {
-              warn(`Skipped ${failed.length} skill(s) with invalid names in "${pluginChoice.name}": ${failed.join(', ')}`);
-            }
-          }
-        }
+        const all = loadMarketplaces(configPath);
 
         success({
-          repoUrl: url,
-          localPath: resolvedPath,
-          branch: opts.branch ?? null,
-          tokenConfigured: !!opts.token,
-          plugins: pluginResults,
-          total: totalInstalled,
-          target: targetDir,
-        }, 'skills', 'marketplace-setup', start);
+          marketplaces: all.map(m => ({
+            name: marketplaceLabel(m),
+            repoUrl: m.repoUrl,
+            localPath: m.localPath,
+            tokenConfigured: !!m.token,
+          })),
+          total: all.length,
+        }, 'skills', 'marketplace-list', start);
       } catch (err) {
-        fail(err, 'skills', 'marketplace-setup', start);
+        fail(err, 'skills', 'marketplace-list', start);
+      }
+    });
+
+  marketplace
+    .command('plugins')
+    .description('List the plugins available in a registered marketplace')
+    .argument('<name>', 'Marketplace name (or repo URL) to inspect')
+    .action((name: string) => {
+      const start = Date.now();
+      try {
+        const configPath = getGlobalConfigPath();
+        const all = loadMarketplaces(configPath);
+        const found = all.find(m => m.name === name || m.repoUrl === name);
+        if (!found) {
+          throw new Error(`Marketplace "${name}" not found. Run: pncli skills marketplace list`);
+        }
+        if (!found.localPath || !fs.existsSync(found.localPath)) {
+          throw new Error(`Marketplace "${marketplaceLabel(found)}" local path not found at ${found.localPath ?? '(not set)'}. Run: pncli skills marketplace add <url>`);
+        }
+
+        const plugins = resolvePluginChoices(found.localPath);
+        success({
+          marketplace: marketplaceLabel(found),
+          plugins,
+          total: plugins.length,
+        }, 'skills', 'marketplace-plugins', start);
+      } catch (err) {
+        fail(err, 'skills', 'marketplace-plugins', start);
+      }
+    });
+
+  marketplace
+    .command('remove')
+    .description('Remove a registered marketplace from the config (does not delete the local clone)')
+    .argument('<name>', 'Name of the marketplace to remove')
+    .action((name: string) => {
+      const start = Date.now();
+      try {
+        const configPath = getGlobalConfigPath();
+        const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
+        const all = getAllMarketplaces(existing);
+
+        const idx = all.findIndex(m => m.name === name || m.repoUrl === name);
+        if (idx === -1) {
+          throw new Error(`Marketplace "${name}" not found. Run: pncli skills marketplace list`);
+        }
+
+        const removed = all.splice(idx, 1)[0];
+        saveMarketplaces(configPath, existing, all);
+
+        success({
+          removed: {
+            name: marketplaceLabel(removed),
+            repoUrl: removed.repoUrl,
+            localPath: removed.localPath,
+          },
+          remaining: all.length,
+        }, 'skills', 'marketplace-remove', start);
+      } catch (err) {
+        fail(err, 'skills', 'marketplace-remove', start);
       }
     });
 
   marketplace
     .command('sync')
-    .description('Pull latest marketplace content and install a plugin\'s skills')
+    .description('Pull latest marketplace content and install plugin skills')
     .argument('[plugin]', 'Plugin name to install, or "all" to install every plugin (skips interactive selection)')
+    .option('--marketplace <name>', 'Marketplace name to sync, or "all" to sync every registered marketplace (skips interactive selection)')
     .option('--agent <agent>', 'Target agent host: github-copilot | claude-code (default: github-copilot)')
     .option('--claude', 'Shorthand for --agent claude-code')
-    .option('--force', 'Force reinstall even if the marketplace repo has no new changes')
-    .action(async (plugin: string | undefined, opts: { agent?: string; claude?: boolean; force?: boolean }) => {
+    .option('--force', 'Reinstall even if a marketplace has no new changes (applies to single-plugin and "all" installs alike)')
+    .action(async (plugin: string | undefined, opts: { marketplace?: string; agent?: string; claude?: boolean; force?: boolean }) => {
       const start = Date.now();
       try {
         const configPath = getGlobalConfigPath();
-        const globalConfig: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
-
-        const marketplacePath = globalConfig.marketplace?.localPath;
-        if (!marketplacePath || !fs.existsSync(marketplacePath)) {
-          throw new Error('Marketplace not configured. Run: pncli skills marketplace setup <url> <localPath>');
-        }
-
-        warn('Pulling latest marketplace content...');
-        const repoUrl = globalConfig.marketplace?.repoUrl;
-        const token = globalConfig.marketplace?.token;
-        const gitArgs = ['-C', marketplacePath];
-        if (repoUrl && token) {
-          gitArgs.push('-c', `remote.origin.url=${injectTokenIntoUrl(repoUrl, token)}`);
-        }
-        gitArgs.push('pull');
-        let pullOutput: string;
-        try {
-          pullOutput = execFileSync('git', gitArgs, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe'], env: { ...process.env, LANG: 'C', LC_ALL: 'C' } });
-        } catch (e: unknown) {
-          const msg = e instanceof Error ? e.message : String(e);
-          throw new Error(msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@'));
-        }
-
-        const marketplaceUpdated = !pullOutput.includes('Already up to date');
-        if (pullOutput.trim() && marketplaceUpdated) {
-          warn(pullOutput.trim());
-        }
-        warn(marketplaceUpdated ? 'Marketplace updated.' : 'Marketplace already up to date — no changes to sync.');
-
-        const pluginChoices = resolvePluginChoices(marketplacePath);
-        if (pluginChoices.length === 0) {
-          throw new Error('No plugins found in marketplace. Check the marketplace repository structure.');
+        const allMarketplaces = loadMarketplaces(configPath);
+        if (allMarketplaces.length === 0) {
+          throw new Error('No marketplaces configured. Run: pncli skills marketplace add <url>');
         }
 
         const agentName = opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
@@ -386,89 +733,111 @@ export function registerSkillsCommands(program: Command): void {
           throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
         }
         const targetDir = agentConfig.user;
+        const force = opts.force ?? false;
 
-        let selectedPlugin: string;
-        if (plugin) {
-          if (plugin !== 'all' && !pluginChoices.some(p => p.name === plugin)) {
-            throw new Error(`Plugin "${plugin}" not found. Available: ${pluginChoices.map(p => p.name).join(', ')}`);
-          }
-          selectedPlugin = plugin;
-        } else {
-          selectedPlugin = await select({
-            message: 'Select a plugin to install:',
-            choices: [
-              { value: 'all', name: 'All — install every plugin' },
-              ...pluginChoices.map(p => ({
-                value: p.name,
-                name: p.description ? `${p.name} — ${p.description}` : p.name,
-              })),
-            ],
-          });
+        // Non-interactive "sync everything" — explicit flag.
+        if (opts.marketplace === 'all') {
+          const results = allMarketplaces.map(m => syncMarketplacePlugins(m, targetDir, force, plugin ?? 'all'));
+          success({ allMarketplaces: true, marketplaces: results, target: targetDir }, 'skills', 'marketplace-sync', start);
+          return;
         }
 
-        if (selectedPlugin === 'all') {
-          if (!marketplaceUpdated && !opts.force) {
+        let selectedMarketplace: MarketplaceConfig | undefined;
+        let selectedPlugin: string | undefined = plugin;
+        const canGoBack = !opts.marketplace && allMarketplaces.length > 1;
+
+        if (opts.marketplace) {
+          const found = allMarketplaces.find(m => m.name === opts.marketplace || m.repoUrl === opts.marketplace);
+          if (!found) {
+            throw new Error(`Marketplace "${opts.marketplace}" not found. Run: pncli skills marketplace list`);
+          }
+          selectedMarketplace = found;
+        } else if (allMarketplaces.length === 1) {
+          selectedMarketplace = allMarketplaces[0];
+        }
+
+        // Interactive loop: lets the user back out of a plugin prompt and reselect the marketplace.
+        for (;;) {
+          if (!selectedMarketplace) {
+            const chosen = await select({
+              message: 'Select a marketplace to sync:',
+              choices: [
+                { value: ALL_MARKETPLACES, name: 'All marketplaces — sync every plugin from every marketplace' },
+                ...allMarketplaces.map(m => ({ value: marketplaceLabel(m), name: `${marketplaceLabel(m)} — ${m.repoUrl ?? ''}` })),
+              ],
+            });
+            if (chosen === ALL_MARKETPLACES) {
+              const results = allMarketplaces.map(m => syncMarketplacePlugins(m, targetDir, force, selectedPlugin ?? 'all'));
+              success({ allMarketplaces: true, marketplaces: results, target: targetDir }, 'skills', 'marketplace-sync', start);
+              return;
+            }
+            selectedMarketplace = allMarketplaces.find(m => marketplaceLabel(m) === chosen);
+            if (!selectedMarketplace) {
+              throw new Error(`Marketplace "${chosen}" not found.`);
+            }
+          }
+
+          const marketplaceName = marketplaceLabel(selectedMarketplace);
+          const marketplacePath = selectedMarketplace.localPath;
+          if (!marketplacePath || !fs.existsSync(marketplacePath)) {
+            throw new Error(`Marketplace "${marketplaceName}" local path not found at ${marketplacePath ?? '(not set)'}. Run: pncli skills marketplace add <url>`);
+          }
+
+          const { updated } = pullMarketplace(marketplacePath, selectedMarketplace.repoUrl, selectedMarketplace.token, marketplaceName);
+
+          const pluginChoices = resolvePluginChoices(marketplacePath);
+          if (pluginChoices.length === 0) {
+            throw new Error(`No plugins found in marketplace "${marketplaceName}". Check the marketplace repository structure.`);
+          }
+
+          if (!selectedPlugin) {
+            const choices: { value: string; name: string }[] = [
+              { value: 'all', name: 'All — install every plugin' },
+              ...pluginChoices.map(p => ({ value: p.name, name: p.description ? `${p.name} — ${p.description}` : p.name })),
+            ];
+            if (canGoBack) {
+              choices.push({ value: BACK, name: '← Back to marketplace selection' });
+            }
+            const chosen = await select({ message: `Select a plugin from "${marketplaceName}" to install:`, choices });
+            if (chosen === BACK) {
+              selectedMarketplace = undefined;
+              continue;
+            }
+            selectedPlugin = chosen;
+          } else if (selectedPlugin !== 'all' && !pluginChoices.some(p => p.name === selectedPlugin)) {
+            throw new Error(`Plugin "${selectedPlugin}" not found in "${marketplaceName}". Available: ${pluginChoices.map(p => p.name).join(', ')}`);
+          }
+
+          if (!updated && !force) {
             success({
-              marketplace: marketplacePath,
+              marketplace: marketplaceName,
               marketplaceUpdated: false,
               updated: false,
               skipped: true,
-              message: 'No marketplace changes detected — skipping install.',
+              message: `No changes detected in "${marketplaceName}" — skipping install. Use --force to reinstall anyway.`,
             }, 'skills', 'marketplace-sync', start);
             return;
           }
 
-          const results: Record<string, { installed: string[]; failed: string[] }> = {};
-          let totalInstalled = 0;
+          const pluginNames = selectedPlugin === 'all' ? pluginChoices.map(p => p.name) : [selectedPlugin];
+          const { results, totalInstalled } = installPluginsForMarketplace(marketplacePath, marketplaceName, selectedMarketplace.repoUrl, pluginNames, targetDir);
 
-          for (const pluginChoice of pluginChoices) {
-            const skillsSrc = resolveSkillsSrc(marketplacePath, pluginChoice.name);
-            if (!fs.existsSync(skillsSrc)) {
-              results[pluginChoice.name] = { installed: [], failed: [] };
-              warn(`No skills directory found for plugin "${pluginChoice.name}" — skipping.`);
-              continue;
-            }
-            const { installed, failed } = copyPluginSkills(skillsSrc, targetDir);
-            results[pluginChoice.name] = { installed, failed };
-            totalInstalled += installed.length;
-            for (const skill of installed) {
-              warn(`  ${skill}: ${path.join(skillsSrc, skill)} → ${path.join(targetDir, skill)}`);
-            }
-            if (failed.length > 0) {
-              warn(`Skipped ${failed.length} skill(s) with invalid names in "${pluginChoice.name}": ${failed.join(', ')}`);
-            }
+          if (selectedPlugin === 'all') {
+            success({ marketplace: marketplaceName, plugins: results, total: totalInstalled, target: targetDir, marketplaceUpdated: updated }, 'skills', 'marketplace-sync', start);
+          } else {
+            const single = results[selectedPlugin] ?? { installed: [], failed: [] };
+            success({
+              marketplace: marketplaceName,
+              plugin: selectedPlugin,
+              installed: single.installed,
+              failed: single.failed,
+              total: single.installed.length,
+              target: targetDir,
+              marketplaceUpdated: updated,
+            }, 'skills', 'marketplace-sync', start);
           }
-
-          success({
-            plugins: results,
-            total: totalInstalled,
-            target: targetDir,
-            marketplaceUpdated,
-          }, 'skills', 'marketplace-sync', start);
           return;
         }
-
-        const skillsSrc = resolveSkillsSrc(marketplacePath, selectedPlugin);
-        if (!fs.existsSync(skillsSrc)) {
-          throw new Error(`No skills directory found at ${skillsSrc}`);
-        }
-
-        const { installed, failed } = copyPluginSkills(skillsSrc, targetDir);
-        for (const skill of installed) {
-          warn(`  ${skill}: ${path.join(skillsSrc, skill)} → ${path.join(targetDir, skill)}`);
-        }
-        if (failed.length > 0) {
-          warn(`Skipped ${failed.length} skill(s) with invalid names: ${failed.join(', ')}`);
-        }
-
-        success({
-          plugin: selectedPlugin,
-          installed,
-          failed,
-          total: installed.length,
-          target: targetDir,
-          marketplaceUpdated,
-        }, 'skills', 'marketplace-sync', start);
       } catch (err) {
         fail(err, 'skills', 'marketplace-sync', start);
       }
@@ -507,7 +876,13 @@ export function resolveSkillsSrc(marketplacePath: string, selectedPlugin: string
   return skillsSrc;
 }
 
-export function copyPluginSkills(skillsSrc: string, targetDir: string): { installed: string[]; failed: string[] } {
+interface InstallMeta {
+  marketplace: string;
+  plugin: string;
+  installedFrom: string;
+}
+
+export function copyPluginSkills(skillsSrc: string, targetDir: string, meta?: InstallMeta): { installed: string[]; failed: string[] } {
   fs.mkdirSync(targetDir, { recursive: true });
   const resolvedTarget = path.resolve(targetDir);
 
@@ -527,6 +902,15 @@ export function copyPluginSkills(skillsSrc: string, targetDir: string): { instal
     fs.rmSync(dest, { recursive: true, force: true });
     fs.cpSync(path.join(skillsSrc, skillName), dest, { recursive: true });
     installed.push(skillName);
+  }
+
+  if (meta) {
+    recordInstalledSkills(targetDir, installed, {
+      source: 'marketplace',
+      marketplace: meta.marketplace,
+      plugin: meta.plugin,
+      installedFrom: meta.installedFrom,
+    });
   }
 
   return { installed, failed };

--- a/src/services/skills/commands.ts
+++ b/src/services/skills/commands.ts
@@ -59,10 +59,34 @@ function marketplaceLabel(m: MarketplaceConfig): string {
   return m.name ?? repoNameFromUrl(m.repoUrl ?? '');
 }
 
+/** Strips injected credentials out of git error output before it reaches JSON output or logs. */
+function scrubToken(msg: string): string {
+  return msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@');
+}
+
+/** Throws a clear error instead of hanging when an interactive prompt would otherwise block a non-TTY caller. */
+function assertInteractive(hint: string): void {
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    throw new Error(`This selection requires an interactive terminal. ${hint}`);
+  }
+}
+
 const AGENT_PATHS: Record<string, { project: string; user: string }> = {
   'github-copilot': { project: '.agents/skills',  user: path.join(os.homedir(), '.copilot/skills') },
   'claude-code':    { project: '.claude/skills',   user: path.join(os.homedir(), '.claude/skills') },
 };
+
+function resolveAgentName(opts: { agent?: string; claude?: boolean }): string {
+  return opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
+}
+
+function resolveAgentPaths(agentName: string): { project: string; user: string } {
+  const agentConfig = AGENT_PATHS[agentName];
+  if (!agentConfig) {
+    throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
+  }
+  return agentConfig;
+}
 
 // Resolve the bundled skills directory relative to this file (dist/cli.js → ../skills)
 function getBundledSkillsDir(): string {
@@ -131,8 +155,15 @@ export function getAllMarketplaces(globalConfig: GlobalConfig): MarketplaceConfi
     const legacyUrl = globalConfig.marketplace.repoUrl;
     const alreadyPresent = result.some(m => m.repoUrl === legacyUrl);
     if (!alreadyPresent) {
+      const existingNames = new Set(result.map(m => m.name).filter((n): n is string => !!n));
+      let legacyName = globalConfig.marketplace.name ?? repoNameFromUrl(legacyUrl);
+      if (existingNames.has(legacyName)) {
+        let suffix = 2;
+        while (existingNames.has(`${legacyName}-${suffix}`)) suffix++;
+        legacyName = `${legacyName}-${suffix}`;
+      }
       result.push({
-        name: globalConfig.marketplace.name ?? repoNameFromUrl(legacyUrl),
+        name: legacyName,
         repoUrl: globalConfig.marketplace.repoUrl,
         localPath: globalConfig.marketplace.localPath,
         token: globalConfig.marketplace.token,
@@ -153,18 +184,43 @@ function saveMarketplaces(configPath: string, existing: GlobalConfig, marketplac
 }
 
 /**
- * Reads all registered marketplaces and, if the legacy single-marketplace field is
- * still present, persists the migration immediately so every pncli upgrade transitions
+ * Reads the global config and all registered marketplaces. If the legacy single-marketplace
+ * field is still present, persists the migration immediately so every pncli upgrade transitions
  * seamlessly to the multi-marketplace format without the user re-running `marketplace add`.
+ * Returns the (post-migration) config object so callers can reuse it for further writes.
  */
-function loadMarketplaces(configPath: string): MarketplaceConfig[] {
+function loadMarketplacesConfig(configPath: string): { existing: GlobalConfig; all: MarketplaceConfig[] } {
   const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
   const all = getAllMarketplaces(existing);
   if (existing.marketplace?.repoUrl) {
     saveMarketplaces(configPath, existing, all);
     warn('Migrated legacy single-marketplace config to the multi-marketplace format.');
+    delete existing.marketplace;
   }
-  return all;
+  return { existing, all };
+}
+
+function loadMarketplaces(configPath: string): MarketplaceConfig[] {
+  return loadMarketplacesConfig(configPath).all;
+}
+
+/**
+ * Adds or updates a marketplace entry in-place, refusing to silently clobber an unrelated
+ * marketplace when its name or repo URL collides with an existing entry's identity.
+ */
+function upsertMarketplace(all: MarketplaceConfig[], entry: MarketplaceConfig): void {
+  const idxByUrl = all.findIndex(m => m.repoUrl === entry.repoUrl);
+  const idxByName = all.findIndex(m => m.name === entry.name);
+  if (idxByUrl !== -1) {
+    if (idxByName !== -1 && idxByName !== idxByUrl) {
+      throw new Error(`Marketplace name "${entry.name}" is already used by a different marketplace (${all[idxByName].repoUrl}). Choose a different --name.`);
+    }
+    all[idxByUrl] = entry;
+  } else if (idxByName !== -1) {
+    throw new Error(`Marketplace name "${entry.name}" is already registered for a different repo (${all[idxByName].repoUrl}). Choose a different --name, or remove the existing marketplace first.`);
+  } else {
+    all.push(entry);
+  }
 }
 
 /**
@@ -198,7 +254,7 @@ function cloneOrReuseMarketplace(url: string, resolvedPath: string, opts: { bran
     } catch { /* repo not valid — fall through and re-throw original error */ }
     if (!cloneActuallySucceeded) {
       const msg = e instanceof Error ? e.message : String(e);
-      throw new Error(msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@'));
+      throw new Error(scrubToken(msg));
     }
   }
 }
@@ -218,7 +274,7 @@ function pullMarketplace(marketplacePath: string, repoUrl: string | undefined, t
     pullOutput = execFileSync('git', gitArgs, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe'], env: { ...process.env, LANG: 'C', LC_ALL: 'C' } });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(msg.replace(/x-(?:token-auth|access-token):[^@]+@/g, 'x-token-auth:***@'));
+    throw new Error(scrubToken(msg));
   }
   const updated = !pullOutput.includes('Already up to date');
   if (pullOutput.trim() && updated) warn(pullOutput.trim());
@@ -337,28 +393,17 @@ async function marketplaceAddAction(url: string, localPath: string | undefined, 
     cloneOrReuseMarketplace(url, resolvedPath, opts);
 
     const configPath = getGlobalConfigPath();
-    const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
-    const all = getAllMarketplaces(existing);
-    const idx = all.findIndex(m => m.name === marketplaceName || m.repoUrl === url);
+    const { existing, all } = loadMarketplacesConfig(configPath);
     const entry: MarketplaceConfig = {
       name: marketplaceName,
       repoUrl: url,
       localPath: resolvedPath,
       ...(opts.token ? { token: opts.token } : {}),
     };
-    if (idx !== -1) {
-      all[idx] = entry;
-    } else {
-      all.push(entry);
-    }
+    upsertMarketplace(all, entry);
     saveMarketplaces(configPath, existing, all);
 
-    const agentName = opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
-    const agentConfig = AGENT_PATHS[agentName];
-    if (!agentConfig) {
-      throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
-    }
-    const targetDir = agentConfig.user;
+    const targetDir = resolveAgentPaths(resolveAgentName(opts)).user;
 
     const { pluginResults, totalInstalled } = installAllPlugins(resolvedPath, marketplaceName, url, targetDir);
 
@@ -394,10 +439,7 @@ export function registerSkillsCommands(program: Command): void {
         if (opts.target) {
           targetDir = path.resolve(opts.target);
         } else {
-          const agentConfig = AGENT_PATHS[opts.agent];
-          if (!agentConfig) {
-            throw new Error(`Unknown agent: "${opts.agent}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
-          }
+          const agentConfig = resolveAgentPaths(opts.agent);
           const scopePath = opts.scope === 'user' ? agentConfig.user : agentConfig.project;
           targetDir = path.resolve(scopePath);
         }
@@ -487,10 +529,7 @@ export function registerSkillsCommands(program: Command): void {
         if (opts.target) {
           targetDir = path.resolve(opts.target);
         } else {
-          const agentConfig = AGENT_PATHS[opts.agent];
-          if (!agentConfig) {
-            throw new Error(`Unknown agent: "${opts.agent}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
-          }
+          const agentConfig = resolveAgentPaths(opts.agent);
           const scopePath = opts.scope === 'user' ? agentConfig.user : agentConfig.project;
           targetDir = path.resolve(scopePath);
         }
@@ -562,11 +601,7 @@ export function registerSkillsCommands(program: Command): void {
         if (opts.target) {
           targetDir = path.resolve(opts.target);
         } else {
-          const agentName = opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
-          const agentConfig = AGENT_PATHS[agentName];
-          if (!agentConfig) {
-            throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
-          }
+          const agentConfig = resolveAgentPaths(resolveAgentName(opts));
           const scopePath = opts.scope === 'project' ? agentConfig.project : agentConfig.user;
           targetDir = path.resolve(scopePath);
         }
@@ -602,30 +637,25 @@ export function registerSkillsCommands(program: Command): void {
 
   const marketplace = skills.command('marketplace').description('Manage git-hosted skills marketplaces');
 
-  marketplace
-    .command('add')
-    .description('Register a new marketplace, clone it, and install all its plugins')
-    .argument('<url>', 'Git clone URL of the marketplace repository')
-    .argument('[localPath]', 'Local directory to clone into (default: ~/.agents/marketplaces/<repo-name>)')
-    .option('--name <name>', 'Human-readable name for this marketplace (default: derived from URL)')
-    .option('--branch <branch>', 'Branch to clone (default: remote HEAD)')
-    .option('--token <token>', 'HTTP access token for authenticated clone and pull (GitHub PAT or Bitbucket token)')
-    .option('--agent <agent>', 'Target agent host for plugin install: github-copilot | claude-code (default: github-copilot)')
-    .option('--claude', 'Shorthand for --agent claude-code')
-    .action((url: string, localPath: string | undefined, opts: MarketplaceAddOptions) => marketplaceAddAction(url, localPath, opts, 'marketplace-add'));
+  function withMarketplaceAddOptions(cmd: Command): Command {
+    return cmd
+      .argument('<url>', 'Git clone URL of the marketplace repository')
+      .argument('[localPath]', 'Local directory to clone into (default: ~/.agents/marketplaces/<repo-name>)')
+      .option('--name <name>', 'Human-readable name for this marketplace (default: derived from URL)')
+      .option('--branch <branch>', 'Branch to clone (default: remote HEAD)')
+      .option('--token <token>', 'HTTP access token for authenticated clone and pull (GitHub PAT or Bitbucket token)')
+      .option('--agent <agent>', 'Target agent host for plugin install: github-copilot | claude-code (default: github-copilot)')
+      .option('--claude', 'Shorthand for --agent claude-code');
+  }
+
+  withMarketplaceAddOptions(
+    marketplace.command('add').description('Register a new marketplace, clone it, and install all its plugins')
+  ).action((url: string, localPath: string | undefined, opts: MarketplaceAddOptions) => marketplaceAddAction(url, localPath, opts, 'marketplace-add'));
 
   // Kept as an alias for `add` for backward compatibility with existing scripts/docs.
-  marketplace
-    .command('setup')
-    .description('Alias for `marketplace add` — clone a marketplace and install all its plugins')
-    .argument('<url>', 'Git clone URL of the marketplace repository')
-    .argument('[localPath]', 'Local directory to clone into (default: ~/.agents/marketplaces/<repo-name>)')
-    .option('--name <name>', 'Human-readable name for this marketplace (default: derived from URL)')
-    .option('--branch <branch>', 'Branch to clone (default: remote HEAD)')
-    .option('--token <token>', 'HTTP access token for authenticated clone and pull (GitHub PAT or Bitbucket token)')
-    .option('--agent <agent>', 'Target agent host for plugin install: github-copilot | claude-code (default: github-copilot)')
-    .option('--claude', 'Shorthand for --agent claude-code')
-    .action((url: string, localPath: string | undefined, opts: MarketplaceAddOptions) => marketplaceAddAction(url, localPath, opts, 'marketplace-setup'));
+  withMarketplaceAddOptions(
+    marketplace.command('setup').description('Alias for `marketplace add` — clone a marketplace and install all its plugins')
+  ).action((url: string, localPath: string | undefined, opts: MarketplaceAddOptions) => marketplaceAddAction(url, localPath, opts, 'marketplace-setup'));
 
   marketplace
     .command('list')
@@ -686,8 +716,7 @@ export function registerSkillsCommands(program: Command): void {
       const start = Date.now();
       try {
         const configPath = getGlobalConfigPath();
-        const existing: GlobalConfig = loadJsonFile<GlobalConfig>(configPath) ?? {};
-        const all = getAllMarketplaces(existing);
+        const { existing, all } = loadMarketplacesConfig(configPath);
 
         const idx = all.findIndex(m => m.name === name || m.repoUrl === name);
         if (idx === -1) {
@@ -727,12 +756,7 @@ export function registerSkillsCommands(program: Command): void {
           throw new Error('No marketplaces configured. Run: pncli skills marketplace add <url>');
         }
 
-        const agentName = opts.claude ? 'claude-code' : (opts.agent ?? 'github-copilot');
-        const agentConfig = AGENT_PATHS[agentName];
-        if (!agentConfig) {
-          throw new Error(`Unknown agent: "${agentName}". Use: ${Object.keys(AGENT_PATHS).join(' | ')}`);
-        }
-        const targetDir = agentConfig.user;
+        const targetDir = resolveAgentPaths(resolveAgentName(opts)).user;
         const force = opts.force ?? false;
 
         // Non-interactive "sync everything" — explicit flag.
@@ -759,11 +783,13 @@ export function registerSkillsCommands(program: Command): void {
         // Interactive loop: lets the user back out of a plugin prompt and reselect the marketplace.
         for (;;) {
           if (!selectedMarketplace) {
+            assertInteractive(`Multiple marketplaces are registered (${allMarketplaces.map(marketplaceLabel).join(', ')}). Pass --marketplace <name> (or --marketplace all) to run this non-interactively.`);
             const chosen = await select({
               message: 'Select a marketplace to sync:',
               choices: [
                 { value: ALL_MARKETPLACES, name: 'All marketplaces — sync every plugin from every marketplace' },
-                ...allMarketplaces.map(m => ({ value: marketplaceLabel(m), name: `${marketplaceLabel(m)} — ${m.repoUrl ?? ''}` })),
+                // Index-based values: labels alone aren't guaranteed unique (two marketplaces can share a derived name).
+                ...allMarketplaces.map((m, i) => ({ value: String(i), name: `${marketplaceLabel(m)} — ${m.repoUrl ?? ''}` })),
               ],
             });
             if (chosen === ALL_MARKETPLACES) {
@@ -771,7 +797,7 @@ export function registerSkillsCommands(program: Command): void {
               success({ allMarketplaces: true, marketplaces: results, target: targetDir }, 'skills', 'marketplace-sync', start);
               return;
             }
-            selectedMarketplace = allMarketplaces.find(m => marketplaceLabel(m) === chosen);
+            selectedMarketplace = allMarketplaces[Number(chosen)];
             if (!selectedMarketplace) {
               throw new Error(`Marketplace "${chosen}" not found.`);
             }
@@ -791,6 +817,7 @@ export function registerSkillsCommands(program: Command): void {
           }
 
           if (!selectedPlugin) {
+            assertInteractive(`Pass a plugin name (or "all") to run this non-interactively.`);
             const choices: { value: string; name: string }[] = [
               { value: 'all', name: 'All — install every plugin' },
               ...pluginChoices.map(p => ({ value: p.name, name: p.description ? `${p.name} — ${p.description}` : p.name })),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -136,6 +136,7 @@ export interface OpenShiftConfig {
 }
 
 export interface MarketplaceConfig {
+  name?: string;
   repoUrl?: string;
   localPath?: string;
   token?: string;
@@ -179,6 +180,7 @@ export interface GlobalConfig {
   sonatypeiq?: SonatypeIqConfig;
   openshift?: OpenShiftConfig;
   marketplace?: MarketplaceConfig;
+  marketplaces?: MarketplaceConfig[];
   defaults?: Defaults;
 }
 


### PR DESCRIPTION
## Summary
- Extend `pncli skills marketplace` from a single-marketplace design to full CRUD over multiple registered marketplaces (`add`, `setup` alias, `list`, `remove`, `plugins`)
- Legacy single-marketplace config auto-migrates to the multi-marketplace format the first time any `marketplace` command runs — no manual steps needed after upgrading
- `sync` gains an interactive back option between marketplace/plugin selection, a `--marketplace all` flow to sync every plugin from every marketplace in one shot, and applies `--force`'s skip-if-unchanged logic uniformly to single-plugin and "all" installs
- Bundled `skills install` now records install metadata (`source: bundled`) so `skills list` no longer shows `installed: null` for bundled skills
- `skills uninstall` gains `--scope` (project | user)
- Fixes two silent-failure bugs found in review: a marketplace name collision no longer clobbers an unrelated entry, and ambiguous interactive prompts now fail fast with a clear error on non-TTY callers instead of hanging

## Commands added / updated
- `pncli skills marketplace add <url> [localPath]` — register a new marketplace, clone it, install all its plugins
  - `--name <name>` — human-readable name (default: derived from URL)
  - `--branch <branch>` — branch to clone (default: remote HEAD)
  - `--token <token>` — HTTP access token for authenticated clone/pull
  - `--agent <agent>` — target agent host: github-copilot | claude-code
  - `--claude` — shorthand for --agent claude-code
- `pncli skills marketplace setup <url> [localPath]` — alias of `add` (same options, backward compatible)
- `pncli skills marketplace list` — list all registered marketplaces
- `pncli skills marketplace plugins <name>` — list a marketplace's plugins without installing
- `pncli skills marketplace remove <name>` — unregister a marketplace (does not delete the local clone)
- `pncli skills marketplace sync [plugin]` — pull latest content and install plugin skills
  - `[plugin]` — plugin name, or "all" to install every plugin
  - `--marketplace <name>` — marketplace to sync, or "all" to sync every registered marketplace
  - `--agent <agent>` / `--claude` — target agent host
  - `--force` — reinstall even with no upstream changes (now applies uniformly to single-plugin and "all")
- `pncli skills uninstall <name>` — added `--scope <project|user>` (default: user)

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: issues found and fixed (see commit history)
- ✅ Tests: 306 passed
- ✅ Docs: skills/pncli/marketplace.md and copilot-instructions.md updated

Closes #240