### PR TITLE
feat(jira): list boards/sprints and set sprint on an issue

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -221,6 +221,18 @@ pncli jira fields
   createmeta (requires --discover)
   --issue-type <type>  Filter allowedValues to a specific issue type (requires
   --project)
+
+pncli jira list-boards
+  --project <key>  Project key
+
+pncli jira list-sprints
+  --board <id>      Board ID
+  --project <key>   Project key — resolves to that project's board(s)
+  --state <states>  Comma-separated states to filter (active,future,closed)
+
+pncli jira set-sprint
+  --key <issue-key>  Issue key
+  --sprint <id>      Sprint ID (from list-sprints)
 ```
 
 ### Bitbucket

--- a/skills/pncli/jira.md
+++ b/skills/pncli/jira.md
@@ -1,6 +1,6 @@
 # Jira
 
-Enables: `pncli jira issue`, `pncli jira sprint`, `pncli jira project`, `pncli jira user` — list and get issues, sprints, custom fields, and project members.
+Enables: `pncli jira get-issue`, `create-issue`, `update-issue`, `search`, `list-boards`, `list-sprints`, `set-sprint`, and more — get, create, and update issues, transitions, comments, attachments, custom fields, and sprints.
 
 ## Required config
 
@@ -29,7 +29,20 @@ export PNCLI_JIRA_API_TOKEN=<token>
 pncli config set --repo defaults.jira.project ACME
 ```
 
+## Sprints
+
+Sprints live behind the Jira Agile API, not the issue API — list boards first, then sprints on a board (or resolve straight from a project key):
+
+```
+pncli jira list-boards --project ACME
+pncli jira list-sprints --project ACME [--state active,future,closed]
+pncli jira list-sprints --board <id> [--state active,future,closed]
+pncli jira set-sprint --key ACME-123 --sprint <sprint-id>
+```
+
+`list-sprints` output includes `startDate`/`endDate`/`state`/`goal` for each sprint.
+
 ## Notes
 
 - Jira Cloud and Jira Data Center both work; token format differs (API token vs PAT)
-- Custom fields discovered with `pncli jira project fields`
+- Custom fields discovered with `pncli jira fields --discover`

--- a/src/services/jira/client.test.ts
+++ b/src/services/jira/client.test.ts
@@ -147,6 +147,152 @@ describe('JiraClient — listAttachments', () => {
   });
 });
 
