### PR TITLE
feat(ado): add work list-areas and list-iterations commands

### DIFF
--- a/src/services/ado/client/work.test.ts
+++ b/src/services/ado/client/work.test.ts
@@ -290,6 +290,130 @@ describe('AdoWorkClient — listAttachments', () => {
   });
 });
 
+describe('AdoWorkClient — listAreas', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns the area tree root node', async () => {
+    const areaTree = {
+      id: 1,
+      identifier: 'area-guid-1',
+      name: 'MyProject',
+      structureType: 'area',
+      hasChildren: true,
+      path: '\\MyProject\\Area',
+      url: 'https://ado.example.com/myorg/MyProject/_apis/wit/classificationnodes/areas',
+      children: [
+        {
+          id: 2,
+          identifier: 'area-guid-2',
+          name: 'TeamA',
+          structureType: 'area',
+          hasChildren: false,
+          path: '\\MyProject\\Area\\TeamA',
+          url: 'https://ado.example.com/myorg/MyProject/_apis/wit/classificationnodes/areas/TeamA'
+        }
+      ]
+    };
+
+    vi.stubGlobal('fetch', async () =>
+      new Response(JSON.stringify(areaTree), { status: 200 })
+    );
+
+    const http = new HttpClient(makeConfig());
+    const client = new AdoWorkClient(http);
+    const result = await client.listAreas('myorg', 'MyProject');
+
+    expect(result.name).toBe('MyProject');
+    expect(result.structureType).toBe('area');
+    expect(result.hasChildren).toBe(true);
+    expect(result.children).toHaveLength(1);
+    expect(result.children![0].name).toBe('TeamA');
+  });
+
+  it('passes depth parameter in the request URL', async () => {
+    let capturedUrl = '';
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify({
+        id: 1, identifier: 'g', name: 'Root', structureType: 'area',
+        hasChildren: false, path: '\\P', url: ''
+      }), { status: 200 });
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new AdoWorkClient(http);
+    await client.listAreas('myorg', 'MyProject', 3);
+
+    expect(capturedUrl).toContain('$depth=3');
+    expect(capturedUrl).toContain('classificationnodes/areas');
+  });
+});
+
+describe('AdoWorkClient — listIterations', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns iteration tree with start and finish dates', async () => {
+    const iterationTree = {
+      id: 10,
+      identifier: 'iter-guid-1',
+      name: 'MyProject',
+      structureType: 'iteration',
+      hasChildren: true,
+      path: '\\MyProject\\Iteration',
+      url: 'https://ado.example.com/myorg/MyProject/_apis/wit/classificationnodes/iterations',
+      children: [
+        {
+          id: 11,
+          identifier: 'iter-guid-2',
+          name: 'Sprint 1',
+          structureType: 'iteration',
+          hasChildren: false,
+          path: '\\MyProject\\Iteration\\Sprint 1',
+          url: 'https://ado.example.com/myorg/MyProject/_apis/wit/classificationnodes/iterations/Sprint%201',
+          attributes: {
+            startDate: '2024-01-01T00:00:00Z',
+            finishDate: '2024-01-14T00:00:00Z'
+          }
+        }
+      ]
+    };
+
+    vi.stubGlobal('fetch', async () =>
+      new Response(JSON.stringify(iterationTree), { status: 200 })
+    );
+
+    const http = new HttpClient(makeConfig());
+    const client = new AdoWorkClient(http);
+    const result = await client.listIterations('myorg', 'MyProject');
+
+    expect(result.name).toBe('MyProject');
+    expect(result.structureType).toBe('iteration');
+    expect(result.children).toHaveLength(1);
+    const sprint = result.children![0];
+    expect(sprint.name).toBe('Sprint 1');
+    expect(sprint.attributes?.startDate).toBe('2024-01-01T00:00:00Z');
+    expect(sprint.attributes?.finishDate).toBe('2024-01-14T00:00:00Z');
+  });
+
+  it('passes depth parameter in the request URL', async () => {
+    let capturedUrl = '';
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify({
+        id: 10, identifier: 'g', name: 'Root', structureType: 'iteration',
+        hasChildren: false, path: '\\P', url: ''
+      }), { status: 200 });
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new AdoWorkClient(http);
+    await client.listIterations('myorg', 'MyProject', 5);
+
+    expect(capturedUrl).toContain('$depth=5');
+    expect(capturedUrl).toContain('classificationnodes/iterations');
+  });
+});
+
 describe('AdoWorkClient — downloadAttachment', () => {
   afterEach(() => { vi.unstubAllGlobals(); });
 

--- a/src/services/ado/client/work.ts
+++ b/src/services/ado/client/work.ts
@@ -9,7 +9,8 @@ import type {
   AdoField,
   AdoWiqlResult,
   AdoPageResponse,
-  AdoWorkItemAttachment
+  AdoWorkItemAttachment,
+  AdoClassificationNode
 } from '../../../types/ado.js';
 
 const API = '7.1';
@@ -141,6 +142,18 @@ export class AdoWorkClient {
 
   async downloadAttachment(absoluteUrl: string): Promise<Buffer> {
     return this.http.adoBuffer(absoluteUrl);
+  }
+
+  async listAreas(collection: string, project: string, depth = 10): Promise<AdoClassificationNode> {
+    return this.http.ado<AdoClassificationNode>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/classificationnodes/areas?$depth=${depth}&api-version=${API}`
+    );
+  }
+
+  async listIterations(collection: string, project: string, depth = 10): Promise<AdoClassificationNode> {
+    return this.http.ado<AdoClassificationNode>(
+      `/${encodeURIComponent(collection)}/${encodeURIComponent(project)}/_apis/wit/classificationnodes/iterations?$depth=${depth}&api-version=${API}`
+    );
   }
 
   async uploadAttachment(

--- a/src/services/ado/commands/work.ts
+++ b/src/services/ado/commands/work.ts
@@ -284,6 +284,34 @@ export function registerAdoWorkCommands(ado: Command): void {
       } catch (err) { fail(err, 'ado', 'work-download-attachment', start); }
     });
 
+  // ── Areas & Iterations ────────────────────────────────────────────
+
+  work
+    .command('list-areas')
+    .description('List classification areas for the team project (tree)')
+    .option('--depth <n>', 'Depth of the area tree to retrieve', '10')
+    .action(async (opts: { depth: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const data = await workClient.listAreas(collection, project, parseInt(opts.depth, 10));
+        success(data, 'ado', 'work-list-areas', start);
+      } catch (err) { fail(err, 'ado', 'work-list-areas', start); }
+    });
+
+  work
+    .command('list-iterations')
+    .description('List classification iterations for the team project (tree), including start/finish dates')
+    .option('--depth <n>', 'Depth of the iteration tree to retrieve', '10')
+    .action(async (opts: { depth: string }) => {
+      const start = Date.now();
+      try {
+        const { collection, project, workClient } = getAdoContext(ado);
+        const data = await workClient.listIterations(collection, project, parseInt(opts.depth, 10));
+        success(data, 'ado', 'work-list-iterations', start);
+      } catch (err) { fail(err, 'ado', 'work-list-iterations', start); }
+    });
+
   // ── Type / Field discovery ────────────────────────────────────────
 
   work

--- a/src/types/ado.ts
+++ b/src/types/ado.ts
@@ -318,6 +318,23 @@ export interface AdoWorkItemAttachment {
   resourceModifiedDate?: string;
 }
 
+// ── Classification Nodes (Areas & Iterations) ────────────────────────
+
+export interface AdoClassificationNode {
+  id: number;
+  identifier: string;
+  name: string;
+  structureType: 'area' | 'iteration';
+  hasChildren: boolean;
+  children?: AdoClassificationNode[];
+  path: string;
+  url: string;
+  attributes?: {
+    startDate?: string;
+    finishDate?: string;
+  };
+}
+
 // ── Shared pagination wrapper ────────────────────────────────────────
 
 export interface AdoPageResponse<T> {


### PR DESCRIPTION
Adds `pncli ado work list-areas` and `pncli ado work list-iterations` commands that fetch the ADO classification node trees for a team project. Iterations include `startDate` and `finishDate` in the `attributes` field.

Closes #245

Generated with [Claude Code](https://claude.ai/code)