+describe('JiraClient — listBoards', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('calls the Agile board endpoint with projectKeyOrId', async () => {
+    const capturedUrls: string[] = [];
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrls.push(url);
+      return new Response(
+        JSON.stringify({ values: [{ id: 1, name: 'Board 1', type: 'scrum' }], total: 1, startAt: 0, maxResults: 100 }),
+        { status: 200 }
+      );
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new JiraClient(http);
+    const boards = await client.listBoards('PROJ');
+
+    expect(capturedUrls[0]).toContain('/rest/agile/1.0/board');
+    expect(capturedUrls[0]).toContain('projectKeyOrId=PROJ');
+    expect(boards).toEqual([{ id: 1, name: 'Board 1', type: 'scrum' }]);
+  });
+
+  it('paginates across multiple pages', async () => {
+    let call = 0;
+    vi.stubGlobal('fetch', async () => {
+      call += 1;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({ values: [{ id: 1, name: 'Board 1', type: 'scrum' }], total: 2, startAt: 0, maxResults: 1 }),
+          { status: 200 }
+        );
+      }
+      return new Response(
+        JSON.stringify({ values: [{ id: 2, name: 'Board 2', type: 'scrum' }], total: 2, startAt: 1, maxResults: 1 }),
+        { status: 200 }
+      );
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new JiraClient(http);
+    const boards = await client.listBoards('PROJ');
+
+    expect(boards).toHaveLength(2);
+    expect(boards.map(b => b.id)).toEqual([1, 2]);
+  });
+});
+
+describe('JiraClient — listSprintsForBoard', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('calls the Agile sprint endpoint for the board with dates', async () => {
+    const capturedUrls: string[] = [];
+    const mockSprint = { id: 5, name: 'Sprint 5', state: 'active', startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-14T00:00:00.000Z' };
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrls.push(url);
+      return new Response(
+        JSON.stringify({ values: [mockSprint], total: 1, startAt: 0, maxResults: 100 }),
+        { status: 200 }
+      );
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new JiraClient(http);
+    const sprints = await client.listSprintsForBoard(3);
+
+    expect(capturedUrls[0]).toContain('/rest/agile/1.0/board/3/sprint');
+    expect(sprints).toEqual([mockSprint]);
+  });
+
+  it('passes a comma-separated state filter when provided', async () => {
+    const capturedUrls: string[] = [];
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrls.push(url);
+      return new Response(JSON.stringify({ values: [], total: 0, startAt: 0, maxResults: 100 }), { status: 200 });
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new JiraClient(http);
+    await client.listSprintsForBoard(3, ['active', 'future']);
+
+    expect(capturedUrls[0]).toContain('state=active%2Cfuture');
+  });
+});
+
+describe('JiraClient — listSprintsForProject', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('resolves boards for the project then dedupes sprints across them', async () => {
+    vi.stubGlobal('fetch', async (url: string) => {
+      if (url.includes('/board?') || url.endsWith('/board')) {
+        return new Response(
+          JSON.stringify({
+            values: [{ id: 1, name: 'Board 1', type: 'scrum' }, { id: 2, name: 'Board 2', type: 'scrum' }],
+            total: 2, startAt: 0, maxResults: 100
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes('/board/1/sprint')) {
+        return new Response(
+          JSON.stringify({ values: [{ id: 10, name: 'Sprint 10', state: 'active' }], total: 1, startAt: 0, maxResults: 100 }),
+          { status: 200 }
+        );
+      }
+      // Board 2 shares sprint 10 (cross-project board) plus its own sprint 11
+      return new Response(
+        JSON.stringify({
+          values: [{ id: 10, name: 'Sprint 10', state: 'active' }, { id: 11, name: 'Sprint 11', state: 'future' }],
+          total: 2, startAt: 0, maxResults: 100
+        }),
+        { status: 200 }
+      );
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new JiraClient(http);
+    const sprints = await client.listSprintsForProject('PROJ');
+
+    expect(sprints.map(s => s.id)).toEqual([10, 11]);
+  });
+});
+
+describe('JiraClient — setSprint', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('posts the issue key to the sprint move endpoint', async () => {
+    const capturedUrls: string[] = [];
+    const capturedBodies: unknown[] = [];
+    const capturedMethods: string[] = [];
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      capturedUrls.push(url);
+      capturedMethods.push(init.method ?? 'GET');
+      capturedBodies.push(JSON.parse(init.body as string));
+      return new Response(null, { status: 204 });
+    });
+
+    const http = new HttpClient(makeConfig());
+    const client = new JiraClient(http);
+    await client.setSprint(42, ['PROJ-1']);
+
+    expect(capturedUrls[0]).toContain('/rest/agile/1.0/sprint/42/issue');
+    expect(capturedMethods[0]).toBe('POST');
+    expect(capturedBodies[0]).toEqual({ issues: ['PROJ-1'] });
+  });
+});
+
 describe('JiraClient — downloadAttachment', () => {
   afterEach(() => { vi.unstubAllGlobals(); });
 

--- a/src/services/jira/client.ts
+++ b/src/services/jira/client.ts
@@ -9,11 +9,14 @@ import type {
   JiraSearchResult,
   JiraFieldInfo,
   JiraAttachment,
+  JiraBoard,
+  JiraSprint,
   CustomFieldDefinition,
   CustomFieldType
 } from '../../types/jira.js';
 
 const API = '/rest/api/2';
+const AGILE_API = '/rest/agile/1.0';
 
 export interface CreateIssueOpts {
   project: string;
@@ -289,6 +292,45 @@ export class JiraClient {
         inwardIssue: { key: opts.key },
         outwardIssue: { key: opts.target }
       }
+    });
+  }
+
+  async listBoards(project: string): Promise<JiraBoard[]> {
+    return this.http.jiraPaginate<JiraBoard>(async (startAt, maxResults) => {
+      return this.http.jira<{ values: JiraBoard[]; total: number; startAt: number; maxResults: number }>(
+        `${AGILE_API}/board`,
+        { params: { projectKeyOrId: project, startAt, maxResults } }
+      );
+    });
+  }
+
+  async listSprintsForBoard(boardId: number, states?: string[]): Promise<JiraSprint[]> {
+    return this.http.jiraPaginate<JiraSprint>(async (startAt, maxResults) => {
+      return this.http.jira<{ values: JiraSprint[]; total: number; startAt: number; maxResults: number }>(
+        `${AGILE_API}/board/${boardId}/sprint`,
+        { params: { startAt, maxResults, ...(states?.length ? { state: states.join(',') } : {}) } }
+      );
+    });
+  }
+
+  async listSprintsForProject(project: string, states?: string[]): Promise<JiraSprint[]> {
+    const boards = await this.listBoards(project);
+    const sprints: JiraSprint[] = [];
+    const seen = new Set<number>();
+    for (const board of boards) {
+      for (const sprint of await this.listSprintsForBoard(board.id, states)) {
+        if (seen.has(sprint.id)) continue;
+        seen.add(sprint.id);
+        sprints.push(sprint);
+      }
+    }
+    return sprints;
+  }
+
+  async setSprint(sprintId: number, issueKeys: string[]): Promise<void> {
+    await this.http.jira<void>(`${AGILE_API}/sprint/${sprintId}/issue`, {
+      method: 'POST',
+      body: { issues: issueKeys }
     });
   }
 }

--- a/src/services/jira/commands.ts
+++ b/src/services/jira/commands.ts
@@ -312,6 +312,49 @@ export function registerJiraCommands(program: Command): void {
         }
       } catch (err) { fail(err, 'jira', 'fields', start); }
     });
+
+  jira.command('list-boards')
+    .description('List Agile boards for a project')
+    .requiredOption('--project <key>', 'Project key')
+    .action(async (opts: { project: string }) => {
+      const start = Date.now();
+      try {
+        const client = getClient(program);
+        const data = await client.listBoards(opts.project);
+        success(data, 'jira', 'list-boards', start);
+      } catch (err) { fail(err, 'jira', 'list-boards', start); }
+    });
+
+  jira.command('list-sprints')
+    .description('List sprints for a board or project, including start/end dates')
+    .option('--board <id>', 'Board ID')
+    .option('--project <key>', 'Project key — resolves to that project\'s board(s)')
+    .option('--state <states>', 'Comma-separated states to filter (active,future,closed)')
+    .action(async (opts: { board?: string; project?: string; state?: string }) => {
+      const start = Date.now();
+      try {
+        if (!opts.board && !opts.project) throw new PncliError('Either --board or --project is required', 1);
+        const client = getClient(program);
+        const states = opts.state ? opts.state.split(',').map(s => s.trim()) : undefined;
+        const data = opts.board
+          ? await client.listSprintsForBoard(parseInt(opts.board, 10), states)
+          : await client.listSprintsForProject(opts.project as string, states);
+        success(data, 'jira', 'list-sprints', start);
+      } catch (err) { fail(err, 'jira', 'list-sprints', start); }
+    });
+
+  jira.command('set-sprint')
+    .description('Move a Jira issue into a sprint')
+    .requiredOption('--key <issue-key>', 'Issue key')
+    .requiredOption('--sprint <id>', 'Sprint ID (from list-sprints)')
+    .action(async (opts: { key: string; sprint: string }) => {
+      const start = Date.now();
+      try {
+        const client = getClient(program);
+        await client.setSprint(parseInt(opts.sprint, 10), [opts.key]);
+        success({ updated: opts.key, sprint: opts.sprint }, 'jira', 'set-sprint', start);
+      } catch (err) { fail(err, 'jira', 'set-sprint', start); }
+    });
 }
 
 export function parseFieldArgs(

--- a/src/types/jira.ts
+++ b/src/types/jira.ts
@@ -86,3 +86,18 @@ export interface JiraAttachment {
   mimeType: string;
   content: string;
 }
+
+export interface JiraBoard {
+  id: number;
+  name: string;
+  type: string;
+}
+
+export interface JiraSprint {
+  id: number;
+  name: string;
+  state: string;
+  startDate?: string;
+  endDate?: string;
+  goal?: string;
+}


### PR DESCRIPTION
## Summary
- Add Agile API support to the Jira client: list-boards, list-sprints, and set-sprint
- Bring Jira sprint handling to parity with the ADO iteration listing requested in #245
- Fix stale skills/pncli/jira.md documentation drift (advertised nonexistent commands)
- Regenerate the auto-generated copilot-instructions.md command reference

## Commands added / updated
- `pncli jira list-boards --project <key>` — List Agile boards for a project
  - `--project <key>` (required) — Project key
- `pncli jira list-sprints [--board <id>] [--project <key>] [--state <states>]` — List sprints for a board or project, including start/end dates
  - `--board <id>` — Board ID
  - `--project <key>` — Project key — resolves to that project's board(s)
  - `--state <states>` — Comma-separated states to filter (active,future,closed)
- `pncli jira set-sprint --key <issue-key> --sprint <id>` — Move a Jira issue into a sprint
  - `--key <issue-key>` (required) — Issue key
  - `--sprint <id>` (required) — Sprint ID (from list-sprints)

## Pre-PR gate
- ✅ Build: passed
- ✅ Typecheck: 0 errors
- ✅ Lint: clean
- ✅ Code review: Approve, no blocking issues
- ✅ Tests: 318 passed
- ✅ Docs: updated (skills/pncli/jira.md, copilot-instructions.md)

Closes #249